### PR TITLE
fix: CSS keyframes rendering

### DIFF
--- a/webcompy/cli/_html.py
+++ b/webcompy/cli/_html.py
@@ -39,9 +39,19 @@ class _Loadscreen(_HtmlElement):
                 "style",
                 {},
                 " ".join(
-                    f"{selector} {{ "
-                    + " ".join(f"{name}: {value};" for name, value in props.items())
-                    + " }"
+                    f"{selector}{{"
+                    + "".join(
+                        name
+                        + (
+                            "{{{}}}".format(
+                                "".join(f"{n}:{v};" for n, v in value.items())
+                            )
+                            if isinstance(value, dict)
+                            else f":{value};"
+                        )
+                        for name, value in props.items()
+                    )
+                    + "}"
                     for selector, props in self._style.items()
                 ),
             ),


### PR DESCRIPTION
## Summary

- Fix CSS keyframes rendering: update loading screen spinner CSS in `_html.py`