### PR TITLE
feat: add head updater

### DIFF
--- a/docs_src/bootstrap.py
+++ b/docs_src/bootstrap.py
@@ -10,23 +10,23 @@ app = WebComPyApp(
 app.set_head(
     {
         "title": "WebComPy - Python Frontend Framework",
-        "meta": [
-            {
+        "meta": {
+            "charset": {
                 "charset": "utf-8",
             },
-            {
+            "viewport": {
                 "name": "viewport",
                 "content": "width=device-width, initial-scale=1.0",
             },
-            {
+            "description": {
                 "name": "description",
                 "content": "WebComPy is Python frontend framework on Browser",
             },
-            {
+            "keywords": {
                 "name": "keywords",
                 "content": "python,framework,browser,frontend,client-side",
             },
-        ],
+        },
         "link": [
             {
                 "rel": "stylesheet",

--- a/docs_src/pages/demo/fizzbuzz.py
+++ b/docs_src/pages/demo/fizzbuzz.py
@@ -6,12 +6,15 @@ from ...components.demo_display import DemoDisplay
 
 
 @define_component
-def FizzbuzzPage(_: ComponentContext[RouterContext]):
+def FizzbuzzPage(context: ComponentContext[RouterContext]):
+    title = "FizzBuzz"
+    context.set_title(f"{title} - WebCompy Demo")
+
     return html.DIV(
         {},
         DemoDisplay(
             {
-                "title": "FizzBuzz",
+                "title": title,
                 "code": """
                     from webcompy.reactive import Reactive, computed_property
                     from webcompy.elements import html, repeat, switch

--- a/docs_src/pages/demo/helloworld.py
+++ b/docs_src/pages/demo/helloworld.py
@@ -6,12 +6,15 @@ from ...templates.demo.helloworld import HelloWorld
 
 
 @define_component
-def HelloWorldPage(_: ComponentContext[RouterContext]):
+def HelloWorldPage(context: ComponentContext[RouterContext]):
+    title = "HelloWorld"
+    context.set_title(f"{title} - WebCompy Demo")
+
     return html.DIV(
         {},
         DemoDisplay(
             {
-                "title": "HelloWorld",
+                "title": title,
                 "code": """
                     from webcompy.elements import html
                     from webcompy.components import define_component, ComponentContext

--- a/docs_src/pages/demo/helloworld_classstyle.py
+++ b/docs_src/pages/demo/helloworld_classstyle.py
@@ -6,12 +6,15 @@ from ...templates.demo.helloworld_classstyle import HelloWorldClassstyle
 
 
 @define_component
-def HelloWorldClassstylePage(_: ComponentContext[RouterContext]):
+def HelloWorldClassstylePage(context: ComponentContext[RouterContext]):
+    title = "HelloWorld (ClassStyle)"
+    context.set_title(f"{title} - WebCompy Demo")
+
     return html.DIV(
         {},
         DemoDisplay(
             {
-                "title": "HelloWorld (ClassStyle)",
+                "title": title,
                 "code": """
                     from webcompy.elements import html
                     from webcompy.components import (

--- a/docs_src/pages/demo/matplotlib_sample.py
+++ b/docs_src/pages/demo/matplotlib_sample.py
@@ -6,12 +6,15 @@ from ...templates.demo.matplotlib_sample import MatpoltlibSample
 
 
 @define_component
-def MatpoltlibSamplePage(_: ComponentContext[RouterContext]):
+def MatpoltlibSamplePage(context: ComponentContext[RouterContext]):
+    title = "Matplotlib Sample"
+    context.set_title(f"{title} - WebCompy Demo")
+
     return html.DIV(
         {},
         DemoDisplay(
             {
-                "title": "Matplotlib Sample",
+                "title": title,
                 "code": """
                     import base64
                     from io import BytesIO

--- a/docs_src/pages/demo/todo.py
+++ b/docs_src/pages/demo/todo.py
@@ -6,12 +6,15 @@ from ...templates.demo.todo import ToDoList
 
 
 @define_component
-def ToDoListPage(_: ComponentContext[RouterContext]):
+def ToDoListPage(context: ComponentContext[RouterContext]):
+    title = "ToDo List"
+    context.set_title(f"{title} - WebCompy Demo")
+
     return html.DIV(
         {},
         DemoDisplay(
             {
-                "title": "ToDo List",
+                "title": title,
                 "code": """
                     from typing import Any, TypedDict
                     from webcompy.elements import html, repeat, DomNodeRef

--- a/docs_src/pages/document/home.py
+++ b/docs_src/pages/document/home.py
@@ -5,5 +5,7 @@ from ...templates.document.home import DocumentHome
 
 
 @define_component
-def DocumentHomePage(_: ComponentContext[RouterContext]):
+def DocumentHomePage(context: ComponentContext[RouterContext]):
+    context.set_title("Documents - WebCompy")
+    
     return html.DIV({}, DocumentHome(None))

--- a/docs_src/pages/home.py
+++ b/docs_src/pages/home.py
@@ -5,5 +5,5 @@ from ..templates.home import Home
 
 
 @define_component
-def HomePage(_: ComponentContext[RouterContext]):
+def HomePage(context: ComponentContext[RouterContext]):
     return html.DIV({}, Home(None))

--- a/docs_src/pages/not_found.py
+++ b/docs_src/pages/not_found.py
@@ -5,6 +5,8 @@ from webcompy.router import RouterContext
 
 @define_component
 def NotFound(context: ComponentContext[RouterContext]):
+    context.set_title("NotFound - WebCompy")
+    
     return html.DIV(
         {},
         html.H3(

--- a/webcompy/_browser/_modules.pyi
+++ b/webcompy/_browser/_modules.pyi
@@ -2,6 +2,8 @@ from typing import Any, Callable, Protocol
 from webcompy.elements._dom_objs import DOMNode, DOMEvent
 
 class PyScriptBrowserModule(Protocol):
+    def __getattr__(self, name: str) -> Any: ...
+    def __setattr__(self, name: str, obj: Any) -> Any: ...
     pyodide: Any
     addEventListener: Any
     alert: Any

--- a/webcompy/app/_app.py
+++ b/webcompy/app/_app.py
@@ -1,20 +1,10 @@
-from typing import Dict, List, Optional, Tuple, TypedDict
 from webcompy.components import ComponentGenerator
 from webcompy.router import Router
 from webcompy.app._root_component import AppDocumentRoot
 
 
-class Head(TypedDict, total=False):
-    title: str
-    meta: List[Dict[str, str]]
-    link: List[Dict[str, str]]
-    script: List[Tuple[Dict[str, str], Optional[str]]]
-
-
 class WebComPyApp:
     _root: AppDocumentRoot
-    _head: Head
-    _scripts: List[Tuple[Dict[str, str], Optional[str]]]
 
     def __init__(
         self,
@@ -22,59 +12,32 @@ class WebComPyApp:
         root_component: ComponentGenerator[None],
         router: Router | None = None,
     ) -> None:
-        self._head: Head = {"meta": [], "link": [], "script": []}
-        self._scripts = []
         self._root = AppDocumentRoot(root_component, router)
-
-    def set_title(self, title: str):
-        self._head["title"] = title
-
-    def append_meta(self, attributes: Dict[str, str]):
-        if "meta" in self._head:
-            self._head["meta"].append(attributes)
-        else:
-            self._head["meta"] = [attributes]
-
-    def append_link(self, attributes: Dict[str, str]):
-        if "link" in self._head:
-            self._head["link"].append(attributes)
-        else:
-            self._head["link"] = [attributes]
-
-    def append_script(
-        self,
-        attributes: Dict[str, str],
-        script: str | None = None,
-        in_head: bool = False,
-    ):
-        if not in_head:
-            self._scripts.append((attributes, script))
-        elif "script" in self._head:
-            self._head["script"].append((attributes, script))
-        else:
-            self._head["script"] = [(attributes, script)]
-
-    def set_head(self, head: Head):
-        self._head = head
-
-    def update_head(self, head: Head):
-        if "title" in head:
-            self.set_title(head["title"])
-        for meta in head.get("meta", []):
-            self.append_meta(meta)
-        for link in head.get("link", []):
-            self.append_link(link)
-        for attrs, script in head.get("script", []):
-            self.append_script(attrs, script, True)
 
     @property
     def __component__(self):
         return self._root
 
     @property
-    def __head__(self):
-        return self._head
+    def set_title(self):
+        return self._root.set_title
 
     @property
-    def __scripts__(self):
-        return self._scripts
+    def set_meta(self):
+        return self._root.set_meta
+
+    @property
+    def append_link(self):
+        return self._root.append_link
+
+    @property
+    def append_script(self):
+        return self._root.append_script
+
+    @property
+    def set_head(self):
+        return self._root.set_head
+
+    @property
+    def update_head(self):
+        return self._root.update_head

--- a/webcompy/app/_root_component.py
+++ b/webcompy/app/_root_component.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+from uuid import uuid4
 from webcompy.elements import html
 from webcompy.elements._dom_objs import DOMNode
 from webcompy._browser._modules import browser
@@ -8,7 +10,22 @@ from webcompy.components._decorators import component_template
 from webcompy.router._router import Router
 from webcompy.router._view import RouterView
 from webcompy.router._link import TypedRouterLink
+from webcompy.reactive import Computed
 from webcompy.exception import WebComPyException
+
+
+class Head(TypedDict, total=False):
+    title: str
+    meta: dict[str, dict[str, str]]
+    link: list[dict[str, str]]
+    script: list[tuple[dict[str, str], str | None]]
+
+
+class HeadReactive(TypedDict):
+    title: Computed[str]
+    meta: Computed[dict[str, dict[str, str]]]
+    link: list[dict[str, str]]
+    script: list[tuple[dict[str, str], str | None]]
 
 
 class AppRootComponent(NonPropsComponentBase):
@@ -19,16 +36,31 @@ class AppRootComponent(NonPropsComponentBase):
 
 class AppDocumentRoot(Component):
     _router: Router | None
+    _links: list[dict[str, str]]
+    _scripts: list[tuple[dict[str, str], str | None]]
+    _scripts_head: list[tuple[dict[str, str], str | None]]
     __loading: bool
 
     def __init__(
         self, root_component: ComponentGenerator[None], router: Router | None
     ) -> None:
+        self._instance_id = uuid4()
         self.__loading = True
         self._router = router
+        self._set_title("")
+        self._links = []
+        self._scripts = []
+        self._scripts_head = []
         if self._router:
             RouterView.__set_router__(self._router)
             TypedRouterLink.__set_router__(self._router)
+        if browser:
+
+            def updte_title(title: str):
+                browser.document.title = title  # type: ignore
+
+            Component._head_props.title.on_after_updating(updte_title)
+
         super().__init__(AppRootComponent, None, {"root": lambda: root_component(None)})
 
     @property
@@ -55,7 +87,7 @@ class AppDocumentRoot(Component):
             return node
         else:
             raise WebComPyException("Not in Browser environment.")
-    
+
     def _mark_as_prerendered(self, node: DOMNode):
         node.__webcompy_prerendered_node__ = True
         for child in getattr(node, "childNodes", []):
@@ -103,3 +135,54 @@ class AppDocumentRoot(Component):
         else:
             self._attrs["hidden"] = hidden
         return html
+
+    # Head controllers
+    def set_title(self, title: str):
+        self._set_title(title)
+
+    def set_meta(self, key: str, attributes: dict[str, str]):
+        self._set_meta(key, attributes)
+
+    def append_link(self, attributes: dict[str, str]):
+        self._links.append(attributes)
+
+    def append_script(
+        self,
+        attributes: dict[str, str],
+        script: str | None = None,
+        in_head: bool = False,
+    ):
+        if not in_head:
+            self._scripts.append((attributes, script))
+        else:
+            self._scripts_head.append((attributes, script))
+
+    def set_head(self, head: Head):
+        self._set_title(head.get("title", ""))
+        for key, value in head.get("meta", {}).items():
+            self._set_meta(key, value)
+        self._links = head.get("link", [])
+        self._scripts_head = head.get("script", [])
+
+    def update_head(self, head: Head):
+        if "title" in head:
+            self.set_title(head["title"])
+        for key, meta in head.get("meta", {}).items():
+            self.set_meta(key, meta)
+        for link in head.get("link", []):
+            self.append_link(link)
+        for attrs, script in head.get("script", []):
+            self.append_script(attrs, script, True)
+
+    @property
+    def head(self) -> HeadReactive:
+        return {
+            "title": Component._head_props.title,
+            "meta": Component._head_props.head_meta,
+            "link": self._links,
+            "script": self._scripts_head,
+        }
+
+    @property
+    def scripts(self):
+        return self._scripts

--- a/webcompy/cli/template_data/app/bootstrap.py
+++ b/webcompy/cli/template_data/app/bootstrap.py
@@ -9,8 +9,10 @@ app = WebComPyApp(
 app.set_head(
     {
         "title": "WebComPy Template",
-        "meta": [
-            {"charset": "utf-8"},
-        ],
+        "meta": {
+            "charset": {
+                "charset": "utf-8",
+            },
+        },
     }
 )

--- a/webcompy/cli/template_data/app/components/fizzbuzz.py
+++ b/webcompy/cli/template_data/app/components/fizzbuzz.py
@@ -58,6 +58,8 @@ FizzbuzzList.scoped_style = {
 @component_class
 class Fizzbuzz(TypedComponentBase(props_type=RouterContext)):
     def __init__(self) -> None:
+        self.context.set_title("FizzBuzz - WebCompy Template")
+
         self.opened = Reactive(True)
         self.count = Reactive(10)
 

--- a/webcompy/cli/template_data/app/components/home.py
+++ b/webcompy/cli/template_data/app/components/home.py
@@ -4,7 +4,9 @@ from webcompy.router import RouterContext
 
 
 @define_component
-def Home(_: ComponentContext[RouterContext]):
+def Home(context: ComponentContext[RouterContext]):
+    context.set_title("WebCompy Template")
+    
     return html.H3(
         {},
         "WebCompy Template",

--- a/webcompy/cli/template_data/app/components/input.py
+++ b/webcompy/cli/template_data/app/components/input.py
@@ -6,7 +6,9 @@ from webcompy.elements import DOMEvent
 
 
 @define_component
-def InOutSample(_: ComponentContext[RouterContext]):
+def InOutSample(context: ComponentContext[RouterContext]):
+    context.set_title("Text Input Sample - WebCompy Template")
+
     text = Reactive("")
 
     def on_input(ev: DOMEvent):

--- a/webcompy/cli/template_data/app/components/not_found.py
+++ b/webcompy/cli/template_data/app/components/not_found.py
@@ -5,6 +5,8 @@ from webcompy.router import RouterContext
 
 @define_component
 def NotFound(context: ComponentContext[RouterContext]):
+    context.set_title("NotFound - WebCompy Template")
+
     return html.DIV(
         {},
         html.H3(

--- a/webcompy/components/_component.py
+++ b/webcompy/components/_component.py
@@ -1,9 +1,11 @@
-from typing import Any, Callable, Type, TypeAlias, TypeGuard, Union
+from typing import Any, Callable, ClassVar, Type, TypeAlias, TypeGuard, Union
+from uuid import UUID, uuid4
 from webcompy.elements.types._element import ElementBase, Element
 from webcompy.components._libs import Context, ComponentProperty, generate_id
 from webcompy.components._abstract import ComponentAbstract
 from webcompy.elements.typealias._element_property import ElementChildren
 from webcompy.exception import WebComPyException
+from webcompy.reactive import ReactiveDict, computed_property
 
 
 FuncComponentDef: TypeAlias = Callable[[Context[Any]], ElementChildren]
@@ -18,13 +20,34 @@ def _is_class_style_component_def(obj: Any) -> TypeGuard[ClassComponentDef]:
     return isinstance(obj, type) and issubclass(obj, ComponentAbstract)
 
 
+class HeadPropsStore:
+    def __init__(self) -> None:
+        self.titles = ReactiveDict[UUID, str]({})
+        self.head_metas = ReactiveDict[UUID, dict[str, dict[str, str]]]({})
+
+    @computed_property
+    def title(self):
+        return tuple(self.titles.values())[-1]
+
+    @computed_property
+    def head_meta(self):
+        return {
+            key: attributes
+            for meta in self.head_metas.values()
+            for key, attributes in meta.items()
+        }
+
+
 class Component(ElementBase):
+    _head_props: ClassVar = HeadPropsStore()
+
     def __init__(
         self,
         component_def: Union[FuncComponentDef, ClassComponentDef],
         props: Any,
         slots: dict[str, Callable[[], ElementChildren]],
     ) -> None:
+        self._instance_id = uuid4()
         self._attrs = {}
         self._event_handlers = {}
         self._ref = None
@@ -40,11 +63,27 @@ class Component(ElementBase):
     ) -> ComponentProperty:
         if _is_class_style_component_def(component_def):
             return component_def.__get_component_instance__(
-                Context(props, slots, component_def.__get_name__())
+                Context(
+                    props,
+                    slots,
+                    component_def.__get_name__(),
+                    lambda: Component._head_props.title.value,
+                    lambda: Component._head_props.head_meta.value,
+                    self._set_title,
+                    self._set_meta,
+                )
             ).__get_component_property__()
         elif _is_function_style_component_def(component_def):
             component_name = component_def.__name__
-            context = Context(props, slots, component_name)
+            context = Context(
+                props,
+                slots,
+                component_name,
+                lambda: Component._head_props.title.value,
+                lambda: Component._head_props.head_meta.value,
+                self._set_title,
+                self._set_meta,
+            )
             template = component_def(context)
             hooks = context.__get_lifecyclehooks__()
             return {
@@ -81,6 +120,10 @@ class Component(ElementBase):
         self._property["on_after_rendering"]()
 
     def _remove_element(self, recursive: bool = True, remove_node: bool = True):
+        if self._instance_id in Component._head_props.titles:
+            del Component._head_props.titles[self._instance_id]
+        if self._instance_id in Component._head_props.head_metas:
+            del Component._head_props.head_metas[self._instance_id]
         self._property["on_before_destroy"]()
         super()._remove_element(recursive, remove_node)
 
@@ -89,3 +132,11 @@ class Component(ElementBase):
 
     def _get_belonging_components(self) -> tuple["Component", ...]:
         return (*self._parent._get_belonging_components(), self)
+
+    def _set_title(self, title: str):
+        Component._head_props.titles[self._instance_id] = title
+
+    def _set_meta(self, key: str, attributes: dict[str, str]):
+        meta = Component._head_props.head_metas.get(self._instance_id, {})
+        meta[key] = attributes
+        Component._head_props.head_metas[self._instance_id] = meta

--- a/webcompy/components/_libs.py
+++ b/webcompy/components/_libs.py
@@ -92,16 +92,16 @@ class Context(Generic[PropsType]):
     def on_before_destroy(self, func: Callable[[], Any]) -> None:
         self.__on_before_destroy = func
 
-    def get_title(self):
+    def get_title(self) -> str:
         return self.__title_getter()
 
-    def get_meta(self):
+    def get_meta(self) -> dict[str, dict[str, str]]:
         return self.__meta_getter()
 
-    def set_title(self, title: str):
+    def set_title(self, title: str) -> None:
         self.__title_setter(title)
 
-    def set_meta(self, key: str, attributes: dict[str, str]):
+    def set_meta(self, key: str, attributes: dict[str, str]) -> None:
         self.__meta_setter(key, attributes)
 
     def __get_lifecyclehooks__(self) -> _Lifecyclehooks:
@@ -136,6 +136,18 @@ class ComponentContext(Protocol[PropsType]):
     def on_before_destroy(self, func: Callable[[], Any]) -> None:
         ...
 
+    def get_title(self) -> str:
+        ...
+
+    def get_meta(self) -> dict[str, dict[str, str]]:
+        ...
+
+    def set_title(self, title: str) -> None:
+        ...
+
+    def set_meta(self, key: str, attributes: dict[str, str]) -> None:
+        ...
+
 
 class ClassStyleComponentContenxt(Protocol[PropsType]):
     @property
@@ -147,6 +159,18 @@ class ClassStyleComponentContenxt(Protocol[PropsType]):
         name: str,
         fallback: NodeGenerator | None = None,
     ) -> ElementChildren:
+        ...
+
+    def get_title(self) -> str:
+        ...
+
+    def get_meta(self) -> dict[str, dict[str, str]]:
+        ...
+
+    def set_title(self, title: str) -> None:
+        ...
+
+    def set_meta(self, key: str, attributes: dict[str, str]) -> None:
         ...
 
 

--- a/webcompy/components/_libs.py
+++ b/webcompy/components/_libs.py
@@ -38,11 +38,20 @@ class Context(Generic[PropsType]):
     __on_after_rendering: Callable[[], Any] | None
     __on_before_destroy: Callable[[], Any] | None
 
+    __title_getter: Callable[[], str]
+    __meta_getter: Callable[[], dict[str, dict[str, str]]]
+    __title_setter: Callable[[str], None]
+    __meta_setter: Callable[[str, dict[str, str]], None]
+
     def __init__(
         self,
         props: PropsType,
         slots: Dict[str, NodeGenerator],
         component_name: str,
+        title_getter: Callable[[], str],
+        meta_getter: Callable[[], dict[str, dict[str, str]]],
+        title_setter: Callable[[str], None],
+        meta_setter: Callable[[str, dict[str, str]], None],
     ) -> None:
         self.__props = props
         self.__slots = slots
@@ -50,6 +59,10 @@ class Context(Generic[PropsType]):
         self.__on_before_rendering = None
         self.__on_after_rendering = None
         self.__on_before_destroy = None
+        self.__title_getter = title_getter
+        self.__meta_getter = meta_getter
+        self.__title_setter = title_setter
+        self.__meta_setter = meta_setter
 
     @property
     def props(self) -> PropsType:
@@ -78,6 +91,18 @@ class Context(Generic[PropsType]):
 
     def on_before_destroy(self, func: Callable[[], Any]) -> None:
         self.__on_before_destroy = func
+
+    def get_title(self):
+        return self.__title_getter()
+
+    def get_meta(self):
+        return self.__meta_getter()
+
+    def set_title(self, title: str):
+        self.__title_setter(title)
+
+    def set_meta(self, key: str, attributes: dict[str, str]):
+        self.__meta_setter(key, attributes)
 
     def __get_lifecyclehooks__(self) -> _Lifecyclehooks:
         hooks: _Lifecyclehooks = {}

--- a/webcompy/elements/types/_text.py
+++ b/webcompy/elements/types/_text.py
@@ -70,9 +70,12 @@ class TextElement(ElementAbstract):
             raise WebComPyException("Not in Browser environment.")
 
     def _update_text(self, new_text: str):
-        node = self._get_node()
-        if node:
-            node.textContent = new_text
+        if browser:
+            node = self._get_node()
+            if node:
+                node.textContent = new_text
+        else:
+            self._text = new_text
 
     def _render_html(
         self, newline: bool = False, indent: int = 2, count: int = 0

--- a/webcompy/reactive/_dict.py
+++ b/webcompy/reactive/_dict.py
@@ -1,4 +1,4 @@
-from typing import Dict, TypeVar
+from typing import Any, Dict, TypeVar
 from webcompy.reactive._base import Reactive, ReactiveBase
 
 
@@ -18,6 +18,14 @@ class ReactiveDict(Reactive[Dict[K, V]]):
     def __setitem__(self, key: K, value: V):
         self._value.__setitem__(key, value)
 
+    @ReactiveBase._change_event
+    def __delitem__(self, key: K):
+        self._value.__delitem__(key)
+
+    @ReactiveBase._change_event
+    def pop(self, key: K):
+        return self._value.pop(key)
+
     @ReactiveBase._get_evnet
     def __len__(self):
         return len(self._value)
@@ -26,11 +34,18 @@ class ReactiveDict(Reactive[Dict[K, V]]):
     def __iter__(self):
         return iter(self._value)
 
+    @ReactiveBase._get_evnet
+    def get(self, key: K, default: Any = None):
+        return self._value.get(key, default)
+
+    @ReactiveBase._get_evnet
     def keys(self):
         return self._value.keys()
 
+    @ReactiveBase._get_evnet
     def values(self):
         return self._value.values()
 
+    @ReactiveBase._get_evnet
     def items(self):
         return self._value.items()


### PR DESCRIPTION
## Summary

- Add head updater: allow `WebComPyApp.set_title()`, `append_meta()`, `append_link()`, `append_script()` methods
- Add `Head` TypedDict for `<head>` element configuration
- Support dynamic head element management for SEO and metadata