### PR TITLE
fix: correct typos in internal API identifiers across the codebase

### DIFF
--- a/openspec/changes/archive/2026-04-17-fix-typos/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-17-fix-typos/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-16

--- a/openspec/changes/archive/2026-04-17-fix-typos/design.md
+++ b/openspec/changes/archive/2026-04-17-fix-typos/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The codebase has four consistent typos in internal API names that are used across multiple modules:
+- `_get_evnet` in the reactive system (20 occurrences across 5 files)
+- `__webcompy_componet_definition__` and `componet_generator` in the component system (3 occurrences across 2 files)
+- `__conponents` in the component store (5 occurrences in 1 file)
+
+These are all internal (private/dunder) names with no public API exposure.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Correct all typo-named internal identifiers to their intended English spellings
+- Ensure all references (definitions, usages, stub files, tests) are updated atomically
+
+**Non-Goals:**
+- Changing any external or public API behavior
+- Refactoring the underlying patterns (e.g., replacing decorator patterns, adding DI)
+- Adding backwards compatibility aliases for the old misspelled names (these are internal-only APIs)
+
+## Decisions
+
+### 1. Direct rename without deprecation aliases
+
+**Decision**: Rename all identifiers in-place without keeping backward-compatible aliases.
+
+**Rationale**: All affected names are private (`_get_evnet` is a classmethod decorator starting with underscore; `__webcompy_componet_definition__` and `__conponents` are dunder/mangled names). No external consumer depends on these names. Adding aliases would add dead code.
+
+**Alternatives**: Add `getattr(cls, '_get_evnet', _get_event)` style compat shims — rejected because no external consumers exist.
+
+### 2. Use find-and-replace across the entire codebase
+
+**Decision**: Perform whole-project search-and-replace for each typo, covering `.py`, `.pyi`, and test files in a single pass.
+
+**Rationale**: These are simple identifier renames with no logic changes. A systematic replace-all ensures nothing is missed.
+
+**Alternatives**: Manual per-file edits — rejected as error-prone and slower.
+
+## Risks / Trade-offs
+
+- **[Risk]** Downstream consumers who may have accessed internal APIs by misspelled name → **Mitigation**: These are all private/dunder names; no public API contract is broken. The `__webcompy_componet_definition__` dunder is the most likely to be accessed externally, but it's an internal protocol attribute.
+- **[Risk]** Merge conflicts on in-flight PRs → **Mitigation**: This is a simple rename; conflict resolution is straightforward with search-and-replace.

--- a/openspec/changes/archive/2026-04-17-fix-typos/proposal.md
+++ b/openspec/changes/archive/2026-04-17-fix-typos/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The codebase contains several consistent typos in internal APIs: `_get_evnet` (should be `_get_event`), `__webcompy_componet_definition__` (should be `__webcompy_component_definition__`), `componet_generator` (should be `component_generator`), and `__conponents` (should be `__components`). These typos are used throughout the codebase and make the code harder to read and maintain.
+
+## What Changes
+
+- Rename `_get_evnet` to `_get_event` across all reactive modules (20 occurrences)
+- Rename `__webcompy_componet_definition__` to `__webcompy_component_definition__` (2 occurrences)
+- Rename `componet_generator` parameter to `component_generator` (1 occurrence)
+- Rename `__conponents` to `__components` (5 occurrences)
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — these are internal implementation details with no observable behavior change.
+
+## Impact
+
+- `webcompy/reactive/_base.py` — `_get_evnet` method definition
+- `webcompy/reactive/_computed.py`, `_list.py`, `_dict.py` — `_get_evnet` usage
+- `webcompy/router/_change_event_handler.py` — `_get_evnet` usage
+- `webcompy/aio/_aio.py` — `_get_evnet` usage
+- `webcompy/components/_generator.py` — `__conponents`, `componet_generator`, `__webcompy_componet_definition__`
+- `webcompy/components/_component.py` — `__webcompy_componet_definition__` usage
+- All `.pyi` stub files referencing these names
+- Test files referencing these names
+
+## Known Issues Addressed
+
+- `_get_evnet` (typo for `_get_event`) is consistently used throughout the codebase
+- `__webcompy_componet_definition__` (typo for "component") is consistently used
+
+## Non-goals
+
+- Refactoring the underlying patterns (e.g., replacing the decorator pattern, adding DI)
+- Changing any external or public API behavior
+- Fixing any non-typo code quality issues

