### PR TITLE
fix: resolve all pyright warnings

### DIFF
--- a/webcompy/components/_decorators.py
+++ b/webcompy/components/_decorators.py
@@ -10,7 +10,7 @@ def component_template(method: Callable[[Any], Element]):
     def inner(self: Any) -> Element:
         return method(self)
 
-    inner.__webcompy_component_class_property__ = "template"
+    inner.__webcompy_component_class_property__ = "template"  # type: ignore[attr-defined]
     return inner
 
 
@@ -19,7 +19,7 @@ def on_before_rendering(method: Callable[[Any], None]):
     def inner(self: Any):
         method(self)
 
-    inner.__webcompy_component_class_property__ = "on_before_rendering"
+    inner.__webcompy_component_class_property__ = "on_before_rendering"  # type: ignore[attr-defined]
     return inner
 
 
@@ -28,7 +28,7 @@ def on_after_rendering(method: Callable[[Any], None]):
     def inner(self: Any):
         method(self)
 
-    inner.__webcompy_component_class_property__ = "on_after_rendering"
+    inner.__webcompy_component_class_property__ = "on_after_rendering"  # type: ignore[attr-defined]
     return inner
 
 
@@ -37,5 +37,5 @@ def on_before_destroy(method: Callable[[Any], None]):
     def inner(self: Any):
         method(self)
 
-    inner.__webcompy_component_class_property__ = "on_before_destroy"
+    inner.__webcompy_component_class_property__ = "on_before_destroy"  # type: ignore[attr-defined]
     return inner

--- a/webcompy/router/_component.py
+++ b/webcompy/router/_component.py
@@ -6,7 +6,7 @@ from webcompy.components._abstract import TypedComponentBase
 from webcompy.router._context import RouterContext, TypedRouterContext
 from webcompy.router._link import TypedRouterLink
 
-RoutedComponent: TypeAlias = TypedComponentBase(RouterContext)
+RoutedComponent = TypedComponentBase(RouterContext)  # type: ignore[assignment]
 
 
 ParamsType = TypeVar("ParamsType")


### PR DESCRIPTION
## Summary

- Add `type: ignore[attr-defined]` for dynamic `__webcompy_component_class_property__` attribute assignments on decorated methods in `_decorators.py` (4 warnings)
- Replace `TypeAlias` annotation with plain assignment for `RoutedComponent` in `_component.py`, adding `type: ignore[assignment]` for runtime call (2 warnings)

Result: pyright 0 errors, 0 warnings (previously 0 errors, 6 warnings)

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>