### PR TITLE
refactor: use public signal imports instead of private modules

### DIFF
--- a/docs_src/pages/demo/fizzbuzz.py
+++ b/docs_src/pages/demo/fizzbuzz.py
@@ -17,8 +17,7 @@ def FizzbuzzPage(context: ComponentContext[RouterContext]):
             {
                 "title": title,
                 "code": """
-                    from webcompy.signal import Signal, computed
-                    from webcompy.signal._dict import ReactiveDict
+                    from webcompy.signal import Signal, computed, ReactiveDict
                     from webcompy.elements import html, repeat, switch, DOMEvent
                     from webcompy.components import (
                         define_component,

--- a/docs_src/pages/demo/todo.py
+++ b/docs_src/pages/demo/todo.py
@@ -21,8 +21,7 @@ def ToDoListPage(context: ComponentContext[RouterContext]):
                     from typing import Any, TypedDict
                     from webcompy.elements import html, repeat, DomNodeRef
                     from webcompy.components import define_component, ComponentContext
-                    from webcompy.signal import Signal, computed
-                    from webcompy.signal._dict import ReactiveDict
+                    from webcompy.signal import Signal, computed, ReactiveDict
 
 
                     class TodoData(TypedDict):

--- a/docs_src/templates/demo/fizzbuzz.py
+++ b/docs_src/templates/demo/fizzbuzz.py
@@ -4,8 +4,7 @@ from webcompy.components import (
     on_before_rendering,
 )
 from webcompy.elements import DOMEvent, html, repeat, switch
-from webcompy.signal import Signal, computed
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict, Signal, computed
 
 
 @define_component

--- a/docs_src/templates/demo/todo.py
+++ b/docs_src/templates/demo/todo.py
@@ -3,8 +3,7 @@ from typing import Any, TypedDict
 
 from webcompy.components import ComponentContext, define_component
 from webcompy.elements import DomNodeRef, html, repeat
-from webcompy.signal import Signal, computed
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict, Signal, computed
 
 
 class TodoData(TypedDict):

--- a/tests/e2e/my_app/pages/dict_repeat.py
+++ b/tests/e2e/my_app/pages/dict_repeat.py
@@ -1,7 +1,6 @@
 from webcompy.components import ComponentContext, define_component
 from webcompy.elements import html, repeat
-from webcompy.signal import Signal
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict, Signal
 
 
 @define_component

--- a/tests/test_dict_mutation.py
+++ b/tests/test_dict_mutation.py
@@ -1,4 +1,4 @@
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict
 
 
 class TestDictMutationMetadata:

--- a/tests/test_keyed_repeat.py
+++ b/tests/test_keyed_repeat.py
@@ -7,8 +7,7 @@ from webcompy.elements.types._element import Element
 from webcompy.elements.types._repeat import RepeatElement
 from webcompy.elements.types._text import TextElement
 from webcompy.exception import WebComPyException
-from webcompy.signal import ReactiveList
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict, ReactiveList
 
 
 class FakeRootElement(Element):

--- a/tests/test_list_mutation.py
+++ b/tests/test_list_mutation.py
@@ -1,4 +1,4 @@
-from webcompy.signal._list import ReactiveList
+from webcompy.signal import ReactiveList
 
 
 class TestListMutationMetadata:

--- a/tests/test_repeat.py
+++ b/tests/test_repeat.py
@@ -2,8 +2,7 @@ from tests.conftest import FakeDOMNode
 from webcompy.elements.types._element import Element
 from webcompy.elements.types._repeat import RepeatElement
 from webcompy.elements.types._text import TextElement
-from webcompy.signal import ReactiveList
-from webcompy.signal._dict import ReactiveDict
+from webcompy.signal import ReactiveDict, ReactiveList
 
 
 class FakeRootElement(Element):


### PR DESCRIPTION
## Summary
- Replace all `from webcompy.signal._dict import ReactiveDict` with `from webcompy.signal import ReactiveDict`
- Replace all `from webcompy.signal._list import ReactiveList` with `from webcompy.signal import ReactiveList`
- Since `_dict` and `_list` are private modules, they should not be imported directly outside the package

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>