--- a/openspec/changes/archive/2026-04-17-fix-typos/specs/internal-naming/spec.md
+++ b/openspec/changes/archive/2026-04-17-fix-typos/specs/internal-naming/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Internal identifiers use correct English spelling
+
+All internal (private/dunder) API identifiers SHALL use the correct English spelling of their intended names.
+
+#### Scenario: Reactive event decorator uses correct spelling
+- **WHEN** a reactive class method is decorated with the event decorator
+- **THEN** the decorator SHALL be named `_get_event` (not `_get_evnet`)
+
+#### Scenario: Component definition attribute uses correct spelling
+- **WHEN** a function is identified as a component definition
+- **THEN** the marker attribute SHALL be named `__webcompy_component_definition__` (not `__webcompy_componet_definition__`)
+
+#### Scenario: Component store uses correct spelling
+- **WHEN** component generators are stored in the component store
+- **THEN** the internal storage SHALL use the attribute name `__components` (not `__conponents`) and the generator parameter SHALL be named `component_generator` (not `componet_generator`)

--- a/openspec/changes/archive/2026-04-17-fix-typos/tasks.md
+++ b/openspec/changes/archive/2026-04-17-fix-typos/tasks.md
@@ -1,0 +1,24 @@
+## 1. Reactive System — `_get_evnet` → `_get_event`
+
+- [x] 1.1 Rename `_get_evnet` to `_get_event` in `webcompy/reactive/_base.py` (definition and self-usage)
+- [x] 1.2 Update all `_get_evnet` references in `webcompy/reactive/_computed.py`
+- [x] 1.3 Update all `_get_evnet` references in `webcompy/reactive/_list.py`
+- [x] 1.4 Update all `_get_evnet` references in `webcompy/reactive/_dict.py`
+- [x] 1.5 Update all `_get_evnet` references in `webcompy/router/_change_event_handler.py`
+- [x] 1.6 Update all `_get_evnet` references in `webcompy/aio/_aio.py`
+
+## 2. Component System — typo renames
+
+- [x] 2.1 Rename `__conponents` to `__components` and `componet_generator` to `component_generator` in `webcompy/components/_generator.py`
+- [x] 2.2 Rename `__webcompy_componet_definition__` to `__webcompy_component_definition__` in `webcompy/components/_generator.py` and `webcompy/components/_component.py`
+
+## 3. Stub and Test Files
+
+- [x] 3.1 Update `.pyi` stub files that reference any renamed identifiers
+- [x] 3.2 Update test files that reference any renamed identifiers
+
+## 4. Verification
+
+- [x] 4.1 Run `uv run ruff check .` and `uv run ruff format .` to verify lint/format
+- [x] 4.2 Run `uv run pyright` to verify type checking passes
+- [x] 4.3 Run `uv run python -m pytest tests/ --tb=short` to verify all tests pass

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -11,12 +11,10 @@ context: |
 
   ### Reactive System
   - No element-level reactivity in ReactiveList/ReactiveDict — any mutation triggers full change notification
-  - _get_evnet (typo for _get_event) is consistently used throughout the codebase
   - __purge_reactive_members__ in ReactiveReceivable is a no-op; reactive member cleanup relies on Python GC
   - No key-based reconciliation for list rendering — RepeatElement rebuilds all children on change
 
   ### Component System
-  - __webcompy_componet_definition__ (typo for "component") is consistently used
   - Component IDs are MD5 hashes — not collision-proof
 
   ### Element System

