### PR TITLE
fix: remove push trigger from CI workflow to prevent duplicate runs on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Remove `push: branches: [main]` trigger from CI workflow to prevent duplicate CI runs when PRs are merged to main