### PR TITLE
chore: introduce OpenCode AI agent configuration

### DIFF
--- a/.opencode/agents/component-developer.md
+++ b/.opencode/agents/component-developer.md
@@ -1,0 +1,19 @@
+---
+description: Develops and refactors WebComPy components
+mode: subagent
+temperature: 0.2
+permission:
+  bash:
+    "*": ask
+    "python -m webcompy *": allow
+    "git status": allow
+    "git diff*": allow
+    "git log*": allow
+---
+
+You are a WebComPy component developer. When creating or modifying components:
+- Use the appropriate base class (ComponentBase, NonPropsComponentBase, TypedComponentBase)
+- Apply @component_template for template definitions
+- Use Reactive/Computed for state management
+- Follow the existing patterns in webcompy/components/
+- Ensure code runs in the PyScript browser environment

--- a/.opencode/agents/runtime-analyzer.md
+++ b/.opencode/agents/runtime-analyzer.md
@@ -1,0 +1,17 @@
+---
+description: Analyzes which runtime context (browser vs server) code executes in
+mode: subagent
+temperature: 0.1
+permission:
+  edit: deny
+  bash:
+    "grep *": allow
+    "python -c *": allow
+---
+
+You analyze WebComPy code to determine its runtime context.
+Look for:
+- platform.system() == "Emscripten" checks
+- Import patterns (js module = browser, uvicorn/starlette = server)
+- webcompy/_browser/ = browser API abstraction
+- webcompy/cli/ = server-side only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# WebComPy — Python Frontend Framework
+
+## Overview
+
+WebComPy is a Python frontend framework that runs in the browser via PyScript.
+It enables building single-page web applications entirely in Python.
+
+## Dual-Environment Architecture (CRITICAL)
+
+This framework operates in two distinct runtime contexts:
+
+- **Browser (PyScript/Emscripten)**: Reactive system, component rendering, DOM manipulation, routing
+- **Server (Standard Python)**: CLI tools, dev server (Starlette+uvicorn), static site generator
+
+When modifying code, always consider which context the code runs in.
+`platform.system() == "Emscripten"` is used to detect the browser environment.
+Code in `webcompy/cli/` and `webcompy/_browser/` is context-sensitive.
+
+## Project Structure
+
+- `webcompy/` — Main package source
+  - `components/` — Component system (base classes, decorators, generators)
+  - `elements/` — Virtual DOM / HTML element system
+  - `reactive/` — Reactive state management (Reactive, Computed, ReactiveList, ReactiveDict)
+  - `router/` — Client-side routing (history/hash modes)
+  - `app/` — Core application class
+  - `cli/` — CLI tools (start, generate, init)
+  - `ajax/` — HTTP client (browser fetch)
+  - `aio/` — Async utilities (AsyncComputed, AsyncWrapper)
+  - `_browser/` — Browser API abstraction layer
+- `docs_src/` — Documentation site source
+- `docs/` — Generated static site (GitHub Pages output, DO NOT Edit directly)
+
+## Build & Run Commands
+
+- Dev server: `python -m webcompy start --dev`
+- Static site generation: `python -m webcompy generate`
+- Project scaffolding: `python -m webcompy init`
+
+## Code Conventions
+
+- Python 3.9+ (uses `X | Y` union syntax from 3.10)
+- Type annotations throughout (package includes `py.typed` marker and `.pyi` stubs)
+- No comments in code unless explicitly requested
+- Component classes use decorators: `@component_template`, `@on_before_rendering`
+- Reactive values are defined via `Reactive`, `Computed`, `ReactiveList`, `ReactiveDict`
+
+## Important Notes
+
+- Do NOT edit files in `docs/` — they are generated output
+- The `.pyi` stub file at `webcompy/_browser/_modules.pyi` provides type hints for browser APIs
+- `webcompy/cli/template_data/` contains the project template for `webcompy init`
+
+## Git Conventions
+
+### Commit Messages
+
+Commit messages MUST use the following format:
+
+```
+<type>: <description>
+
+🤖 Generated with opencode
+
+Co-Authored-By: opencode <noreply@opencode.ai>
+```
+
+Where `<type>` is one of:
+
+- `feat:` — New feature
+- `fix:` — Bug fix
+- `refactor:` — Code refactoring without behavior change
+- `docs:` — Documentation changes
+- `chore:` — Maintenance tasks, dependency updates, etc.
+- `test:` — Adding or updating tests
+- `style:` — Code style changes (formatting, etc.)
+- `perf:` — Performance improvements
+
+The footer with `Co-Authored-By` MUST be included on every commit.
+
+### Branch Names
+
+Branch names MUST use the following prefix format:
+
+```
+<type>/<description>
+```
+
+Where `<type>` is one of:
+
+- `feat/` — New feature (e.g., `feat/add-di-system`)
+- `fix/` — Bug fix (e.g., `fix/reactive-update-order`)
+- `refactor/` — Code refactoring (e.g., `refactor/component-lifecycle`)
+- `docs/` — Documentation (e.g., `docs/api-reference`)
+- `chore/` — Maintenance (e.g., `chore/update-dependencies`)
+- `test/` — Testing (e.g., `test/reactive-list`)
+- `perf/` — Performance (e.g., `perf/dom-patching`)
+
+Use kebab-case for the description part of branch names.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["AGENTS.md"],
+  "watcher": {
+    "ignore": ["docs/**", ".git/**", "__pycache__/**", "*.pyc"]
+  },
+  "agent": {
+    "webcompy-docs": {
+      "description": "Generates and maintains the documentation site under docs_src/",
+      "mode": "subagent",
+      "prompt": "You are working on the WebComPy documentation site. Only modify files in docs_src/. Never edit docs/ directly as it is generated output.",
+      "permission": {
+        "edit": "ask"
+      }
+    },
+    "browser-runtime": {
+      "description": "Analyzes and modifies code that runs in the PyScript/browser environment (reactive, components, elements, router)",
+      "mode": "subagent",
+      "prompt": "You are working on browser-side WebComPy code that runs via PyScript/Emscripten. Remember: no standard library modules are available at runtime; browser APIs are accessed through js module. The reactive system must work without server-side Python."
+    },
+    "server-runtime": {
+      "description": "Analyzes and modifies server-side code (CLI, dev server, static site generator)",
+      "mode": "subagent",
+      "prompt": "You are working on server-side WebComPy code (CLI tools, Starlette dev server, static site generator). This code runs in standard Python with uvicorn, aiofiles, etc."
+    }
+  },
+  "command": {
+    "dev": {
+      "template": "Start the WebComPy development server with hot-reload enabled",
+      "description": "Start dev server"
+    },
+    "generate-docs": {
+      "template": "Generate the static documentation site from docs_src/ using `python -m webcompy generate`",
+      "description": "Generate docs site"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` with project rules, dual-environment architecture documentation, and Git conventions (commit message format with type prefix + Co-Authored-By footer, branch naming with type prefix)
- Add `opencode.json` with project-level configuration (instructions, watcher ignore patterns, custom subagents, commands)
- Add `.opencode/agents/` with custom subagents: `component-developer` and `runtime-analyzer` for WebComPy-specific workflows

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>