--- a/openspec/specs/internal-naming/spec.md
+++ b/openspec/specs/internal-naming/spec.md
@@ -1,0 +1,21 @@
+## Purpose
+
+Internal identifier names should use correct English spelling. This spec documents the correct spelling of internal (private/dunder) API identifiers that were previously misspelled.
+
+## Requirements
+
+### Requirement: Internal identifiers use correct English spelling
+
+All internal (private/dunder) API identifiers SHALL use the correct English spelling of their intended names.
+
+#### Scenario: Reactive event decorator uses correct spelling
+- **WHEN** a reactive class method is decorated with the event decorator
+- **THEN** the decorator SHALL be named `_get_event` (not `_get_evnet`)
+
+#### Scenario: Component definition attribute uses correct spelling
+- **WHEN** a function is identified as a component definition
+- **THEN** the marker attribute SHALL be named `__webcompy_component_definition__` (not `__webcompy_componet_definition__`)
+
+#### Scenario: Component store uses correct spelling
+- **WHEN** component generators are stored in the component store
+- **THEN** the internal storage SHALL use the attribute name `__components` (not `__conponents`) and the generator parameter SHALL be named `component_generator` (not `componet_generator`)

--- a/openspec/specs/reactive/spec.md
+++ b/openspec/specs/reactive/spec.md
@@ -6,7 +6,7 @@ Reactive state is the foundation of a declarative UI. In a traditional imperativ
 
 WebComPy's reactive system provides primitive containers (`Reactive`), derived values (`Computed`), and collections (`ReactiveList`, `ReactiveDict`) that integrate seamlessly with the element system. Any part of the UI that reads a reactive value is automatically tracked as a dependent, and any change to that value triggers updates in all dependents — whether they are text content, element attributes, computed derivations, or conditional renderings.
 
-**What WebComPy does not yet provide:** In other reactive frameworks like Vue or SolidJS, list and dict mutations can trigger fine-grained updates for individual items. In WebComPy, `ReactiveList` and `ReactiveDict` are coarse-grained — any mutation triggers a full-collection change notification. Additionally, the `_get_evnet` method name (typo for `_get_event`) and `__webcompy_componet_definition__` attribute (typo for "component") are embedded throughout the codebase and await correction.
+**What WebComPy does not yet provide:** In other reactive frameworks like Vue or SolidJS, list and dict mutations can trigger fine-grained updates for individual items. In WebComPy, `ReactiveList` and `ReactiveDict` are coarse-grained — any mutation triggers a full-collection change notification.
 
 ## Requirements
 

--- a/webcompy/aio/_aio.py
+++ b/webcompy/aio/_aio.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from re import compile as re_complie
+from re import compile as re_compile
 from re import escape as re_escape
 from traceback import TracebackException
 from typing import Any, Generic, TypeAlias, TypeVar
@@ -13,12 +13,12 @@ from webcompy import logging
 from webcompy._browser._modules import browser
 from webcompy.reactive._base import ReactiveBase
 
-AsysncResolver: TypeAlias = Callable[[Coroutine[Any, Any, Any]], None]
+AsyncResolver: TypeAlias = Callable[[Coroutine[Any, Any, Any]], None]
 
 if browser:
-    aio_run: AsysncResolver = asyncio.get_event_loop().run_until_complete
+    aio_run: AsyncResolver = asyncio.get_event_loop().run_until_complete
 else:
-    aio_run: AsysncResolver = asyncio.run
+    aio_run: AsyncResolver = asyncio.run
 
 
 A = ParamSpec("A")
@@ -27,7 +27,7 @@ T = TypeVar("T")
 
 _package_name = "/webcompy/"
 _filepath_in_package = _package_name + __file__.split(_package_name)[-1]
