### PR TITLE
feat: add CLI tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# dev dir
-dev/*
+# dev files
+/dev
+/webcompy_config.py

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Kento NIWASE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
 # WebComPy
 
-Python client-side web framework which works on Browser.
+## What is WebComPy
+WebComPy is Python client-side web framework on Browser (powered by [Brython](https://github.com/brython-dev/brython), thank you very much!), which has following features.
 
-## ToDo
-- Add PyScript support ([Github Repo](https://github.com/pyscript/pyscript))
-- Add provide/inject (DI)
-- Add Plugin System
+- Component-based declarative rendering
+- Automatic DOM refreshing
+- Built-in router
+
+## Get started
+```
+mkdir webcompy-project
+cd webcompy-project
+pip install webcompy
+python -m webcompy init
+python -m webcompy start --dev
+```
+
+then access `http://127.0.0.1:8080/WebComPy/`.
 
 ## Sample Code
 ```python
@@ -131,6 +142,11 @@ class Fizzbuzz(TypedComponentBase(props_type=RouterContext)):
         )
 
 ```
+
+## ToDo
+- Add PyScript support ([Github Repo](https://github.com/pyscript/pyscript))
+- Add provide/inject (DI)
+- Add Plugin System
 
 ## Lisence
 This project is licensed under the MIT License, see the LICENSE.txt file for details.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+brython ~= 3.10
+wheel
+starlette
+sse-starlette
+uvicorn

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,62 @@
+import os
+import pathlib
+from setuptools import setup, find_packages
+from pathlib import Path
+
+
+def _get_files(path: pathlib.Path, suffix: str) -> list[str]:
+    ret: list[str] = []
+    if path.is_dir():
+        for p in path.iterdir():
+            ret.extend(_get_files(p, suffix))
+    elif path.suffix == suffix:
+        ret.append(str(path))
+    return ret
+
+
+package_name = "webcompy"
+root_dir = Path(__file__).parent.absolute()
+
+package_dir = root_dir / "webcompy"
+pyi_files = [
+    p.replace(str(package_dir) + os.sep, "").replace("\\", "/")
+    for p in _get_files(package_dir, ".pyi")
+]
+
+template_data_dir = package_dir / "cli" / "template_data"
+template_files = [
+    p.replace(str(package_dir) + os.sep, "").replace("\\", "/")
+    for p in _get_files(template_data_dir, ".py")
+]
+
+setup(
+    name=package_name,
+    version="0.0.1",
+    description="Python client-side web framework which works on Browser",
+    long_description=(root_dir / "README.md").open("r", encoding="utf8").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/kniwase/WebComPy",
+    author="Kento Niwase",
+    author_email="kento.niwase@outlook.com",
+    license="MIT",
+    keywords="browser,front-end,client-side,framework",
+    packages=find_packages(exclude=["docs_src", "template"]),
+    package_data={
+        "webcompy": [
+            "py.typed",
+            *pyi_files,
+            *template_files,
+        ],
+    },
+    install_requires=[
+        name.rstrip()
+        for name in (root_dir / "requirements.txt")
+        .open("r", encoding="utf8")
+        .readlines()
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3.10",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+)

--- a/webcompy/__init__.py
+++ b/webcompy/__init__.py
@@ -11,6 +11,11 @@ from . import (
     utils,
 )
 
+if brython.browser:
+    cli = None
+else:
+    from . import cli
+
 
 __all__ = [
     "brython",
@@ -23,4 +28,5 @@ __all__ = [
     "aio",
     "ajax",
     "utils",
+    "cli",
 ]

--- a/webcompy/__main__.py
+++ b/webcompy/__main__.py
@@ -1,7 +1,15 @@
 from webcompy.cli._argparser import get_params
 from webcompy.cli._server import run_server
+from webcompy.cli._generate import generate_static_site
 
-command, _ = get_params()
 
-if command == "start":
-    run_server()
+def main():
+    command, _ = get_params()
+    if command == "start":
+        run_server()
+    elif command == "generate":
+        generate_static_site()
+
+
+if __name__ == "__main__":
+    main()

--- a/webcompy/__main__.py
+++ b/webcompy/__main__.py
@@ -1,0 +1,7 @@
+from webcompy.cli._argparser import get_params
+from webcompy.cli._server import run_server
+
+command, _ = get_params()
+
+if command == "start":
+    run_server()

--- a/webcompy/__main__.py
+++ b/webcompy/__main__.py
@@ -1,6 +1,7 @@
 from webcompy.cli._argparser import get_params
 from webcompy.cli._server import run_server
 from webcompy.cli._generate import generate_static_site
+from webcompy.cli._init_project import init_project
 
 
 def main():
@@ -9,6 +10,8 @@ def main():
         run_server()
     elif command == "generate":
         generate_static_site()
+    elif command == "init":
+        init_project()
 
 
 if __name__ == "__main__":

--- a/webcompy/app/_app.py
+++ b/webcompy/app/_app.py
@@ -16,17 +16,5 @@ class WebComPyApp:
         self._root = AppDocumentRoot(root_component, router)
 
     @property
-    def __routes__(self):
-        return self._root.routes
-
-    @property
-    def __router_mode__(self):
-        return self._root.router_mode
-
-    @property
-    def __render__(self):
-        return self._root.__render__
-
-    @property
-    def __component_styles__(self):
-        return self._root.style
+    def __component__(self):
+        return self._root

--- a/webcompy/app/_app.py
+++ b/webcompy/app/_app.py
@@ -1,11 +1,20 @@
+from typing import Dict, List, Optional, Tuple, TypedDict
 from webcompy.components import ComponentGenerator
 from webcompy.router import Router
 from webcompy.app._root_component import AppDocumentRoot
 
 
+class Head(TypedDict, total=False):
+    title: str
+    meta: List[Dict[str, str]]
+    link: List[Dict[str, str]]
+    script: List[Tuple[Dict[str, str], Optional[str]]]
+
+
 class WebComPyApp:
     _root: AppDocumentRoot
-    _router: Router | None
+    _head: Head
+    _scripts: List[Tuple[Dict[str, str], Optional[str]]]
 
     def __init__(
         self,
@@ -13,8 +22,59 @@ class WebComPyApp:
         root_component: ComponentGenerator[None],
         router: Router | None = None,
     ) -> None:
+        self._head: Head = {"meta": [], "link": [], "script": []}
+        self._scripts = []
         self._root = AppDocumentRoot(root_component, router)
+
+    def set_title(self, title: str):
+        self._head["title"] = title
+
+    def append_meta(self, attributes: Dict[str, str]):
+        if "meta" in self._head:
+            self._head["meta"].append(attributes)
+        else:
+            self._head["meta"] = [attributes]
+
+    def append_link(self, attributes: Dict[str, str]):
+        if "link" in self._head:
+            self._head["link"].append(attributes)
+        else:
+            self._head["link"] = [attributes]
+
+    def append_script(
+        self,
+        attributes: Dict[str, str],
+        script: str | None = None,
+        in_head: bool = False,
+    ):
+        if not in_head:
+            self._scripts.append((attributes, script))
+        elif "script" in self._head:
+            self._head["script"].append((attributes, script))
+        else:
+            self._head["script"] = [(attributes, script)]
+
+    def set_head(self, head: Head):
+        self._head = head
+
+    def update_head(self, head: Head):
+        if "title" in head:
+            self.set_title(head["title"])
+        for meta in head.get("meta", []):
+            self.append_meta(meta)
+        for link in head.get("link", []):
+            self.append_link(link)
+        for attrs, script in head.get("script", []):
+            self.append_script(attrs, script, True)
 
     @property
     def __component__(self):
         return self._root
+
+    @property
+    def __head__(self):
+        return self._head
+
+    @property
+    def __scripts__(self):
+        return self._scripts

--- a/webcompy/app/_app.py
+++ b/webcompy/app/_app.py
@@ -16,26 +16,17 @@ class WebComPyApp:
         self._root = AppDocumentRoot(root_component, router)
 
     @property
+    def __routes__(self):
+        return self._root.routes
+
+    @property
+    def __router_mode__(self):
+        return self._root.router_mode
+
+    @property
     def __render__(self):
-        return self._root.render
+        return self._root.__render__
 
-    def __generate__(self):
-        import pathlib
-        import os
-        import shutil
-
-        dist = pathlib.Path.cwd() / "dist"
-        if dist.exists():
-            shutil.rmtree(dist)
-        os.mkdir(dist)
-        if len(self._root.routes) and self._root.router_mode == "history":
-            for path in self._root.routes:
-                page_dir = dist / path
-                if not page_dir.exists():
-                    os.makedirs(page_dir)
-                html = self._root.render_html(path, indent=0)
-                with (page_dir / "index.html").open("w", encoding="utf8") as f:
-                    f.write(html)
-        else:
-            html = self._root.render_html(indent=0)
-            (dist / "index.html").open("w", encoding="utf8").write(html)
+    @property
+    def __component_styles__(self):
+        return self._root.style

--- a/webcompy/app/_root_component.py
+++ b/webcompy/app/_root_component.py
@@ -17,7 +17,6 @@ class AppRootComponent(NonPropsComponentBase):
 
 
 class AppDocumentRoot(Component):
-    routes: list[str]
     _router: Router | None
 
     def __init__(
@@ -28,15 +27,10 @@ class AppDocumentRoot(Component):
             RouterView.__set_router__(self._router)
             TypedRouterLink.__set_router__(self._router)
         super().__init__(AppRootComponent, None, {"root": lambda: root_component(None)})
-        self.routes = [p[0] for p in self._router.__routes__] if self._router else []
-        self.router_mode = self._router.__mode__ if self._router else None
 
-    def render(self):
-        if browser:
-            style_node = browser.document.createElement("style")
-            style_node.textContent = self._style
-            browser.document.body.appendChild(style_node)
-            self._render()
+    @property
+    def __render__(self):
+        return self._render
 
     def _render(self):
         self._mount_node()
@@ -66,14 +60,17 @@ class AppDocumentRoot(Component):
         return (self,)
 
     @property
-    def _style(self):
+    def routes(self):
+        return [p[0] for p in self._router.__routes__] if self._router else None
+
+    @property
+    def router_mode(self):
+        return self._router.__mode__ if self._router else None
+
+    @property
+    def style(self):
         return "\n".join(
             style
             for component in ComponentStore.components.values()
             if (style := component.scoped_style)
         )
-
-    def render_html(self, path: str | None = None, indent: int = 2):
-        if self._router and path is not None:
-            self._router.__set_path__(path, None)
-        return self._render_html(0, indent)

--- a/webcompy/app/_root_component.py
+++ b/webcompy/app/_root_component.py
@@ -38,7 +38,6 @@ class AppDocumentRoot(Component):
         if browser and self.__loading:
             self.__loading = False
             browser.document.getElementById("webcompy-loading").remove()
-        self._mount_node()
         self._property["on_before_rendering"]()
         for child in self._children:
             child._render()
@@ -46,17 +45,17 @@ class AppDocumentRoot(Component):
 
     def _init_node(self) -> DOMNode:
         if browser:
-            node = browser.document.createElement("div")
-            node.setAttribute("id", "webcompy-app")
+            node = browser.document.getElementById("webcompy-app")
+            for name in tuple(node.attrs.keys()):
+                if name != "id":
+                    del node.attrs[name]
             node.__webcompy_node__ = True
             return node
         else:
             raise WebComPyException("Not in Browser environment.")
 
     def _mount_node(self):
-        if browser:
-            old_node = browser.document.getElementById("webcompy-app")
-            old_node.parent.replaceChild(self._get_node(), old_node)
+        pass
 
     def _get_belonging_component(self):
         return ""
@@ -86,10 +85,12 @@ class AppDocumentRoot(Component):
             if (style := component.scoped_style)
         )
 
-    def _render_html(self, count: int, indent: int) -> str:
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
         hidden = self._attrs.get("hidden")
         self._attrs["hidden"] = True
-        html = super()._render_html(count, indent)
+        html = super()._render_html(newline, indent, count)
         if hidden is None:
             del self._attrs["hidden"]
         else:

--- a/webcompy/cli/__init__.py
+++ b/webcompy/cli/__init__.py
@@ -1,0 +1,9 @@
+from webcompy.cli._config import WebComPyConfig
+from webcompy.cli._utils import get_app
+from webcompy.cli._server import create_asgi_app
+
+__all__ = [
+    "WebComPyConfig",
+    "get_app",
+    "create_asgi_app",
+]

--- a/webcompy/cli/_argparser.py
+++ b/webcompy/cli/_argparser.py
@@ -1,0 +1,39 @@
+from argparse import ArgumentParser
+import sys
+from typing import Any, Literal
+
+
+def get_params() -> tuple[Literal["start"], dict[str, Any]]:
+    def _command(subcommand_name: str):
+        return lambda: subcommand_name
+
+    parser = ArgumentParser(prog="python -m webcompy", add_help=True)
+    subparsers = parser.add_subparsers()
+
+    # start
+    subcommand_name = "start"
+    parser_start = subparsers.add_parser(
+        subcommand_name,
+        help=f"see `{subcommand_name} --help`",
+    )
+    parser_start.add_argument(
+        "--dev",
+        action="store_true",
+        help="launch dev server",
+    )
+    parser_start.add_argument(
+        "--port",
+        type=int,
+        help="server port",
+    )
+    parser_start.set_defaults(__command_getter__=_command(subcommand_name))
+
+    # parse
+    args = parser.parse_args()
+    if hasattr(args, "__command_getter__"):
+        subcommand_name = getattr(args, "__command_getter__")()
+        args_dict = {n: getattr(args, n) for n in dir(args) if not n.startswith("_")}
+        return subcommand_name, args_dict
+    else:
+        parser.print_help()
+        sys.exit()

--- a/webcompy/cli/_argparser.py
+++ b/webcompy/cli/_argparser.py
@@ -3,23 +3,24 @@ import sys
 from typing import Any, Literal
 
 
-def get_params() -> tuple[Literal["start"], dict[str, Any]]:
+def get_params() -> tuple[Literal["start", "generate"], dict[str, Any]]:
     def _command(subcommand_name: str):
         return lambda: subcommand_name
 
-    parser = ArgumentParser(prog="python -m webcompy", add_help=True)
+    maincommand = "webcompy-cli"
+    parser = ArgumentParser(prog=maincommand, add_help=True)
     subparsers = parser.add_subparsers()
 
     # start
     subcommand_name = "start"
     parser_start = subparsers.add_parser(
         subcommand_name,
-        help=f"see `{subcommand_name} --help`",
+        help=f"Starts HTTP server. See `{maincommand} {subcommand_name} --help` for options.",
     )
     parser_start.add_argument(
         "--dev",
         action="store_true",
-        help="launch dev server",
+        help="launch dev server with hot-reload",
     )
     parser_start.add_argument(
         "--port",
@@ -27,6 +28,19 @@ def get_params() -> tuple[Literal["start"], dict[str, Any]]:
         help="server port",
     )
     parser_start.set_defaults(__command_getter__=_command(subcommand_name))
+
+    # generate
+    subcommand_name = "generate"
+    parser_generate = subparsers.add_parser(
+        subcommand_name,
+        help=f"Generates static html files. See `{maincommand} {subcommand_name} --help` for options.",
+    )
+    parser_generate.add_argument(
+        "--dist",
+        type=str,
+        help="dist dir",
+    )
+    parser_generate.set_defaults(__command_getter__=_command(subcommand_name))
 
     # parse
     args = parser.parse_args()

--- a/webcompy/cli/_argparser.py
+++ b/webcompy/cli/_argparser.py
@@ -3,11 +3,11 @@ import sys
 from typing import Any, Literal
 
 
-def get_params() -> tuple[Literal["start", "generate"], dict[str, Any]]:
+def get_params() -> tuple[Literal["start", "generate", "init"], dict[str, Any]]:
     def _command(subcommand_name: str):
         return lambda: subcommand_name
 
-    maincommand = "webcompy-cli"
+    maincommand = "python -m webcompy"
     parser = ArgumentParser(prog=maincommand, add_help=True)
     subparsers = parser.add_subparsers()
 
@@ -41,6 +41,14 @@ def get_params() -> tuple[Literal["start", "generate"], dict[str, Any]]:
         help="dist dir",
     )
     parser_generate.set_defaults(__command_getter__=_command(subcommand_name))
+
+    # init
+    subcommand_name = "init"
+    parser_init = subparsers.add_parser(
+        subcommand_name,
+        help="Creates new project on current dir.",
+    )
+    parser_init.set_defaults(__command_getter__=_command(subcommand_name))
 
     # parse
     args = parser.parse_args()

--- a/webcompy/cli/_asgi_app.py
+++ b/webcompy/cli/_asgi_app.py
@@ -1,0 +1,7 @@
+from webcompy.cli._server import create_asgi_app
+from webcompy.cli._utils import get_config
+from webcompy.cli._argparser import get_params
+
+config = get_config()
+_, args = get_params()
+app = create_asgi_app(config, args["dev"])

--- a/webcompy/cli/_brython_cli.py
+++ b/webcompy/cli/_brython_cli.py
@@ -1,0 +1,47 @@
+import os
+import pathlib
+import shutil
+import sys
+from tempfile import TemporaryDirectory
+from brython.__main__ import main as brython_main  # type: ignore
+from webcompy.cli._utils import external_cli_tool_wrapper
+from webcompy.cli._exception import WebComPyCliException
+
+
+@external_cli_tool_wrapper
+def install_brython_scripts(dest: str):
+    DEST_FILES = {"brython.js", "brython_stdlib.js", "unicode.txt"}
+    dest_path = pathlib.Path(dest).absolute()
+    if not dest_path.exists():
+        os.mkdir(dest_path)
+    else:
+        for p in (dest_path / n for n in DEST_FILES):
+            if p.exists():
+                os.remove(p)
+
+    with TemporaryDirectory() as temp_dir:
+        temp_dir = pathlib.Path(temp_dir)
+        os.chdir(temp_dir)
+        sys.argv.append("--install")
+        brython_main()
+        for child in temp_dir.iterdir():
+            if child.name.lower() in DEST_FILES:
+                shutil.copy(child, dest_path)
+        os.chdir(temp_dir.parent)
+
+
+@external_cli_tool_wrapper
+def make_brython_package(package_dir: str, dest: str):
+    if not (package_dir_path := pathlib.Path(package_dir).absolute()).exists():
+        raise WebComPyCliException(f"Package dir '{package_dir}' does not exist")
+    if not (dest_path := pathlib.Path(dest).absolute()).exists():
+        os.mkdir(dest_path)
+    package_name = package_dir_path.name
+    package_file_name = f"{package_name}.brython.js"
+    os.chdir(package_dir_path)
+    sys.argv.append("--make_package")
+    sys.argv.append(package_name)
+    brython_main()
+    if (dest_path / package_file_name).exists():
+        os.remove(dest_path / package_file_name)
+    shutil.move(package_dir_path / package_file_name, dest_path)

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -1,19 +1,10 @@
-from dataclasses import dataclass, field
-from typing import TypedDict
-
-
-class Head(TypedDict, total=False):
-    title: str
-    meta: list[dict[str, str]]
-
+from dataclasses import dataclass
 
 @dataclass
 class WebComPyConfig:
     app_package: str
-    head: Head = field(default_factory=Head)
     base: str = "/"
     server_port: int = 8080
-    ssr: bool = True
 
     def __post_init__(self):
         self.base = f"/{base}" if (base := self.base.strip("/")) else "/"

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -5,6 +5,7 @@ class WebComPyConfig:
     app_package: str
     base: str = "/"
     server_port: int = 8080
+    dist: str = "dist"
 
     def __post_init__(self):
         self.base = f"/{base}" if (base := self.base.strip("/")) else "/"

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -14,3 +14,6 @@ class WebComPyConfig:
     base: str = "/"
     server_port: int = 8080
     ssr: bool = True
+
+    def __post_init__(self):
+        self.base = f"/{base}" if (base := self.base.strip("/")) else "/"

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -13,3 +13,4 @@ class WebComPyConfig:
     head: Head = field(default_factory=Head)
     base: str = "/"
     server_port: int = 8080
+    ssr: bool = True

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass, field
+from typing import TypedDict
+
+
+class Head(TypedDict, total=False):
+    title: str
+    meta: list[dict[str, str]]
+
+
+@dataclass
+class WebComPyConfig:
+    app_package: str
+    head: Head = field(default_factory=Head)
+    base: str = "/"
+    server_port: int = 8080

--- a/webcompy/cli/_exception.py
+++ b/webcompy/cli/_exception.py
@@ -1,0 +1,5 @@
+from webcompy.exception import WebComPyException
+
+
+class WebComPyCliException(WebComPyException):
+    pass

--- a/webcompy/cli/_generate.py
+++ b/webcompy/cli/_generate.py
@@ -1,0 +1,65 @@
+from functools import partial
+import os
+import pathlib
+import shutil
+from webcompy.cli._argparser import get_params
+from webcompy.cli._brython_cli import (
+    install_brython_scripts,
+    make_brython_package,
+)
+from webcompy.cli._html import generate_html
+from webcompy.cli._utils import (
+    get_app,
+    get_config,
+    get_webcompy_packge_dir,
+)
+
+
+def generate_static_site():
+    config = get_config()
+    app = get_app(config)
+    _, args = get_params()
+    config = get_config()
+    dist = config.dist if args.get("dist") is None else args["dist"]
+
+    dist_dir = pathlib.Path(dist).absolute()
+    if dist_dir.exists():
+        shutil.rmtree(dist_dir)
+    os.mkdir(dist_dir)
+
+    scripts_dir = dist_dir / "_scripts"
+    os.mkdir(scripts_dir)
+    install_brython_scripts(
+        str(scripts_dir),
+    )
+    make_brython_package(
+        get_webcompy_packge_dir(),
+        str(scripts_dir),
+    )
+    make_brython_package(
+        str(pathlib.Path(f"./{config.app_package}").absolute()),
+        str(scripts_dir),
+    )
+
+    html_generator = partial(generate_html, config, False)
+    if app.__component__.router_mode == "history" and app.__component__.routes:
+        for path, _, _, _, _ in app.__component__.routes:
+            path_dir = dist_dir / path
+            if not path_dir.exists():
+                os.makedirs(path_dir)
+            app.__component__.set_path(path)
+            html = html_generator(app, True)
+            html_path = path_dir / "index.html"
+            html_path.open("w", encoding="utf8").write(html)
+            print(html_path)
+        app.__component__.set_path("//:404://")
+        html = html_generator(app, True)
+        html_path = dist_dir / "404.html"
+        html_path.open("w", encoding="utf8").write(html)
+        print(html_path)
+    else:
+        html = html_generator(app, False)
+        html_path = dist_dir / "index.html"
+        html_path.open("w", encoding="utf8").write(html)
+        print(html_path)
+    print("done")

--- a/webcompy/cli/_generate.py
+++ b/webcompy/cli/_generate.py
@@ -43,15 +43,19 @@ def generate_static_site():
 
     html_generator = partial(generate_html, config, False)
     if app.__component__.router_mode == "history" and app.__component__.routes:
-        for path, _, _, _, _ in app.__component__.routes:
-            path_dir = dist_dir / path
-            if not path_dir.exists():
-                os.makedirs(path_dir)
-            app.__component__.set_path(path)
-            html = html_generator(app, True)
-            html_path = path_dir / "index.html"
-            html_path.open("w", encoding="utf8").write(html)
-            print(html_path)
+        for p, _, _, _, page in app.__component__.routes:
+            if path_params := page.get("path_params"):
+                paths = {p.format(**params) for params in path_params}
+            else:
+                paths = {p}
+            for path in paths:
+                if not (path_dir := dist_dir / path).exists():
+                    os.makedirs(path_dir)
+                app.__component__.set_path(path)
+                html = html_generator(app, True)
+                html_path = path_dir / "index.html"
+                html_path.open("w", encoding="utf8").write(html)
+                print(html_path)
         app.__component__.set_path("//:404://")
         html = html_generator(app, True)
         html_path = dist_dir / "404.html"

--- a/webcompy/cli/_html.py
+++ b/webcompy/cli/_html.py
@@ -1,0 +1,91 @@
+from webcompy.elements.types import Element
+from webcompy.elements.typealias import ElementChildren
+
+
+class HtmlElement(Element):
+    def __init__(
+        self,
+        tag_name: str,
+        attrs: dict[str, str],
+        *children: ElementChildren,
+    ) -> None:
+        super().__init__(
+            tag_name,  # type: ignore
+            attrs,  # type: ignore
+            {},
+            None,
+            children,
+        )
+
+    def render_html(self):
+        return "<!doctype html>" + self._render_html(0, 0)
+
+    def _get_belonging_component(self):
+        return ""
+
+    def _get_belonging_components(self):
+        return tuple()
+
+
+def generate_html(
+    *,
+    app_package_name: str,
+    component_styles: str,
+    base: str,
+    dev_mode: bool,
+):
+    return HtmlElement(
+        "html",
+        {},
+        HtmlElement(
+            "head",
+            {},
+            HtmlElement("base", {"href": base}),
+            HtmlElement("meta", {"charset": "utf-8"}),
+            HtmlElement("style", {}, "[hidden] { display: none; }"),
+        ),
+        HtmlElement(
+            "body",
+            {
+                "onload": "brython({debug: 1, cache: false, indexedDB: true})"
+                if dev_mode
+                else "brython({debug: 0, cache: true, indexedDB: true})"
+            },
+            HtmlElement("div", {"id": "webcompy-app"}, "loading..."),
+            HtmlElement(
+                "script",
+                {
+                    "type": "text/javascript",
+                    "src": "_scripts/brython.js",
+                },
+            ),
+            HtmlElement(
+                "script",
+                {
+                    "type": "text/javascript",
+                    "src": "_scripts/brython_stdlib.js",
+                },
+            ),
+            HtmlElement(
+                "script",
+                {
+                    "type": "text/javascript",
+                    "src": "_scripts/webcompy.brython.js",
+                },
+            ),
+            HtmlElement(
+                "script",
+                {
+                    "type": "text/javascript",
+                    "src": f"_scripts/{app_package_name}.brython.js",
+                },
+            ),
+            HtmlElement(
+                "script",
+                {"type": "text/python"},
+                f"from {app_package_name} import webcompyapp\n",
+                "webcompyapp.__render__()",
+            ),
+            HtmlElement("style", {}, *component_styles.split("\n")),
+        ),
+    )

--- a/webcompy/cli/_html.py
+++ b/webcompy/cli/_html.py
@@ -88,6 +88,20 @@ def generate_html(
             f"from {config.app_package} import webcompyapp\nwebcompyapp.__component__.render()",
         )
     )
+    if dev_mode:
+        scripts.append(
+            (
+                {"type": "text/javascript"},
+                "\n".join(
+                    (
+                        "var stream= new EventSource('{base}_webcompy_reload');".format(
+                            base=b if (b := config.base) == "/" else f"{b}/"
+                        ),
+                        "stream.addEventListener('error', (e) => { window.location.reload(); });"
+                    )
+                ),
+            )
+        )
     if title := app.__head__.get("title"):
         title = _HtmlElement("title", {}, title)
     else:

--- a/webcompy/cli/_init_project.py
+++ b/webcompy/cli/_init_project.py
@@ -1,0 +1,50 @@
+import os
+import pathlib
+import shutil
+import sys
+from webcompy.cli._utils import get_webcompy_packge_dir
+
+
+def _get_files(path: pathlib.Path, suffix: str) -> list[str]:
+    ret: list[str] = []
+    if path.is_dir():
+        for p in path.iterdir():
+            ret.extend(_get_files(p, suffix))
+    elif path.suffix == suffix:
+        ret.append(str(path))
+    return ret
+
+
+def init_project():
+    template_data_dir = (
+        pathlib.Path(get_webcompy_packge_dir()) / "cli" / "template_data"
+    )
+    cwd = pathlib.Path().cwd().absolute()
+    filepath_pairs = [
+        (
+            filepath,
+            cwd / str(filepath).replace(str(template_data_dir), "").lstrip(os.sep),
+        )
+        for filepath in map(pathlib.Path, _get_files(template_data_dir, ".py"))
+    ]
+
+    files_exist = [p for _, p in filepath_pairs if p.exists()]
+    if files_exist:
+        for p in files_exist:
+            print(p)
+        while True:
+            ans = input("Some files already exist. Will you overwrite them? (y/N): ")
+            if len(ans) == 0 or (ans.isalpha() and ans.lower() in {"y", "n"}):
+                if len(ans) == 0 or ans.lower() == "n":
+                    sys.exit()
+                else:
+                    break
+            else:
+                continue
+    for template_filepath, project_filepath in filepath_pairs:
+        if not project_filepath.parent.exists():
+            os.makedirs(project_filepath.parent)
+        if project_filepath.exists():
+            os.remove(project_filepath)
+        shutil.copy(template_filepath, project_filepath)
+        print(project_filepath)

--- a/webcompy/cli/_server.py
+++ b/webcompy/cli/_server.py
@@ -42,13 +42,7 @@ def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
             raise HTTPException(404)
 
     app = get_app(config)
-    html_generator = partial(
-        generate_html,
-        config.app_package,
-        app.__component__.style,
-        config.base,
-        dev_mode,
-    )
+    html_generator = partial(generate_html, config, dev_mode)
     base_url_stripper = partial(re_compile("^" + re_escape(config.base)).sub, "")
 
     if app.__component__.router_mode == "history" and app.__component__.routes:
@@ -69,10 +63,10 @@ def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
             # response html
             if matched:
                 app.__component__.set_path(matched[0])
-                return HTMLResponse(html_generator(app.__component__))
+                return HTMLResponse(html_generator(app, True))
             elif "text/html" in accept_types:
                 app.__component__.set_path(requested_path)
-                return HTMLResponse(html_generator(app.__component__))
+                return HTMLResponse(html_generator(app, True))
             else:
                 raise HTTPException(404)
 
@@ -86,7 +80,7 @@ def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
             return HTMLResponse(html)
 
         html_route = config.base + "/" if config.base != "/" else "/"
-        html = html_generator(None)
+        html = html_generator(app, False)
 
     routes = [
         Route("/_scripts/{filename:path}", send_script_file),

--- a/webcompy/cli/_server.py
+++ b/webcompy/cli/_server.py
@@ -1,0 +1,69 @@
+import mimetypes
+import pathlib
+from tempfile import TemporaryDirectory
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from starlette.types import ASGIApp
+import uvicorn  # type: ignore
+from webcompy.cli._argparser import get_params
+from webcompy.cli._brython_cli import (
+    install_brython_scripts,
+    make_brython_package,
+)
+from webcompy.cli._config import WebComPyConfig
+from webcompy.cli._html import generate_html
+from webcompy.cli._utils import get_app, get_config
+
+
+def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
+    with TemporaryDirectory() as temp:
+        install_brython_scripts(temp)
+        make_brython_package("webcompy", temp)
+        make_brython_package("dev", temp)
+        script_files: dict[str, tuple[bytes, str]] = {
+            p.name: (
+                p.open("rb").read(),
+                t if (t := mimetypes.guess_type(p)[0]) else "application/octet-stream",
+            )
+            for p in pathlib.Path(temp).iterdir()
+        }
+
+    fastapi_app = FastAPI()
+
+    @fastapi_app.get("/_scripts/{filename}")
+    async def _(filename: str):
+        if filename in script_files.keys():
+            content, media_type = script_files[filename]
+            return PlainTextResponse(content, media_type=media_type)
+        else:
+            raise HTTPException(404)
+
+    app = get_app(config)
+    index_html = generate_html(
+        app_package_name=config.app_package,
+        component_styles=app.__component_styles__,
+        base=config.base,
+        dev_mode=dev_mode,
+    ).render_html()
+
+    if app.__router_mode__ == "history" and app.__routes__:
+        for route in app.__routes__:
+
+            @fastapi_app.get(f"/{route}")
+            async def _():
+                return HTMLResponse(index_html)
+
+    else:
+
+        @fastapi_app.get("/")
+        async def _():
+            return HTMLResponse(index_html)
+
+    return fastapi_app
+
+
+def run_server():
+    _, args = get_params()
+    config = get_config()
+    port = config.server_port if args["port"] is None else args["port"]
+    uvicorn.run("webcompy.cli._asgi_app:app", port=port, reload=args["dev"])

--- a/webcompy/cli/_server.py
+++ b/webcompy/cli/_server.py
@@ -111,5 +111,9 @@ def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
 def run_server():
     _, args = get_params()
     config = get_config()
-    port = config.server_port if args.get("port") is None else args["port"]
-    uvicorn.run("webcompy.cli._asgi_app:app", port=port, reload=args["dev"])
+    uvicorn.run(
+        "webcompy.cli._asgi_app:app",
+        host="0.0.0.0",
+        port=args.get("port", config.server_port),
+        reload=args["dev"],
+    )

--- a/webcompy/cli/_server.py
+++ b/webcompy/cli/_server.py
@@ -114,6 +114,6 @@ def run_server():
     uvicorn.run(
         "webcompy.cli._asgi_app:app",
         host="0.0.0.0",
-        port=args.get("port", config.server_port),
+        port=port if (port := args["port"]) else config.server_port,
         reload=args["dev"],
     )

--- a/webcompy/cli/_utils.py
+++ b/webcompy/cli/_utils.py
@@ -57,6 +57,15 @@ def get_app(config: WebComPyConfig) -> WebComPyApp:
     return app
 
 
+def get_webcompy_packge_dir(path: pathlib.Path | None = None) -> str:
+    if path is None:
+        path = pathlib.Path(__file__)
+    if path.is_dir() and path.name == "webcompy":
+        return str(path.absolute())
+    else:
+        return get_webcompy_packge_dir(path.parent)
+
+
 P = ParamSpec("P")
 T = TypeVar("T")
 

--- a/webcompy/cli/_utils.py
+++ b/webcompy/cli/_utils.py
@@ -1,0 +1,78 @@
+import os
+import pathlib
+import sys
+from typing import Callable, ParamSpec, TypeVar
+from webcompy.cli._config import WebComPyConfig
+from webcompy.cli._exception import WebComPyCliException
+from webcompy.app._app import WebComPyApp
+
+
+def get_config() -> WebComPyConfig:
+    try:
+        webcompy_config = __import__("webcompy_config")
+    except ModuleNotFoundError:
+        raise WebComPyCliException(
+            "No python module named 'webcompy_config'",
+        )
+    configs = tuple(
+        it
+        for name in dir(webcompy_config)
+        if isinstance(it := getattr(webcompy_config, name), WebComPyConfig)
+    )
+    if len(configs) == 0:
+        raise WebComPyCliException(
+            "No WebComPyConfig instance in 'webcompy_config.py'",
+        )
+    elif len(configs) == 0:
+        raise WebComPyCliException(
+            "Multiple WebComPyConfig instances in 'webcompy_config.py'"
+        )
+    else:
+        config = configs[0]
+    return config
+
+
+def get_app(config: WebComPyConfig) -> WebComPyApp:
+    try:
+        bootstrap = __import__(config.app_package)
+    except ModuleNotFoundError:
+        raise WebComPyCliException(
+            f"No python module named '{config.app_package}'",
+        )
+    app_instances = tuple(
+        it
+        for name in dir(bootstrap)
+        if isinstance(it := getattr(bootstrap, name), WebComPyApp)
+    )
+    if len(app_instances) == 0:
+        raise WebComPyCliException(
+            "No WebComPyApp instance in 'bootstrap.py'",
+        )
+    elif len(app_instances) == 0:
+        raise WebComPyCliException(
+            "Multiple WebComPyApp instances in 'bootstrap.py'",
+        )
+    else:
+        app = app_instances[0]
+    return app
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def external_cli_tool_wrapper(func: Callable[P, T]) -> Callable[P, T]:
+    def inner(*args: P.args, **kwargs: P.kwargs):
+        cwd_ori = pathlib.Path.cwd()
+        argv_ori = tuple(sys.argv[1:])
+        for _ in range(1, len(sys.argv)):
+            sys.argv.pop(1)
+        ret = func(*args, **kwargs)
+        for _ in range(1, len(sys.argv)):
+            sys.argv.pop(1)
+        for arg in argv_ori:
+            sys.argv.append(arg)
+        os.chdir(cwd_ori)
+        return ret
+
+    return inner

--- a/webcompy/cli/template_data/app/__init__.py
+++ b/webcompy/cli/template_data/app/__init__.py
@@ -1,0 +1,3 @@
+from .bootstrap import app as webcompyapp
+
+__all__ = ["webcompyapp"]

--- a/webcompy/cli/template_data/app/bootstrap.py
+++ b/webcompy/cli/template_data/app/bootstrap.py
@@ -1,0 +1,16 @@
+from webcompy.app import WebComPyApp
+from .router import router
+from .components.root import Root
+
+app = WebComPyApp(
+    root_component=Root,
+    router=router,
+)
+app.set_head(
+    {
+        "title": "WebComPy Template",
+        "meta": [
+            {"charset": "utf-8"},
+        ],
+    }
+)

--- a/webcompy/cli/template_data/app/components/fizzbuzz.py
+++ b/webcompy/cli/template_data/app/components/fizzbuzz.py
@@ -1,0 +1,120 @@
+from webcompy.reactive import Reactive, computed_property, computed
+from webcompy.elements import html, repeat, switch
+from webcompy.components import (
+    define_component,
+    ComponentContext,
+    TypedComponentBase,
+    component_class,
+    on_before_rendering,
+    component_template,
+)
+from webcompy.router import RouterContext
+from webcompy.brython import DOMEvent
+
+
+@define_component
+def FizzbuzzList(context: ComponentContext[Reactive[int]]):
+    @computed
+    def numbers():
+        li: list[str] = []
+        for n in range(1, context.props.value + 1):
+            if n % 15 == 0:
+                li.append("FizzBuzz")
+            elif n % 5 == 0:
+                li.append("Fizz")
+            elif n % 3 == 0:
+                li.append("Buzz")
+            else:
+                li.append(str(n))
+        return li
+
+    return html.DIV(
+        {},
+        html.UL(
+            {},
+            repeat(numbers, lambda s: html.LI({}, s)),
+        ),
+    )
+
+
+FizzbuzzList.scoped_style = {
+    "ul": {
+        "border": "dashed 2px #668ad8",
+        "background": "#f1f8ff",
+        "padding": "0.5em 0.5em 0.5em 2em",
+    },
+    "ul > li:nth-child(3n)": {
+        "color": "red",
+    },
+    "ul > li:nth-child(5n)": {
+        "color": "blue",
+    },
+    "ul > li:nth-child(15n)": {
+        "color": "purple",
+    },
+}
+
+
+@component_class
+class Fizzbuzz(TypedComponentBase(props_type=RouterContext)):
+    def __init__(self) -> None:
+        self.opened = Reactive(True)
+        self.count = Reactive(10)
+
+    @computed_property
+    def toggle_button_text(self):
+        return "Hide" if self.opened.value else "Open"
+
+    @on_before_rendering
+    def on_before_rendering(self):
+        self.count.value = 10
+
+    def add(self, ev: DOMEvent):
+        self.count.value += 1
+
+    def pop(self, ev: DOMEvent):
+        if self.count.value > 0:
+            self.count.value -= 1
+
+    def toggle(self, ev: DOMEvent):
+        self.opened.value = not self.opened.value
+
+    @component_template
+    def template(self):
+        return html.DIV(
+            {},
+            html.H2(
+                {},
+                "FizzBuzz",
+            ),
+            html.P(
+                {},
+                html.BUTTON(
+                    {"@click": self.toggle},
+                    self.toggle_button_text,
+                ),
+                html.BUTTON(
+                    {"@click": self.add},
+                    "Add",
+                ),
+                html.BUTTON(
+                    {"@click": self.pop},
+                    "Pop",
+                ),
+            ),
+            html.P(
+                {},
+                "Count: ",
+                self.count,
+            ),
+            switch(
+                {
+                    "case": self.opened,
+                    "generator": lambda: FizzbuzzList(props=self.count),
+                },
+                default=lambda: html.DIV(
+                    {},
+                    "FizzBuzz Hidden",
+                ),
+            ),
+        )

--- a/webcompy/cli/template_data/app/components/home.py
+++ b/webcompy/cli/template_data/app/components/home.py
@@ -1,0 +1,11 @@
+from webcompy.elements import html
+from webcompy.components import define_component, ComponentContext
+from webcompy.router import RouterContext
+
+
+@define_component
+def Home(_: ComponentContext[RouterContext]):
+    return html.H3(
+        {},
+        "WebCompy Template",
+    )

--- a/webcompy/cli/template_data/app/components/input.py
+++ b/webcompy/cli/template_data/app/components/input.py
@@ -1,0 +1,30 @@
+from webcompy.reactive import Reactive
+from webcompy.elements import html
+from webcompy.components import define_component, ComponentContext
+from webcompy.router import RouterContext
+from webcompy.brython import DOMEvent
+
+
+@define_component
+def InOutSample(_: ComponentContext[RouterContext]):
+    text = Reactive("")
+
+    def on_input(ev: DOMEvent):
+        text.value = ev.target.value
+
+    return html.DIV(
+        {},
+        html.H4({}, "Text Input Sample"),
+        html.P(
+            {},
+            "Input: ",
+            html.INPUT(
+                {"type": "text", "@input": on_input},
+            ),
+        ),
+        html.P(
+            {},
+            "Output: ",
+            text,
+        ),
+    )

--- a/webcompy/cli/template_data/app/components/navigation.py
+++ b/webcompy/cli/template_data/app/components/navigation.py
@@ -1,0 +1,43 @@
+from webcompy.elements import html
+from webcompy.components import (
+    component_class,
+    NonPropsComponentBase,
+    component_template,
+)
+from webcompy.router import RouterLink
+
+
+@component_class
+class Navigation(NonPropsComponentBase):
+    def __init__(self) -> None:
+        pass
+
+    @component_template
+    def template(self):
+        return html.NAV(
+            {},
+            html.UL(
+                {},
+                html.LI(
+                    {},
+                    RouterLink(
+                        to="/",
+                        text=["Home"],
+                    ),
+                ),
+                html.LI(
+                    {},
+                    RouterLink(
+                        to="/fizzbuzz",
+                        text=["FizzBuzz"],
+                    ),
+                ),
+                html.LI(
+                    {},
+                    RouterLink(
+                        to="/input",
+                        text=["Text Input Sample"],
+                    ),
+                ),
+            ),
+        )

--- a/webcompy/cli/template_data/app/components/not_found.py
+++ b/webcompy/cli/template_data/app/components/not_found.py
@@ -1,0 +1,18 @@
+from webcompy.elements import html
+from webcompy.components import define_component, ComponentContext
+from webcompy.router import RouterContext
+
+
+@define_component
+def NotFound(context: ComponentContext[RouterContext]):
+    return html.DIV(
+        {},
+        html.H3(
+            {},
+            "NotFound",
+        ),
+        html.PRE(
+            {},
+            context.props.path,
+        ),
+    )

--- a/webcompy/cli/template_data/app/components/root.py
+++ b/webcompy/cli/template_data/app/components/root.py
@@ -1,0 +1,13 @@
+from webcompy.elements import html
+from webcompy.components import ComponentContext, define_component
+from webcompy.router import RouterView
+from .navigation import Navigation
+
+
+@define_component
+def Root(_: ComponentContext[None]):
+    return html.DIV(
+        {},
+        Navigation(None),
+        RouterView(),
+    )

--- a/webcompy/cli/template_data/app/router.py
+++ b/webcompy/cli/template_data/app/router.py
@@ -1,0 +1,14 @@
+from webcompy.router import Router
+from .components.home import Home
+from .components.fizzbuzz import Fizzbuzz
+from .components.input import InOutSample
+from .components.not_found import NotFound
+
+router = Router(
+    {"path": "/", "component": Home},
+    {"path": "/fizzbuzz", "component": Fizzbuzz},
+    {"path": "/input", "component": InOutSample},
+    default=NotFound,
+    mode="history",
+    base_url="/WebComPy"
+)

--- a/webcompy/cli/template_data/webcompy_config.py
+++ b/webcompy/cli/template_data/webcompy_config.py
@@ -1,0 +1,6 @@
+from webcompy.cli import WebComPyConfig
+
+config = WebComPyConfig(
+    app_package="app",
+    base="/WebComPy"
+)

--- a/webcompy/elements/generators.py
+++ b/webcompy/elements/generators.py
@@ -10,7 +10,7 @@ from typing import (
     Union,
 )
 from webcompy.elements.types._text import TextElement, NewLine
-from webcompy.elements.types._element import Element
+from webcompy.elements.types._element import ElementBase, Element
 from webcompy.elements.types._refference import DomNodeRef
 from webcompy.elements.types._repeat import RepeatElement, MultiLineTextElement
 from webcompy.elements.types._switch import SwitchElement
@@ -56,7 +56,7 @@ def create_element(
 
 
 ChildNode: TypeAlias = Union[
-    Element,
+    ElementBase,
     TextElement,
     MultiLineTextElement,
     NewLine,

--- a/webcompy/elements/types/_abstract.py
+++ b/webcompy/elements/types/_abstract.py
@@ -33,7 +33,7 @@ class ElementAbstract(ReactiveReceivable):
         self._mount_node()
 
     def _mount_node(self):
-        if node := self._get_node():
+        if not self._mounted and (node := self._get_node()):
             parent_node = self._parent._get_node()
             if self._mounted is None:
                 if parent_node.childNodes.length <= self._node_idx:
@@ -85,6 +85,15 @@ class ElementAbstract(ReactiveReceivable):
     def _clear_node_cache(self, recursive: bool = True):
         self._node_cache = None
 
+    def _get_prerendered_node(self) -> DOMNode | None:
+        parent_node = self._parent._get_node()
+        if parent_node.childNodes.length > self._node_idx:
+            prerendered_node: DOMNode = parent_node.childNodes[self._node_idx]
+            return prerendered_node
+        return None
+
     @abstractmethod
-    def _render_html(self, count: int, indent: int) -> str:
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
         ...

--- a/webcompy/elements/types/_base.py
+++ b/webcompy/elements/types/_base.py
@@ -126,18 +126,23 @@ class ElementWithChildren(ElementAbstract):
     def _get_belonging_components(self) -> tuple[Any, ...]:
         return self._parent._get_belonging_components()
 
-    def _render_html(self, count: int, indent: int) -> str:
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
         attrs: str = " ".join(
             f'{name}="{value}"' if value else name
             for name, value in self._get_processed_attrs().items()
             if value is not None
         )
-        return "\n".join(
+        separator = "\n" if newline else ""
+        indent_text = (" " * indent * count) if newline else ""
+        return separator.join(
             (
-                f'{" " * indent * count}<{self._tag_name}{" " + attrs if attrs else ""}>',
-                "\n".join(
-                    child._render_html(count + 1, indent) for child in self._children
+                f'{indent_text}<{self._tag_name}{" " + attrs if attrs else ""}>',
+                separator.join(
+                    child._render_html(newline, indent, count + 1)
+                    for child in self._children
                 ),
-                f'{" " * indent * count}</{self._tag_name}>',
+                f"{indent_text}</{self._tag_name}>",
             )
         )

--- a/webcompy/elements/types/_dynamic.py
+++ b/webcompy/elements/types/_dynamic.py
@@ -29,8 +29,12 @@ class DynamicElement(ElementWithChildren):
     def _get_node(self) -> NoReturn:
         raise WebComPyException("'DynamicElement' does not have its own node.")
 
-    def _render_html(self, count: int, indent: int) -> str:
-        return "\n".join(child._render_html(count, indent) for child in self._children)
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
+        return ("\n" if newline else "").join(
+            child._render_html(newline, indent, count) for child in self._children
+        )
 
     @property
     def _parent(self) -> "ElementWithChildren":

--- a/webcompy/elements/types/_element.py
+++ b/webcompy/elements/types/_element.py
@@ -22,12 +22,24 @@ class ElementBase(ElementWithChildren):
             if prerendered_node and not hasattr(prerendered_node, "__webcompy_node__"):
                 node = prerendered_node
                 self._mounted = True
+                attr_names_to_remove = set(
+                    name
+                    for name, value in self._get_processed_attrs().items()
+                    if value is None and name in node.attrs.keys()
+                )
+                attr_names_to_remove.update(
+                    name
+                    for name in node.attrs.keys()
+                    if name not in self._get_processed_attrs().keys()
+                )
+                for name in attr_names_to_remove:
+                    node.removeAttribute(name)
             else:
                 node: DOMNode = browser.document.createElement(self._tag_name)
-                for name, value in self._get_processed_attrs().items():
-                    if value is not None:
-                        node.setAttribute(name, value)
             node.__webcompy_node__ = True
+            for name, value in self._get_processed_attrs().items():
+                if value is not None:
+                    node.setAttribute(name, value)
             for name, value in self._attrs.items():
                 if isinstance(value, ReactiveBase):
                     self._set_callback_id(

--- a/webcompy/elements/types/_element.py
+++ b/webcompy/elements/types/_element.py
@@ -18,11 +18,16 @@ class ElementBase(ElementWithChildren):
 
     def _init_node(self) -> DOMNode:
         if browser:
-            node: DOMNode = browser.document.createElement(self._tag_name)
+            prerendered_node = self._get_prerendered_node()
+            if prerendered_node and not hasattr(prerendered_node, "__webcompy_node__"):
+                node = prerendered_node
+                self._mounted = True
+            else:
+                node: DOMNode = browser.document.createElement(self._tag_name)
+                for name, value in self._get_processed_attrs().items():
+                    if value is not None:
+                        node.setAttribute(name, value)
             node.__webcompy_node__ = True
-            for name, value in self._get_processed_attrs().items():
-                if value is not None:
-                    node.setAttribute(name, value)
             for name, value in self._attrs.items():
                 if isinstance(value, ReactiveBase):
                     self._set_callback_id(

--- a/webcompy/elements/types/_switch.py
+++ b/webcompy/elements/types/_switch.py
@@ -28,12 +28,6 @@ class SwitchElement(DynamicElement):
         self._rendered_idx = None
         super().__init__()
 
-    def _on_set_parent(self):
-        if not browser:
-            idx, generator = self._select_generator()
-            self._rendered_idx = idx
-            self._children = self._generate_children(generator)
-
     def _select_generator(self) -> tuple[int, Callable[[], ElementChildren]]:
         if isinstance(self._cases, ReactiveBase):
             cases = self._cases.value
@@ -81,3 +75,23 @@ class SwitchElement(DynamicElement):
             child._node_idx = self._node_idx + c_idx
             child._render()
         self._parent._re_index_children(False)
+
+    def _on_set_parent(self):
+        if not browser:
+
+            def refresh(*args: Any):
+                idx, generator = self._select_generator()
+                self._rendered_idx = idx
+                self._children = self._generate_children(generator)
+
+            refresh()
+
+            if not self._reactive_activated:
+                self._reactive_activated = True
+
+                if isinstance(self._cases, ReactiveBase):
+                    self._set_callback_id(self._cases.on_after_updating(refresh))
+                else:
+                    for cond, _ in self._cases:
+                        if isinstance(cond, ReactiveBase):  # type: ignore
+                            self._set_callback_id(cond.on_after_updating(refresh))

--- a/webcompy/elements/types/_text.py
+++ b/webcompy/elements/types/_text.py
@@ -11,14 +11,24 @@ class NewLine(ElementAbstract):
 
     def _init_node(self) -> DOMNode:
         if browser:
-            node = browser.html.BR()
+            prerendered_node = self._get_prerendered_node()
+            if prerendered_node and not hasattr(prerendered_node, "__webcompy_node__"):
+                node = prerendered_node
+                self._mounted = True
+            else:
+                node = browser.html.BR()
             node.__webcompy_node__ = True
             return node
         else:
             raise WebComPyException("Not in Browser environment.")
 
-    def _render_html(self, count: int, indent: int) -> str:
-        return (" " * indent * count) + "<br>"
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
+        if newline:
+            return (" " * indent * count) + "<br>"
+        else:
+            return "<br>"
 
 
 class _HTMLTextElement(DOMNode):
@@ -40,10 +50,13 @@ class TextElement(ElementAbstract):
             text = value if isinstance(value, str) else str(value)
         else:
             text = self._text
-        return text.replace("\n", " ")
+        return text
 
     def _init_node(self) -> DOMNode:
         if browser:
+            prerendered_node = self._get_prerendered_node()
+            if prerendered_node and prerendered_node.nodeName == "#text":
+                prerendered_node.remove()
             node = browser.document.createTextNode(self._get_text())
             node.__webcompy_node__ = True
             return node
@@ -58,5 +71,10 @@ class TextElement(ElementAbstract):
     def _get_node(self) -> _HTMLTextElement:
         return cast(_HTMLTextElement, super()._get_node())
 
-    def _render_html(self, count: int, indent: int) -> str:
-        return (" " * indent * count) + self._get_text()
+    def _render_html(
+        self, newline: bool = False, indent: int = 2, count: int = 0
+    ) -> str:
+        if newline:
+            return (" " * indent * count) + self._get_text()
+        else:
+            return self._get_text()

--- a/webcompy/reactive/_base.py
+++ b/webcompy/reactive/_base.py
@@ -12,7 +12,6 @@ from typing import (
     cast,
     final,
 )
-from weakref import WeakValueDictionary
 
 
 V = TypeVar("V")
@@ -34,13 +33,9 @@ class ReactiveStore:
     __dependency: list["ReactiveBase[Any]"] | None
 
     def __init__(self) -> None:
-        self.__instances = cast(Any, WeakValueDictionary({}))
-        self.__on_before_updating = cast(
-            dict[int, Callable[[Any], Any]], WeakValueDictionary({})
-        )
-        self.__on_after_updating = cast(
-            dict[int, Callable[[Any], Any]], WeakValueDictionary({})
-        )
+        self.__instances = {}
+        self.__on_before_updating = {}
+        self.__on_after_updating = {}
         self.__callback_ids = {}
         self.__latest_instance_id = 0
         self.__latest_callback_id = 0

--- a/webcompy/router/_change_event_hander.py
+++ b/webcompy/router/_change_event_hander.py
@@ -39,7 +39,7 @@ class Location(ReactiveBase[str]):
     @ReactiveBase._change_event
     def __set_path__(self, path: str, state: dict[str, Any] | None):
         self._state = state
-        if self.__mode__ == "hash":
+        if self.__mode__ == "hash" and path.startswith("#"):
             self._value = path[1:]
         else:
             self._value = path

--- a/webcompy/router/_component.py
+++ b/webcompy/router/_component.py
@@ -1,22 +1,7 @@
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    List,
-    Tuple,
-    Type,
-    TypeAlias,
-    TypeVar,
-    Union,
-)
-from webcompy.reactive import ReactiveBase, computed
-from webcompy.elements.typealias._element_property import AttrValue
+from typing import Any, Tuple, Type, TypeAlias, TypeVar
 from webcompy.components._abstract import TypedComponentBase
-from webcompy.components._generator import ComponentGenerator
 from webcompy.router._context import RouterContext, TypedRouterContext
-from webcompy.router._link import TypedRouterLink as Base
-from webcompy.router._pages import RouterPage
+from webcompy.router._link import TypedRouterLink
 
 
 RoutedComponent: TypeAlias = TypedComponentBase(RouterContext)
@@ -26,60 +11,19 @@ ParamsType = TypeVar("ParamsType")
 QueryParamsType = TypeVar("QueryParamsType")
 PathParamsType = TypeVar("PathParamsType")
 
-
-class RouterLink(
-    Generic[ParamsType, QueryParamsType, PathParamsType],
-    Base[ParamsType, QueryParamsType],
-):
-    _path: str
-
-    def __init__(
-        self,
-        *,
-        text: List[Union[str, ReactiveBase[Any]]],
-        params: ReactiveBase[ParamsType] | None = None,
-        query: ReactiveBase[QueryParamsType] | None = None,
-        path_params: ReactiveBase[PathParamsType] | None = None,
-        attrs: Dict[str, AttrValue] | None = None,
-    ) -> None:
-        if path_params:
-            to = computed(lambda: self._path.format(**path_params.value))
-        else:
-            to = self._path
-        super().__init__(to=to, text=text, params=params, query=query, attrs=attrs)
-
-
 TypedRoute: TypeAlias = Tuple[
     Type[TypedRouterContext[ParamsType, QueryParamsType, PathParamsType]],
-    Type[RouterLink[ParamsType, QueryParamsType, PathParamsType]],
-    Callable[
-        [
-            ComponentGenerator[
-                TypedRouterContext[ParamsType, QueryParamsType, PathParamsType]
-            ]
-        ],
-        RouterPage,
-    ],
+    Type[TypedRouterLink[ParamsType, QueryParamsType, PathParamsType]],
 ]
 
 
 def create_typed_route(
-    path: str,
     *,
     params_type: Type[ParamsType] = dict[str, Any],
     query_type: Type[QueryParamsType] = dict[str, str],
     path_params_type: Type[PathParamsType] = dict[str, str],
-    router_meta: Any = None,
 ) -> TypedRoute[ParamsType, QueryParamsType, PathParamsType]:
-    _ParamsType = TypeVar("_ParamsType")
-    _QueryParamsType = TypeVar("_QueryParamsType")
-    _PathParamsType = TypeVar("_PathParamsType")
-
-    class TypedRouterLink(RouterLink[_ParamsType, _QueryParamsType, _PathParamsType]):
-        _path: str = path
-
     return (
         TypedRouterContext[ParamsType, QueryParamsType, PathParamsType],
         TypedRouterLink[ParamsType, QueryParamsType, PathParamsType],
-        lambda component_generator: {"path": path, "component": component_generator},
     )

--- a/webcompy/router/_pages.py
+++ b/webcompy/router/_pages.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, Dict, List, TypedDict
 from webcompy.components import ComponentGenerator
 from webcompy.router._context import TypedRouterContext
 from webcompy.components import WebComPyComponentException
@@ -14,4 +14,5 @@ class RouterPageRequired(TypedDict):
 
 
 class RouterPage(RouterPageRequired, total=False):
+    path_params: List[Dict[str, str]]
     meta: Any

--- a/webcompy/router/_router.py
+++ b/webcompy/router/_router.py
@@ -27,6 +27,7 @@ RouteType: TypeAlias = Tuple[
     Callable[[str], Match[str] | None],
     List[str],
     ComponentGenerator[RouterContext],
+    RouterPage,
 ]
 
 _convert_to_regex_pattern = partial(re_compile(r"\\\{[^\{\}/]+\\\}").sub, r"([^/]*?)")
@@ -89,7 +90,7 @@ class Router:
         return pathname, search
 
     def _get_elements_generator(self, args: RouteType) -> Tuple[Any, NodeGenerator]:
-        match_targeted_routes, path_param_names, component = args[1:]
+        match_targeted_routes, path_param_names, component = args[1:-1]
         current_path, search = self._get_current_path()
         if self.__mode__ == "history" and self.__base_url__:
             current_path = self._base_url_stripper(current_path)
@@ -142,8 +143,8 @@ class Router:
 
     def _generate_routes(self, pages: Sequence[RouterPage]) -> list[RouteType]:
         return [
-            (*path, component)
-            for path, component in zip(
+            (*path, component, page)
+            for path, component, page in zip(
                 map(
                     lambda path: (
                         path,
@@ -153,6 +154,7 @@ class Router:
                     map(lambda page: page["path"].strip("/"), pages),
                 ),
                 map(lambda page: page["component"], pages),
+                pages,
             )
         ]
 

--- a/webcompy/router/_router.py
+++ b/webcompy/router/_router.py
@@ -84,7 +84,7 @@ class Router:
             map(urllib.parse.unquote, self._location.value.split("?", 2))
         )
         pathname, search = (
-            [decoded_href[0], ""] if len(decoded_href) == 1 else decoded_href
+            (decoded_href[0], "") if len(decoded_href) == 1 else decoded_href
         )
         return pathname, search
 

--- a/webcompy/router/_router.py
+++ b/webcompy/router/_router.py
@@ -68,10 +68,12 @@ class Router:
     def __default__(self) -> ElementChildren:
         if self._default:
             current_path, search = self._get_current_path()
+            if current_path == "//:404://":
+                current_path = "/404.html"
+            elif self.__mode__ == "history" and self.__base_url__:
+                current_path = self._base_url_stripper(current_path)
             props = self._generate_router_context(
-                self._base_url_stripper(current_path)
-                if self.__mode__ == "history" and self.__base_url__
-                else current_path,
+                current_path,
                 search,
                 None,
                 [],

--- a/webcompy/router/_router.py
+++ b/webcompy/router/_router.py
@@ -91,12 +91,12 @@ class Router:
     def _get_elements_generator(self, args: RouteType) -> Tuple[Any, NodeGenerator]:
         match_targeted_routes, path_param_names, component = args[1:]
         current_path, search = self._get_current_path()
+        if self.__mode__ == "history" and self.__base_url__:
+            current_path = self._base_url_stripper(current_path)
         match = match_targeted_routes(current_path.strip("/"))
         if match:
             props = self._generate_router_context(
-                self._base_url_stripper(current_path)
-                if self.__mode__ == "history" and self.__base_url__
-                else current_path,
+                current_path,
                 search,
                 match,
                 path_param_names,
@@ -138,14 +138,7 @@ class Router:
         )
 
     def _generate_route_matcher(self, path: str):
-        return re_compile(
-            _convert_to_regex_pattern(
-                re_escape(self.__base_url__ + "/" + path)
-                if (self.__mode__ == "history" and self.__base_url__)
-                else re_escape(path)
-            )
-            + "$"
-        ).match
+        return re_compile(_convert_to_regex_pattern(re_escape(path)) + "$").match
 
     def _generate_routes(self, pages: Sequence[RouterPage]) -> list[RouteType]:
         return [

--- a/webcompy/utils/__init__.py
+++ b/webcompy/utils/__init__.py
@@ -1,4 +1,8 @@
 from webcompy.utils._serialize import is_json_seriarizable
+from webcompy.utils._text import strip_multiline_text
 
 
-__all__ = ["is_json_seriarizable"]
+__all__ = [
+    "is_json_seriarizable",
+    "strip_multiline_text",
+]

--- a/webcompy/utils/_text.py
+++ b/webcompy/utils/_text.py
@@ -1,0 +1,24 @@
+from functools import partial
+from itertools import dropwhile
+from re import compile as re_compile
+from typing import Any
+
+
+_is_blank_line = re_compile(r"^\s*$").match
+_get_head_blanks = re_compile(r"^\s+").match
+
+
+def strip_multiline_text(text: str):
+    lines = list(dropwhile(_is_blank_line, text.split("\n")))
+    if lines:
+        if head_blanks := _get_head_blanks(lines[0]):
+            return "\n".join(
+                map(
+                    partial(re_compile("^" + head_blanks.group()).sub, ""),
+                    lines,
+                )
+            )
+        else:
+            return "\n".join(lines)
+    else:
+        return ""


### PR DESCRIPTION
## Summary

- Add CLI tool (`python -m webcompy`) with `start`, `generate`, and `init` subcommands
- Add dev server with hot-reload (Starlette + uvicorn + SSE)
- Add static site generation command
- Add project scaffolding command (`webcompy init`)
- Add `WebComPyConfig` dataclass for app configuration
- Add Brython script installer and package builder
- Add HTML generation with Brython bootstrap
- Add template project data (FizzBuzz sample, router, navigation)
- Add MIT license and README with setup instructions