### PR TITLE
fix: browser back button navigation

### DIFF
--- a/webcompy/router/_change_event_hander.py
+++ b/webcompy/router/_change_event_hander.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 from webcompy.reactive._base import ReactiveBase
-from webcompy._browser._modules import browser
+from webcompy._browser._modules import browser, browser_pyscript
 
 
 class Location(ReactiveBase[str]):
@@ -15,7 +15,14 @@ class Location(ReactiveBase[str]):
         self._base_url = base_url.strip().strip("/")
         self.set_mode(mode)
         if browser:
-            browser.window.addEventListener("popstate", self._refresh_path, False)
+            if browser_pyscript:
+                browser_pyscript.window.addEventListener(
+                    "popstate",
+                    browser_pyscript.pyodide.create_proxy(self._refresh_path),
+                    False,
+                )
+            else:
+                browser.window.addEventListener("popstate", self._refresh_path, False)
 
     @ReactiveBase._change_event
     def set_mode(self, mode: Literal["hash", "history"]):


### PR DESCRIPTION
## Summary

- Fix browser back button navigation in router
- Update `Location` class in `_change_event_hander.py` to properly handle browser history