### PR TITLE
refactor: remove error handling on app package import

### DIFF
--- a/webcompy/cli/_utils.py
+++ b/webcompy/cli/_utils.py
@@ -12,12 +12,7 @@ from webcompy.app._app import WebComPyApp
 
 
 def get_config() -> WebComPyConfig:
-    try:
-        webcompy_config = import_module("webcompy_config")
-    except ModuleNotFoundError:
-        raise WebComPyCliException(
-            "No python module named 'webcompy_config'",
-        )
+    webcompy_config = import_module("webcompy_config")
     configs = tuple(
         it
         for name in dir(webcompy_config)
@@ -37,18 +32,7 @@ def get_config() -> WebComPyConfig:
 
 
 def get_app(config: WebComPyConfig) -> WebComPyApp:
-    try:
-        import_module(config.app_package_path.name)
-    except ModuleNotFoundError:
-        raise WebComPyCliException(
-            f"No python module named '{config.app_package_path.name}'",
-        )
-    try:
-        bootstrap = import_module(config.app_package_path.name + ".bootstrap")
-    except AttributeError:
-        raise WebComPyCliException(
-            f"No python module named 'bootstrap' in '{config.app_package_path.name}'",
-        )
+    bootstrap = import_module(config.app_package_path.name + ".bootstrap")
     app_instances = tuple(
         it
         for name in dir(bootstrap)


### PR DESCRIPTION
## Summary

- Remove error handling on importing app packages in CLI utils
- Simplify `get_config()` and `get_app()` by removing unnecessary try/except patterns