-_is_traceback_in_this_file = re_complie(
+_is_traceback_in_this_file = re_compile(
     r'\s+File\s+".+' + re_escape(_filepath_in_package) + r'",\s+line\s+[0-9]+,\s+in\s+'
 ).match
 
@@ -100,16 +100,16 @@ class AsyncComputed(ReactiveBase[T | None]):
         self._exception = err
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def value(self) -> T | None:
         return self._value
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def error(self) -> Exception | None:
         return self._exception
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def done(self) -> bool:
         return self._done

--- a/webcompy/cli/_static_files.py
+++ b/webcompy/cli/_static_files.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 from functools import partial
-from re import compile as re_complie
+from re import compile as re_compile
 from re import escape as re_escape
 
 from webcompy.cli._exception import WebComPyCliException
@@ -22,5 +22,5 @@ def get_static_files(static_file_dir: pathlib.Path):
         raise WebComPyCliException(
             f"'{static_file_dir}' is not directory",
         )
-    get_relative_path = partial(re_complie("^" + re_escape(str(static_file_dir) + os.sep)).sub, "")
+    get_relative_path = partial(re_compile("^" + re_escape(str(static_file_dir) + os.sep)).sub, "")
     return tuple(get_relative_path(str(p)).replace("\\", "/") for p in _list_up_files(static_file_dir))

--- a/webcompy/components/_component.py
+++ b/webcompy/components/_component.py
@@ -16,7 +16,7 @@ ClassComponentDef: TypeAlias = type[ComponentAbstract[Any]]
 
 
 def _is_function_style_component_def(obj: Any) -> TypeGuard[FuncComponentDef]:
-    return bool(callable(obj) and getattr(obj, "__webcompy_componet_definition__", None))
+    return bool(callable(obj) and getattr(obj, "__webcompy_component_definition__", None))
 
 
 def _is_class_style_component_def(obj: Any) -> TypeGuard[ClassComponentDef]:

--- a/webcompy/components/_generator.py
+++ b/webcompy/components/_generator.py
@@ -28,19 +28,19 @@ def _instantiate(cls: type[T]) -> T:
 
 @_instantiate
 class ComponentStore:
-    __conponents: dict[str, ComponentGenerator[Any]]
+    __components: dict[str, ComponentGenerator[Any]]
 
     def __init__(self) -> None:
-        self.__conponents = {}
+        self.__components = {}
 
-    def add_component(self, name: str, componet_generator: ComponentGenerator[Any]):
-        if name in self.__conponents:
+    def add_component(self, name: str, component_generator: ComponentGenerator[Any]):
+        if name in self.__components:
             raise WebComPyComponentException(f"Duplicated Component Name: '{name}'")
-        self.__conponents[name] = componet_generator
+        self.__components[name] = component_generator
 
     @property
     def components(self) -> dict[str, ComponentGenerator[Any]]:
-        return self.__conponents
+        return self.__components
 
 
 PropsType = TypeVar("PropsType")
@@ -108,7 +108,7 @@ class ComponentGenerator(Generic[PropsType]):
 def define_component(
     setup: Callable[[ComponentContext[PropsType]], ElementChildren],
 ) -> ComponentGenerator[PropsType]:
-    setup.__webcompy_componet_definition__ = True
+    setup.__webcompy_component_definition__ = True
     return ComponentGenerator(setup.__name__, setup)
 
 

--- a/webcompy/reactive/_base.py
+++ b/webcompy/reactive/_base.py
@@ -71,7 +71,7 @@ class ReactiveStore:
             if idx in self.__callback_ids[instance.__reactive_id__]:
                 func(value)
 
-    def resister(self, reactive: ReactiveBase[Any]):
+    def register(self, reactive: ReactiveBase[Any]):
         if self.__dependency is not None:
             self.__dependency.append(reactive)
 
@@ -92,13 +92,13 @@ class ReactiveStore:
             del self.__on_after_updating[callback_id]
         elif callback_id in self.__on_before_updating:
             del self.__on_before_updating[callback_id]
-        targeted_isntance_id: int | None = None
-        for isntance_id in self.__callback_ids:
-            if callback_id in self.__callback_ids[isntance_id]:
-                targeted_isntance_id = isntance_id
+        targeted_instance_id: int | None = None
+        for instance_id in self.__callback_ids:
+            if callback_id in self.__callback_ids[instance_id]:
+                targeted_instance_id = instance_id
                 break
-        if targeted_isntance_id is not None:
-            self.__callback_ids[targeted_isntance_id].remove(callback_id)
+        if targeted_instance_id is not None:
+            self.__callback_ids[targeted_instance_id].remove(callback_id)
 
 
 # Reactives
@@ -138,10 +138,10 @@ class ReactiveBase(Generic[V]):
 
     @final
     @staticmethod
-    def _get_evnet(reactive_obj_method: Callable[A, V]) -> Callable[A, V]:
+    def _get_event(reactive_obj_method: Callable[A, V]) -> Callable[A, V]:
         @wraps(reactive_obj_method)
         def method(*args: A.args, **kwargs: A.kwargs) -> V:
-            ReactiveBase._store.resister(cast("ReactiveBase[V]", args[0]))
+            ReactiveBase._store.register(cast("ReactiveBase[V]", args[0]))
             return reactive_obj_method(*args, **kwargs)
 
         return method
@@ -156,7 +156,7 @@ class Reactive(ReactiveBase[V]):
 
     @final
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def value(self) -> V:
         return self._value
 

--- a/webcompy/reactive/_computed.py
+++ b/webcompy/reactive/_computed.py
@@ -21,7 +21,7 @@ class Computed(ReactiveBase[V]):
         super().__init__(init_value)
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def value(self) -> V:
         return self._value
 

--- a/webcompy/reactive/_dict.py
+++ b/webcompy/reactive/_dict.py
@@ -10,7 +10,7 @@ class ReactiveDict(Reactive[dict[K, V]]):
     def __init__(self, init_value: dict[K, V] | None = None) -> None:
         super().__init__(init_value if init_value is not None else {})
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __getitem__(self, key: K):
         return self._value.__getitem__(key)
 
@@ -26,26 +26,26 @@ class ReactiveDict(Reactive[dict[K, V]]):
     def pop(self, key: K):
         return self._value.pop(key)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __len__(self):
         return len(self._value)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __iter__(self):
         return iter(self._value)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def get(self, key: K, default: Any = None):
         return self._value.get(key, default)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def keys(self):
         return self._value.keys()
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def values(self):
         return self._value.values()
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def items(self):
         return self._value.items()

--- a/webcompy/reactive/_list.py
+++ b/webcompy/reactive/_list.py
@@ -32,11 +32,11 @@ class ReactiveList(Reactive[list[V]]):
     def sort(self, key: Callable[[V], Any] = lambda it: it, reverse: bool = False):
         self._value.sort(key=key, reverse=reverse)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def index(self, value: V):
         return self._value.index(value)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def count(self, value: V):
         return self._value.count(value)
 
@@ -58,7 +58,7 @@ class ReactiveList(Reactive[list[V]]):
     @overload
     def __getitem__(self, idx: slice) -> list[V]: ...
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __getitem__(self, idx: int | slice):
         return self._value.__getitem__(idx)
 
@@ -75,10 +75,10 @@ class ReactiveList(Reactive[list[V]]):
         else:
             self._value.__setitem__(idx, cast("Iterable[V]", value))
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __len__(self):
         return len(self._value)
 
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def __iter__(self):
         return iter(self._value)

--- a/webcompy/router/_change_event_handler.py
+++ b/webcompy/router/_change_event_handler.py
@@ -41,12 +41,12 @@ class Location(ReactiveBase[str]):
         self._refresh_path()
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def value(self):
         return self._value
 
     @property
-    @ReactiveBase._get_evnet
+    @ReactiveBase._get_event
     def state(self):
         return self._state
 


### PR DESCRIPTION
## Summary

- Rename 8 misspelled internal identifiers to correct English spelling: `_get_evnet` → `_get_event`, `__conponents` → `__components`, `componet_generator` → `component_generator`, `__webcompy_componet_definition__` → `__webcompy_component_definition__`, `resister` → `register`, `isntance`/`targeted_isntance_id` → `instance`/`targeted_instance_id`, `AsysncResolver` → `AsyncResolver`, `re_complie` → `re_compile`
- Add `internal-naming` spec documenting correct identifier naming
- Remove resolved typo entries from known issues in `config.yaml` and `reactive` spec

## Changes

All affected names are internal (private/dunder) APIs with no public consumers, so no breaking changes.

| Typo | Correct | Files |
|------|---------|-------|
| `_get_evnet` | `_get_event` | 6 files |
| `__conponents` | `__components` | 1 file |
| `componet_generator` | `component_generator` | 1 file |
| `__webcompy_componet_definition__` | `__webcompy_component_definition__` | 2 files |
| `resister` | `register` | 1 file |
| `isntance`/`targeted_isntance_id` | `instance`/`targeted_instance_id` | 1 file |
| `AsysncResolver` | `AsyncResolver` | 1 file |
| `re_complie` | `re_compile` | 1 file |

## Verification

- `ruff check .` — passed
- `pyright` — 0 errors
- `pytest` — 192 passed (e2e errors are pre-existing port conflicts)
- Pre-commit hooks (ruff lint/format, pyright) passed on commit

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>