### PR TITLE
fix: server-side rendering

### DIFF
--- a/webcompy/aio/_aio.py
+++ b/webcompy/aio/_aio.py
@@ -1,11 +1,10 @@
 from typing import Any, Callable, Coroutine, Generic, ParamSpec, TypeVar
+from webcompy.brython import browser
 from webcompy.reactive._base import ReactiveBase
 
-try:
-    from browser import aio  # type: ignore
-
-    aio_run: Any = aio.run  # type: ignore
-except ModuleNotFoundError:
+if browser:
+    aio_run: Any = browser.aio.run
+else:
     import asyncio
 
     aio_run: Any = asyncio.run

--- a/webcompy/app/_app.py
+++ b/webcompy/app/_app.py
@@ -8,15 +8,18 @@ class WebComPyApp:
     _router: Router | None
 
     def __init__(
-        self, *, root_component: ComponentGenerator[None], router: Router | None = None
+        self,
+        *,
+        root_component: ComponentGenerator[None],
+        router: Router | None = None,
     ) -> None:
-        self._root_component = root_component
-        self._router = router
+        self._root = AppDocumentRoot(root_component, router)
 
-    def init(self):
-        self._root = AppDocumentRoot(self._root_component, self._router)
+    @property
+    def __render__(self):
+        return self._root.render
 
-    def generate(self):
+    def __generate__(self):
         import pathlib
         import os
         import shutil
@@ -25,14 +28,14 @@ class WebComPyApp:
         if dist.exists():
             shutil.rmtree(dist)
         os.mkdir(dist)
-        if len(self._root.routes):
+        if len(self._root.routes) and self._root.router_mode == "history":
             for path in self._root.routes:
-                html = self._root.render_html(path, indent=0)
                 page_dir = dist / path
                 if not page_dir.exists():
                     os.makedirs(page_dir)
+                html = self._root.render_html(path, indent=0)
                 with (page_dir / "index.html").open("w", encoding="utf8") as f:
                     f.write(html)
         else:
             html = self._root.render_html(indent=0)
-            (dist / "index.html").open("w").write(html)
+            (dist / "index.html").open("w", encoding="utf8").write(html)

--- a/webcompy/app/_root_component.py
+++ b/webcompy/app/_root_component.py
@@ -19,28 +19,26 @@ class AppRootComponent(NonPropsComponentBase):
 class AppDocumentRoot(Component):
     routes: list[str]
     _router: Router | None
-    _initilized: bool
 
     def __init__(
         self, root_component: ComponentGenerator[None], router: Router | None
     ) -> None:
-        self._initilized = False
         self._router = router
         if self._router:
             RouterView.__set_router__(self._router)
             TypedRouterLink.__set_router__(self._router)
         super().__init__(AppRootComponent, None, {"root": lambda: root_component(None)})
+        self.routes = [p[0] for p in self._router.__routes__] if self._router else []
+        self.router_mode = self._router.__mode__ if self._router else None
+
+    def render(self):
         if browser:
             style_node = browser.document.createElement("style")
             style_node.textContent = self._style
             browser.document.body.appendChild(style_node)
-        self._render()
-        self.routes = [p[0] for p in self._router.__routes__] if self._router else []
+            self._render()
 
     def _render(self):
-        if not self._initilized:
-            self._initilized = True
-            self._init_component()
         self._mount_node()
         self._property["on_before_rendering"]()
         for child in self._children:

--- a/webcompy/brython/_typing/_browser.py
+++ b/webcompy/brython/_typing/_browser.py
@@ -6,6 +6,17 @@ ENVIRONMENT: Final[Literal["browser", "server"]]
 
 try:
     from browser import *  # type: ignore
+    from browser import (  # type: ignore
+        aio,  # type: ignore
+        local_storage,  # type: ignore
+        markdown,  # type: ignore
+        object_storage,  # type: ignore
+        session_storage,  # type: ignore
+        svg,  # type: ignore
+        timer,  # type: ignore
+        websocket,  # type: ignore
+        worker,  # type: ignore
+    )
     import javascript  # type: ignore
 
     ENVIRONMENT = "browser"  # type: ignore

--- a/webcompy/components/_component.py
+++ b/webcompy/components/_component.py
@@ -19,41 +19,33 @@ def _is_class_style_component_def(obj: Any) -> TypeGuard[ClassComponentDef]:
 
 
 class Component(ElementBase):
-    __initilized: bool
-    __component_def: Union[FuncComponentDef, ClassComponentDef]
-    __props: Any
-    __slots: dict[str, Callable[[], ElementChildren]]
-
     def __init__(
         self,
         component_def: Union[FuncComponentDef, ClassComponentDef],
         props: Any,
         slots: dict[str, Callable[[], ElementChildren]],
     ) -> None:
-        self.__initilized = False
-        self.__component_def = component_def
-        self.__props = props
-        self.__slots = slots
-
         self._attrs = {}
         self._event_handlers = {}
         self._ref = None
         self._children = []
         super().__init__()
+        self.__init_component(self.__setup(component_def, props, slots))
 
-    def __setup(self) -> ComponentProperty:
-        if _is_class_style_component_def(self.__component_def):
-            return self.__component_def.__get_component_instance__(
-                Context(
-                    self.__props,
-                    self.__slots,
-                    self.__component_def.__get_name__(),
-                )
+    def __setup(
+        self,
+        component_def: Union[FuncComponentDef, ClassComponentDef],
+        props: Any,
+        slots: dict[str, Callable[[], ElementChildren]],
+    ) -> ComponentProperty:
+        if _is_class_style_component_def(component_def):
+            return component_def.__get_component_instance__(
+                Context(props, slots, component_def.__get_name__())
             ).__get_component_property__()
-        elif _is_function_style_component_def(self.__component_def):
-            component_name = self.__component_def.__name__
-            context = Context(self.__props, self.__slots, component_name)
-            template = self.__component_def(context)
+        elif _is_function_style_component_def(component_def):
+            component_name = component_def.__name__
+            context = Context(props, slots, component_name)
+            template = component_def(context)
             hooks = context.__get_lifecyclehooks__()
             return {
                 "component_id": generate_id(component_name),
@@ -66,28 +58,24 @@ class Component(ElementBase):
         else:
             raise WebComPyException("Invalid Component Definition")
 
-    def _init_component(self):
-        self._property = self.__setup()
-        node = self._property["template"]
+    def __init_component(self, property: ComponentProperty):
+        node = property["template"]
         if not isinstance(node, Element):
             raise WebComPyException(
                 "Root Node of Component must be instance of 'Element'"
             )
-
         self._tag_name = node._tag_name
         self._attrs = {
             **node._attrs,
-            "webcompy-component": self._property["component_name"],
-            "webcompy-cid-" + self._property["component_id"]: True,
+            "webcompy-component": property["component_name"],
+            "webcompy-cid-" + property["component_id"]: True,
         }
         self._event_handlers = node._event_handlers
         self._ref = node._ref
         self._init_children(node._children)
+        self._property = property
 
     def _render(self):
-        if not self.__initilized:
-            self.__initilized = True
-            self._init_component()
         self._property["on_before_rendering"]()
         super()._render()
         self._property["on_after_rendering"]()

--- a/webcompy/elements/types/_abstract.py
+++ b/webcompy/elements/types/_abstract.py
@@ -8,19 +8,26 @@ from webcompy.exception import WebComPyException
 
 
 class ElementAbstract(ReactiveReceivable):
-    _parent: ElementAbstract
     _node_idx: int
     _node_cache: DOMNode | None = None
     _mounted: bool | None = None
     _remount_to: DOMNode | None = None
-
     _callback_ids: set[int]
+    __parent: ElementAbstract
 
     def __init__(self) -> None:
         self._node_cache = None
         self._mounted = None
         self._remount_to = None
         self._callback_ids: set[int] = set()
+
+    @property
+    def _parent(self) -> "ElementAbstract":
+        return self.__parent
+
+    @_parent.setter
+    def _parent(self, parent: "ElementAbstract"):
+        self.__parent = parent
 
     def _render(self):
         self._mount_node()

--- a/webcompy/elements/types/_base.py
+++ b/webcompy/elements/types/_base.py
@@ -12,16 +12,23 @@ from webcompy.elements.types._text import TextElement
 
 
 class ElementWithChildren(ElementAbstract):
-    _parent: ElementWithChildren
-
     _tag_name: HtmlTags
     _attrs: dict[str, AttrValue] = {}
     _event_handlers: dict[str, EventHandler] = {}
     _children: list[ElementAbstract] = []
+    __parent: ElementWithChildren
 
     def __init__(self) -> None:
         self._node_cache = None
         self._callback_ids: set[int] = set()
+
+    @property
+    def _parent(self) -> "ElementWithChildren":
+        return self.__parent
+
+    @_parent.setter
+    def _parent(self, parent: "ElementWithChildren"):  # type: ignore
+        self.__parent = parent
 
     def _render(self):
         super()._render()
@@ -56,7 +63,10 @@ class ElementWithChildren(ElementAbstract):
                 child._remove_element(True, False)
 
     def _create_child_element(
-        self, parent: "ElementWithChildren", child: ElementChildren
+        self,
+        parent: "ElementWithChildren",
+        node_idx: int | None,
+        child: ElementChildren,
     ):
         if child is None:
             return None
@@ -64,6 +74,8 @@ class ElementWithChildren(ElementAbstract):
             element = TextElement(child)
         else:
             element = child
+        if node_idx is not None:
+            element._node_idx = node_idx
         element._parent = parent
         return element
 
@@ -82,18 +94,16 @@ class ElementWithChildren(ElementAbstract):
                     child._re_index_children(True)
 
     def _append_child(self, child: ElementChildren):
-        child_ele = self._create_child_element(self, child)
+        if self._children_length == 0:
+            node_idx = 0
+        else:
+            node_idx = self._children[-1]._node_idx + self._children[-1]._node_count
+        child_ele = self._create_child_element(self, node_idx, child)
         if child_ele is not None:
-            if self._children_length == 0:
-                child_ele._node_idx = 0
-            else:
-                child_ele._node_idx = (
-                    self._children[-1]._node_idx + self._children[-1]._node_count
-                )
             self._children.append(child_ele)
 
     def _insert_child(self, index: int, child: ElementChildren):
-        child_ele = self._create_child_element(self, child)
+        child_ele = self._create_child_element(self, None, child)
         if child_ele is not None:
             self._children.insert(index, child_ele)
             self._re_index_children(False)

--- a/webcompy/elements/types/_dynamic.py
+++ b/webcompy/elements/types/_dynamic.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import NoReturn
 from webcompy.elements.typealias._element_property import ElementChildren
 from webcompy.elements.types._base import ElementWithChildren
@@ -5,12 +6,19 @@ from webcompy.exception import WebComPyException
 
 
 class DynamicElement(ElementWithChildren):
+    __parent: ElementWithChildren
+
     @property
     def _node_count(self) -> int:
         return sum(child._node_count for child in self._children)
 
-    def _create_child_element(self, parent: ElementWithChildren, child: ElementChildren):
-        child_element = super()._create_child_element(parent, child)
+    def _create_child_element(
+        self,
+        parent: "ElementWithChildren",
+        node_idx: int | None,
+        child: ElementChildren,
+    ):
+        child_element = super()._create_child_element(parent, node_idx, child)
         if isinstance(child_element, DynamicElement):
             raise WebComPyException("Nested DynamicElement is not allowed.")
         return child_element
@@ -23,3 +31,16 @@ class DynamicElement(ElementWithChildren):
 
     def _render_html(self, count: int, indent: int) -> str:
         return "\n".join(child._render_html(count, indent) for child in self._children)
+
+    @property
+    def _parent(self) -> "ElementWithChildren":
+        return self.__parent
+
+    @_parent.setter
+    def _parent(self, parent: "ElementWithChildren"):
+        self.__parent = parent
+        self._on_set_parent()
+
+    @abstractmethod
+    def _on_set_parent(self):
+        ...

--- a/webcompy/elements/types/_switch.py
+++ b/webcompy/elements/types/_switch.py
@@ -5,6 +5,7 @@ from webcompy.elements.types._abstract import ElementAbstract
 from webcompy.elements.typealias._element_property import ElementChildren
 from webcompy.exception import WebComPyException
 from webcompy.elements.types._dynamic import DynamicElement
+from webcompy.brython import browser
 
 
 NodeGenerator: TypeAlias = Callable[[], ElementChildren]
@@ -27,6 +28,12 @@ class SwitchElement(DynamicElement):
         self._rendered_idx = None
         super().__init__()
 
+    def _on_set_parent(self):
+        if not browser:
+            idx, generator = self._select_generator()
+            self._rendered_idx = idx
+            self._children = self._generate_children(generator)
+
     def _select_generator(self) -> tuple[int, Callable[[], ElementChildren]]:
         if isinstance(self._cases, ReactiveBase):
             cases = self._cases.value
@@ -43,7 +50,7 @@ class SwitchElement(DynamicElement):
             return (-1, lambda: None)
 
     def _generate_children(self, generator: NodeGenerator) -> list[ElementAbstract]:
-        ele = self._create_child_element(self._parent, generator())
+        ele = self._create_child_element(self._parent, None, generator())
         return [ele] if ele is not None else []
 
     def _render(self):


### PR DESCRIPTION
## Summary

- Fix server-side rendering to properly handle prerendered content
- Refactor `AppDocumentRoot` rendering: remove `_initilized` flag, use `_render()` method
- Improve component initialization: call `_init_component()` via `__setup__()`
- Fix `_get_belonging_component` return type
- Add `_get_prerendered_node()` method for reusing existing DOM nodes during SSR hydration
- Update `_render_html()` signature to accept `newline`, `indent`, and `count` parameters