### PR TITLE
feat: remove /WebComPy subdirectory base and adopt root path with custom domain webcompy.net

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Code in `webcompy/cli/` and `webcompy/_browser/` is context-sensitive.
 
 - Install dependencies: `uv sync` (use `uv sync --dev --no-group docs` for lightweight setup without matplotlib/numpy)
 - Dev server: `uv run python -m webcompy start --dev` (default port: 8080)
-- Dev server (with Playwright MCP): Requires Node.js/npx. (1) Run `uv run python -m webcompy start --dev`, (2) use Playwright MCP tools to navigate to `http://localhost:8080/WebComPy/`. If the server fails to start, check `webcompy_config.py` for port conflicts.
+- Dev server (with Playwright MCP): Requires Node.js/npx. (1) Run `uv run python -m webcompy start --dev`, (2) use Playwright MCP tools to navigate to `http://localhost:8080/`. If the server fails to start, check `webcompy_config.py` for port conflicts.
 - Static site generation: `uv run python -m webcompy generate`
 - Project scaffolding: `uv run python -m webcompy init`
 - Build package: `uv build`

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ uv run python -m webcompy generate  # for generating static site
 
 > Note: `uv init` creates a stub `hello.py` that can be deleted after running `webcompy init`.
 
-then access [http://127.0.0.1:8080/WebComPy/](http://127.0.0.1:8080/WebComPy/)
+then access [http://127.0.0.1:8080/](http://127.0.0.1:8080/)
 
 ## Documents and Demos
-- [Github Pages](https://kniwase.github.io/WebComPy/)
+- [webcompy.net](https://webcompy.net/)
     * [Source Codes](https://github.com/kniwase/WebComPy/tree/main/docs_src/)
     * [Generated Files](https://github.com/kniwase/WebComPy/tree/main/docs/)
 

--- a/docs_src/router.py
+++ b/docs_src/router.py
@@ -21,5 +21,5 @@ router = Router(
     {"path": "/sample/fetch", "component": FetchSamplePage},
     default=NotFound,
     mode="history",
-    base_url="/WebComPy",
+    base_url="",
 )

--- a/opencode.json
+++ b/opencode.json
@@ -52,7 +52,7 @@
   },
   "command": {
     "dev": {
-      "template": "Start the WebComPy development server. Run `uv run python -m webcompy start --dev` from the project root (default port 8080). Requires Node.js/npx for Playwright MCP. The server serves the docs_src app at http://localhost:8080/WebComPy/. Once the server is running, use Playwright MCP tools to navigate to the URL.",
+      "template": "Start the WebComPy development server. Run `uv run python -m webcompy start --dev` from the project root (default port 8080). Requires Node.js/npx for Playwright MCP. The server serves the docs_src app at http://localhost:8080/. Once the server is running, use Playwright MCP tools to navigate to the URL.",
       "description": "Start dev server"
     },
     "generate-docs": {

--- a/tests/e2e/app/router.py
+++ b/tests/e2e/app/router.py
@@ -23,5 +23,5 @@ router = Router(
     {"path": "/scoped-style", "component": ScopedStylePage},
     default=NotFound,
     mode="history",
-    base_url="/WebComPy",
+    base_url="",
 )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 PROJECT_ROOT = Path(__file__).parent.parent.parent
 E2E_DIR = Path(__file__).parent
-BASE_URL = "http://localhost:8088/WebComPy/"
+BASE_URL = "http://localhost:8088/"
 PORT = 8088
 PYSCRIPT_INIT_TIMEOUT = 120_000
 SERVER_LOG = Path(__file__).parent / ".e2e-server.log"

--- a/tests/e2e/test_router.py
+++ b/tests/e2e/test_router.py
@@ -19,7 +19,7 @@ def test_router_link_to_home(app_page):
     expect(app_page.locator("[data-testid='reactive-page']")).to_be_visible()
 
     app_page.locator("[data-testid='nav-home']").click()
-    expect(app_page).to_have_url(re.compile(r"/WebComPy"))
+    expect(app_page).to_have_url(re.compile(r"/$"))
     expect(app_page.locator("[data-testid='home-page']")).to_be_visible()
 
 

--- a/tests/e2e/webcompy_config.py
+++ b/tests/e2e/webcompy_config.py
@@ -4,7 +4,7 @@ from webcompy.cli import WebComPyConfig
 
 config = WebComPyConfig(
     app_package=Path(__file__).parent / "app",
-    base="/WebComPy",
+    base="/",
     server_port=8088,
     dependencies=[],
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,8 +15,8 @@ class TestWebComPyConfig:
         assert config.app_package_path == app_dir.absolute()
 
     def test_base_normalization(self):
-        config = WebComPyConfig(app_package="myapp", base="/WebComPy")
-        assert config.base == "/WebComPy/"
+        config = WebComPyConfig(app_package="myapp", base="/myapp")
+        assert config.base == "/myapp/"
 
     def test_base_root(self):
         config = WebComPyConfig(app_package="myapp", base="/")
@@ -67,3 +67,11 @@ class TestWebComPyConfig:
     def test_dist_default(self):
         config = WebComPyConfig(app_package="myapp")
         assert config.dist == "dist"
+
+    def test_cname_default(self):
+        config = WebComPyConfig(app_package="myapp")
+        assert config.cname == ""
+
+    def test_cname_custom(self):
+        config = WebComPyConfig(app_package="myapp", cname="webcompy.net")
+        assert config.cname == "webcompy.net"

--- a/webcompy/cli/_config.py
+++ b/webcompy/cli/_config.py
@@ -10,6 +10,7 @@ class WebComPyConfig:
     static_files_dir_path: Path
     dist: str
     dependencies: list[str]
+    cname: str
 
     def __init__(
         self,
@@ -19,6 +20,7 @@ class WebComPyConfig:
         static_files_dir: Path | str = "static",
         dist: str = "dist",
         dependencies: list[str] | None = None,
+        cname: str = "",
     ) -> None:
         if isinstance(app_package, Path):
             self.app_package_path = app_package.absolute()
@@ -32,3 +34,4 @@ class WebComPyConfig:
             self.static_files_dir_path = self.app_package_path.parent / static_files_dir
         self.dist = dist
         self.dependencies = [*dependencies] if dependencies else []
+        self.cname = cname

--- a/webcompy/cli/_generate.py
+++ b/webcompy/cli/_generate.py
@@ -32,6 +32,11 @@ def generate_static_site():
     nojekyll_path.touch()
     print(nojekyll_path)
 
+    if config.cname:
+        cname_path = dist_dir / "CNAME"
+        cname_path.open("w", encoding="utf8").write(config.cname)
+        print(cname_path)
+
     static_files_dir = config.static_files_dir_path.absolute()
     for relative_path in get_static_files(static_files_dir):
         src = static_files_dir / relative_path

--- a/webcompy/cli/template_data/app/router.py
+++ b/webcompy/cli/template_data/app/router.py
@@ -11,5 +11,5 @@ router = Router(
     {"path": "/input", "component": InOutSample},
     default=NotFound,
     mode="history",
-    base_url="/WebComPy",
+    base_url="",
 )

--- a/webcompy/cli/template_data/webcompy_config.py
+++ b/webcompy/cli/template_data/webcompy_config.py
@@ -2,4 +2,4 @@ from pathlib import Path
 
 from webcompy.cli import WebComPyConfig
 
-config = WebComPyConfig(app_package=Path(__file__).parent / "app", base="/WebComPy")
+config = WebComPyConfig(app_package=Path(__file__).parent / "app", base="/")

--- a/webcompy_config.py
+++ b/webcompy_config.py
@@ -5,9 +5,10 @@ from webcompy.cli import WebComPyConfig
 config = WebComPyConfig(
     app_package=Path(__file__).parent / "docs_src",
     dist="docs",
-    base="/WebComPy",
+    base="/",
     dependencies=[
         "numpy",
         "matplotlib",
     ],
+    cname="webcompy.net",
 )


### PR DESCRIPTION
## Summary

- Remove `/WebComPy` subdirectory base path and switch to root path (`/`) as the base URL for the app, dev server, and static site
- Add `cname` property to `WebComPyConfig` for GitHub Pages custom domain support, generating a `CNAME` file during `webcompy generate`
- Set `webcompy.net` as the custom domain for the documentation site
- Update all affected configs, routers, E2E tests, and documentation URLs

## Changes

| Category | Files | Change |
|---|---|---|
| Config `base` | `webcompy_config.py`, `tests/e2e/webcompy_config.py`, `webcompy/cli/template_data/webcompy_config.py` | `/WebComPy` → `/` |
| Router `base_url` | `docs_src/router.py`, `tests/e2e/app/router.py`, `webcompy/cli/template_data/app/router.py` | `/WebComPy` → `""` |
| E2E tests | `tests/e2e/conftest.py`, `tests/e2e/test_router.py` | URLs and assertions updated for root path |
| Framework | `webcompy/cli/_config.py`, `webcompy/cli/_generate.py` | Added `cname` property and CNAME file generation |
| Docs | `README.md`, `AGENTS.md`, `opencode.json` | URLs updated, GitHub Pages → webcompy.net |
| Unit tests | `tests/test_config.py` | Added `cname` tests, updated base path test |

## Notes

- DNS CNAME/A record for `webcompy.net` → GitHub Pages must be configured separately
- GitHub Pages custom domain setting must be enabled in repository Settings > Pages
- Framework code that dynamically uses `config.base` / `base_url` requires no changes

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>