### PR TITLE
fix: app package importing

### DIFF
--- a/webcompy/cli/_html.py
+++ b/webcompy/cli/_html.py
@@ -83,8 +83,8 @@ def generate_html(
         (
             {"type": "text/python"},
             """
-                from {app_package} import webcompyapp
-                webcompyapp.__component__.render()
+                from {app_package}.bootstrap import app
+                app.__component__.render()
             """.format(
                 app_package=config.app_package
             ),

--- a/webcompy/cli/_server.py
+++ b/webcompy/cli/_server.py
@@ -28,6 +28,8 @@ from webcompy.cli._utils import (
 
 
 def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
+    app = get_app(config)
+    
     with TemporaryDirectory() as temp:
         install_brython_scripts(temp)
         make_brython_package(get_webcompy_packge_dir(), temp)
@@ -50,7 +52,6 @@ def create_asgi_app(config: WebComPyConfig, dev_mode: bool = False) -> ASGIApp:
         else:
             raise HTTPException(404)
 
-    app = get_app(config)
     html_generator = partial(generate_html, config, dev_mode)
     base_url_stripper = partial(re_compile("^" + re_escape(config.base)).sub, "")
 

--- a/webcompy/cli/_utils.py
+++ b/webcompy/cli/_utils.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 import os
 import pathlib
 import sys
@@ -9,7 +10,7 @@ from webcompy.app._app import WebComPyApp
 
 def get_config() -> WebComPyConfig:
     try:
-        webcompy_config = __import__("webcompy_config")
+        webcompy_config = import_module("webcompy_config")
     except ModuleNotFoundError:
         raise WebComPyCliException(
             "No python module named 'webcompy_config'",
@@ -34,10 +35,16 @@ def get_config() -> WebComPyConfig:
 
 def get_app(config: WebComPyConfig) -> WebComPyApp:
     try:
-        bootstrap = __import__(config.app_package)
+        import_module(config.app_package)
     except ModuleNotFoundError:
         raise WebComPyCliException(
             f"No python module named '{config.app_package}'",
+        )
+    try:
+        bootstrap = import_module(config.app_package + ".bootstrap")
+    except AttributeError:
+        raise WebComPyCliException(
+            f"No python module named 'bootstrap' in '{config.app_package}'",
         )
     app_instances = tuple(
         it

--- a/webcompy/cli/template_data/app/__init__.py
+++ b/webcompy/cli/template_data/app/__init__.py
@@ -1,3 +1,0 @@
-from .bootstrap import app as webcompyapp
-
-__all__ = ["webcompyapp"]


### PR DESCRIPTION
## Summary

- Fix app package importing in CLI: use `importlib.import_module` instead of `__import__`
- Import `bootstrap` submodule explicitly from the app package
- Remove `__init__.py` from template data that re-exported `webcompyapp`