### PR TITLE
feat: add performance improvement proposals

### DIFF
--- a/openspec/changes/feat/hydration-full/proposal.md
+++ b/openspec/changes/feat/hydration-full/proposal.md
@@ -159,5 +159,6 @@ The Python-side overhead (component construction, Signal graph) remains unchange
 ## Specs Affected
 
 - `elements` — adds `_hydrate_node()` method to `ElementAbstract`; updates "Pre-rendered DOM nodes shall be reused during hydration" requirement
-- `app` — adds `hydrate` config option to `AppConfig`; updates "The application shall hydrate pre-rendered content" requirement; updates `WebComPyApp.__init__()` signature to accept `hydrate` parameter
+- `app` — adds `hydrate` config option to `AppConfig`; updates "The application shall hydrate pre-rendered content" requirement
+- `app-lifecycle` — updates `WebComPyApp.__init__()` signature to accept `hydrate` parameter
 - `cli` — no changes needed (SSG output format unchanged)

--- a/openspec/changes/feat/hydration-full/proposal.md
+++ b/openspec/changes/feat/hydration-full/proposal.md
@@ -1,0 +1,164 @@
+# Proposal: Full Hydration — DOM-First Component Reconstruction
+
+## Summary
+
+Add a "full hydration" mode where the browser-side app initialization reconstructs the Python component tree by walking the pre-rendered DOM rather than creating new DOM nodes. This eliminates all DOM creation operations (createElement, createTextNode, appendChild, insertBefore) during initial hydration, replacing them with DOM node adoption and event handler attachment.
+
+## Motivation
+
+Even with partial hydration (skipping redundant setAttribute/textContent calls), the current hydration process still constructs the full Python component tree from scratch and then checks each DOM node against the pre-rendered tree. A full hydration mode would:
+
+1. Skip `_init_node()` DOM creation entirely for prerendered nodes
+2. Skip `Element._mount_node()` for prerendered nodes (they're already in the DOM)
+3. Only attach Signal callbacks and event handlers to the existing DOM
+
+This is the largest potential performance improvement for the DOM-mounting phase, though it requires significant architectural changes.
+
+## Known Issues Addressed
+
+- **No virtual DOM diffing — direct DOM manipulation only** (partially — full hydration bypasses DOM creation entirely for initial render)
+- **TextElement does not hydrate pre-rendered text nodes** (fully addressed — text nodes are adopted, not recreated)
+
+## Non-goals
+
+- This does not reduce Python import time or Pyodide startup time (addressed by other proposals).
+- This does not implement progressive hydration (hydrating components on-demand as they scroll into view).
+- This does not change the SSG output beyond adding minimal metadata attributes.
+- This does not change the router or component API surface.
+
+## Dependencies
+
+- **Depends on** `feat/hydration-measurement` — needed to validate performance gains.
+- **Depends on** `feat/hydration-partial` — partial hydration is a prerequisite (content-comparison checks are needed regardless).
+- **Informs** `feat/lazy-routing` — lazy routing reduces the number of components that need hydration on initial load.
+
+## Design
+
+### Current vs. Proposed Flow
+
+```
+CURRENT FLOW (app.run()):
+══════════════════════════════════════════════════════════
+  1. WebComPyApp.__init__()
+     → Build entire component tree in Python
+     → Each Component.__setup() runs the template function
+     → Each Element/TextElement/Component object created
+     → Signal graph constructed
+
+  2. AppDocumentRoot._render()  (recursive)
+     → For each element:
+       a. _init_node() → check for prerendered node
+          - If found & matching → reuse (set _mounted=True)
+          - If NOT found → createElement/createTextNode
+       b. _mount_node() → appendChild/insertBefore if not mounted
+     → Remove #webcompy-loading
+
+PROPOSED FLOW (full hydration mode):
+══════════════════════════════════════════════════════════
+  1. WebComPyApp.__init__(hydrate=True)
+     → Build component tree in Python (same as current)
+     → Template functions still run (needed for Signal graph)
+     → BUT: Elements marked with _hydrate=True
+
+  2. AppDocumentRoot._render()  (recursive)
+     → For each element with _hydrate=True:
+       a. _hydrate_node() → walk prerendered DOM
+          - Find matching node by position + tag
+          - Adopt existing node (set _node_cache, _mounted=True)
+          - Attach Signal callbacks to node attributes
+          - Attach event handlers via create_proxy
+          - Skip all createElement/createTextNode/appendChild
+     → For elements NOT in prerendered tree (e.g., conditional branches):
+       a. Fall back to current _init_node() + _mount_node()
+     → Remove #webcompy-loading
+```
+
+### Key Insight: Full Hydration Still Needs Python Object Construction
+
+Even in full hydration mode, we cannot skip `Component.__setup()` because:
+
+- Signal graphs must be constructed for reactivity to work
+- Event handlers must be registered (they can't be extracted from DOM)
+- DI scopes must be created for `provide`/`inject`
+- `on_after_rendering` hooks must be registered
+
+Therefore, the optimization is purely on the **DOM side** — no createElement/createTextNode/appendChild for nodes that already exist in the prerendered tree.
+
+### Implementation Steps
+
+#### Step 1: Add `hydrate` parameter to `WebComPyApp` and `AppConfig`
+
+```python
+@dataclass
+class AppConfig:
+    app_package: Path | str = "."
+    base_url: str = "/"
+    dependencies: list[str] = field(default_factory=list)
+    assets: dict[str, str] | None = None
+    hydrate: bool = True  # Default True when browser, ignored for SSG
+```
+
+When `hydrate=True` (the default in browser environment), the app will attempt full hydration of prerendered nodes. When `hydrate=False` or in SSG mode, current behavior applies.
+
+#### Step 2: Implement `_hydrate_node()` on `ElementAbstract`
+
+A new method that walks the prerendered DOM and adopts nodes without creating new ones:
+
+```python
+class ElementAbstract:
+    def _hydrate_node(self) -> DOMNode:
+        """Adopt an existing prerendered DOM node instead of creating a new one."""
+        existing = self._get_existing_node()
+        if existing and getattr(existing, "__webcompy_prerendered_node__", False):
+            node = existing
+            self._mounted = True
+            # Attach event handlers to existing node
+            self._event_handlers_added = {}
+            for name, func in self._event_handlers.items():
+                event_handler = _generate_event_handler(func)
+                node.addEventListener(name, event_handler, False)
+                self._event_handlers_added[name] = event_handler
+            # Set up Signal callbacks for reactive attributes
+            for name, value in self._attrs.items():
+                if isinstance(value, SignalBase):
+                    self._add_callback_node(
+                        value.on_after_updating(self._generate_attr_updater(name))
+                    )
+            return node
+        else:
+            # Fallback to current behavior
+            return self._init_node()
+```
+
+#### Step 3: Thread hydration through the render tree
+
+`AppDocumentRoot` already marks prerendered nodes via `_mark_as_prerendered()`. In hydration mode, every element should use `_hydrate_node()` instead of `_init_node()` for prerendered nodes.
+
+#### Step 4: Handle conditional content (SwitchElement, RepeatElement)
+
+Dynamic elements that were not pre-rendered (e.g., conditional branches that don't match the SSG route) will fall back to `_init_node()` + `_mount_node()`. This already works correctly — `SwitchElement._get_existing_node()` returns `None` for non-matching branches.
+
+### SSG Changes
+
+The SSG output needs minimal changes to support full hydration:
+
+1. The `__webcompy_prerendered_node__` flag is already set on all prerendered nodes
+2. No new HTML attributes are needed (the existing `webcompy-component` and `webcompy-cid-*` attributes are sufficient for matching)
+3. The `hidden` attribute on `AppDocumentRoot` (already used during SSG) ensures the pre-rendered content is not displayed twice
+
+### Metrics Expected
+
+Based on analysis of the codebase:
+
+- For a page with ~200 DOM nodes: ~200 fewer `createElement`/`createTextNode` calls, ~200 fewer `appendChild`/`insertBefore` calls
+- For a page with ~50 event handlers: ~50 `addEventListener` calls (same as current, unavoidable)
+- For a page with ~30 reactive attributes: ~30 Signal callback registrations (same as current, unavoidable)
+
+The Python-side overhead (component construction, Signal graph) remains unchanged. Expected DOM-side time savings: 30-60% of the current DOM-mounting phase.
+
+## Specs Affected
+
+- `elements` — adds `_hydrate_node()` method to `ElementAbstract`; updates "Pre-rendered DOM nodes shall be reused during hydration" requirement
+- `app` — adds `hydrate` config option to `AppConfig`; updates "The application shall hydrate pre-rendered content" requirement
+- `app-lifecycle` — updates `WebComPyApp.__init__()` signature to accept `hydrate` parameter
+- `cli` — no changes needed (SSG output format unchanged)

--- a/openspec/changes/feat/hydration-full/proposal.md
+++ b/openspec/changes/feat/hydration-full/proposal.md
@@ -159,6 +159,5 @@ The Python-side overhead (component construction, Signal graph) remains unchange
 ## Specs Affected
 
 - `elements` — adds `_hydrate_node()` method to `ElementAbstract`; updates "Pre-rendered DOM nodes shall be reused during hydration" requirement
-- `app` — adds `hydrate` config option to `AppConfig`; updates "The application shall hydrate pre-rendered content" requirement
-- `app-lifecycle` — updates `WebComPyApp.__init__()` signature to accept `hydrate` parameter
+- `app` — adds `hydrate` config option to `AppConfig`; updates "The application shall hydrate pre-rendered content" requirement; updates `WebComPyApp.__init__()` signature to accept `hydrate` parameter
 - `cli` — no changes needed (SSG output format unchanged)

--- a/openspec/changes/feat/hydration-measurement/proposal.md
+++ b/openspec/changes/feat/hydration-measurement/proposal.md
@@ -1,0 +1,101 @@
+# Proposal: Hydration Performance Measurement
+
+## Summary
+
+Add opt-in performance profiling to `WebComPyApp` to measure and report the time spent in each phase of application startup and hydration in the browser. This provides the data foundation needed to identify bottlenecks and validate future performance improvements.
+
+## Motivation
+
+WebComPy applications running in the browser via PyScript/Pyodide have significant startup latency, but we currently have no way to quantify how much time is spent in each phase (imports, app initialization, DOM mounting, etc.). Without measurement data, performance optimization efforts are based on guesswork rather than evidence.
+
+## Known Issues Addressed
+
+None (this is a new capability).
+
+## Non-goals
+
+- This proposal does not include any performance optimizations — only measurement.
+- This does not cover network-level metrics (download sizes, latency). Those are observable via browser DevTools and Playwright MCP.
+- This does not instrument PyScript/Pyodide internals (which are outside WebComPy's control).
+
+## Dependencies
+
+- None. This is a foundational change that subsequent hydration and performance proposals will build upon.
+
+## Design
+
+### Approach
+
+Add a `profile` parameter to `WebComPyApp.__init__()` and `WebComPyApp.run()`. When enabled, timestamps are recorded at key lifecycle points and logged to the browser console via `console.log` (or printed via `print` in server environments).
+
+### Measured Phases
+
+```
+Phase                       Timestamp Key          Description
+──────────────────────────────────────────────────────────────────────
+PyScript ready              pyscript_ready          <script type="py"> starts executing
+Imports done                 imports_done            All webcompy and app modules imported
+App init done                app_init_done           WebComPyApp.__init__() completed
+App run start                app_run_start           app.run() called
+App run done                 app_run_done            app.run() completed (first render)
+Loading screen removed       loading_removed         #webcompy-loading element removed
+```
+
+### Timestamp Capture Points
+
+In `WebComPyApp.__init__()`:
+- Record `init_start` at entry
+- Record `imports_done` after DI scope setup and component registration
+- Record `init_done` after `AppDocumentRoot` construction
+
+In `WebComPyApp.run()` / `AppDocumentRoot._render()`:
+- Record `run_start` at entry
+- Record `run_done` after first render completes
+- Record `loading_removed` when `#webcompy-loading` is removed
+
+In the generated HTML bootstrap (`<script type="py">`):
+- Record `pyscript_ready` at the very start of the script body
+
+### API
+
+```python
+class WebComPyApp:
+    def __init__(self, ..., profile: bool = False):
+        self._profile = profile
+        self._profile_data: dict[str, float] = {}
+        ...
+
+    @property
+    def profile_data(self) -> dict[str, float] | None:
+        """Returns recorded timestamps if profiling was enabled, else None."""
+        ...
+
+    def _record_phase(self, name: str):
+        """Record the current time for a phase if profiling is enabled."""
+        ...
+```
+
+### Output Format
+
+When profiling is enabled and the app finishes rendering, a summary is printed to the browser console:
+
+```
+[WebComPy Profile]
+  pyscript_ready → imports_done:  0.234s
+  imports_done  → init_done:     0.156s
+  init_done     → run_start:     0.002s
+  run_start     → run_done:      0.089s
+  run_done      → loading_off:   0.001s
+  ─────────────────────────────────
+  Total:                          0.482s
+```
+
+### SSG Impact
+
+The `profile` parameter must be stored in `AppConfig` so that `generate_html()` can conditionally include the profiling bootstrap code. When `profile=True`, the generated `<script type="py">` tag wraps the bootstrap code with timestamp recording.
+
+## Specs Affected
+
+- `app-lifecycle` — adds profiling capability to `WebComPyApp`
+- `app` — adds `profile` field to `AppConfig`
+- `cli` — generated HTML must include profiling code when enabled

--- a/openspec/changes/feat/hydration-measurement/proposal.md
+++ b/openspec/changes/feat/hydration-measurement/proposal.md
@@ -96,6 +96,6 @@ The `profile` parameter must be stored in `AppConfig` so that `generate_html()` 
 
 ## Specs Affected
 
-- `app` — adds profiling capability to `WebComPyApp`
+- `app-lifecycle` — adds profiling capability to `WebComPyApp`
 - `app` — adds `profile` field to `AppConfig`
 - `cli` — generated HTML must include profiling code when enabled

--- a/openspec/changes/feat/hydration-measurement/proposal.md
+++ b/openspec/changes/feat/hydration-measurement/proposal.md
@@ -96,6 +96,6 @@ The `profile` parameter must be stored in `AppConfig` so that `generate_html()` 
 
 ## Specs Affected
 
-- `app-lifecycle` — adds profiling capability to `WebComPyApp`
+- `app` — adds profiling capability to `WebComPyApp`
 - `app` — adds `profile` field to `AppConfig`
 - `cli` — generated HTML must include profiling code when enabled

--- a/openspec/changes/feat/hydration-partial/proposal.md
+++ b/openspec/changes/feat/hydration-partial/proposal.md
@@ -1,0 +1,97 @@
+# Proposal: Partial Hydration — Skip Redundant DOM Operations
+
+## Summary
+
+Optimize the browser-side hydration phase by skipping redundant DOM operations when a prerendered node matches the expected content. Specifically: skip `textContent` updates for `TextElement` nodes whose content matches, and skip attribute re-setting for `Element` nodes whose prerendered attributes already match the component's current state. This reduces browser-side DOM manipulation time during app startup.
+
+## Motivation
+
+Currently, even when WebComPy reuses a prerendered DOM node (detected via `__webcompy_prerendered_node__`), it still performs redundant operations:
+- `TextElement._init_node()` always calls `existing_node.textContent = self._get_text()` even when the text is identical
+- `Element._init_node()` always calls `node.setAttribute()` for every attribute, even when the attribute already has the same value
+
+These operations are individually cheap, but in a page with thousands of nodes, they add up. Since SSG pre-renders the exact same content, we know the values should match — we can skip these operations.
+
+## Known Issues Addressed
+
+- **TextElement does not hydrate pre-rendered text nodes** (from config.yaml known issues): This proposal addresses it by adding content-comparison checks.
+
+## Non-goals
+
+- This does not add a full "hydration mode" where the Python component tree is reconstructed from the DOM rather than built from scratch. That is addressed in a separate proposal (feat/hydration-full).
+- This does not change the SSG output format or add new metadata attributes.
+- This does not skip Python object construction — only DOM operations.
+
+## Dependencies
+
+- Depends on `feat/hydration-measurement` for validating the performance impact.
+
+## Design
+
+### Approach
+
+Add content-equality checks in `_init_node()` for `TextElement` and `Element` when a prerendered node is reused.
+
+### TextElement Optimization
+
+Currently (`_text.py:67`):
+```python
+if (
+    getattr(existing_node, "__webcompy_prerendered_node__", False)
+    and existing_node.nodeName.lower() == "#text"
+):
+    existing_node.textContent = self._get_text()  # ← always sets, even if same
+    node = existing_node
+    self._mounted = True
+```
+
+Proposed:
+```python
+if (
+    getattr(existing_node, "__webcompy_prerendered_node__", False)
+    and existing_node.nodeName.lower() == "#text"
+):
+    current_text = self._get_text()
+    if existing_node.textContent != current_text:
+        existing_node.textContent = current_text
+    node = existing_node
+    self._mounted = True
+```
+
+### Element Optimization
+
+Currently (`_element.py:48-67`):
+```python
+if (
+    getattr(existing_node, "__webcompy_prerendered_node__", False)
+    and existing_node.nodeName.lower() == self._tag_name
+):
+    node = existing_node
+    self._mounted = True
+    attr_names_to_remove = set(...)
+    for name, value in self._get_processed_attrs().items():
+        if value is not None:
+            node.setAttribute(name, value)  # ← always sets, even if same
+```
+
+Proposed: Only call `setAttribute` when the new value differs from the current value:
+```python
+for name, value in self._get_processed_attrs().items():
+    if value is not None:
+        existing = node.getAttribute(name)
+        if existing != value:
+            node.setAttribute(name, value)
+```
+
+### Performance Consideration
+
+`getAttribute()` and `textContent` property access are fast DOM reads. The net effect should be positive when attribute/text values match (which they always will during initial hydration after SSG), since `setAttribute()` triggers style recalculation and potential reflow, while `getAttribute()` is a pure read.
+
+### Risk
+
+In rare cases where SSG output and browser state diverge (e.g., browser extensions modifying the DOM, or user-specific pre-rendering), the old values might be stale. However, since `_get_processed_attrs()` always computes the current reactive values, this divergence would only matter if someone modifies the prerendered HTML between SSG and hydration — which is not a supported use case.
+
+## Specs Affected
+
+- `elements` — updates the "Pre-rendered DOM nodes shall be reused during hydration" requirement to add content-preservation behavior
+- `app` — may want to reference this optimization in the hydration requirement

--- a/openspec/changes/feat/lazy-routing/proposal.md
+++ b/openspec/changes/feat/lazy-routing/proposal.md
@@ -90,8 +90,11 @@ class LazyComponentGenerator(ComponentGenerator):
     def _resolve(self) -> ComponentGenerator:
         if self._resolved is None:
             module_path, attr_name = self._import_path.rsplit(":", 1)
-            # Resolve using caller's package for relative imports
-            caller_package = pathlib.Path(self._caller_file).parent.name
+            # Derive the full package path from the caller's __file__.
+            # e.g. __file__ = "/app/pages/about.py" → package = "pages.about"
+            # This works for both top-level and nested packages.
+            caller_path = pathlib.Path(self._caller_file)
+            caller_package = ".".join(caller_path.parent.parts)
             module = importlib.import_module(module_path, package=caller_package)
             self._resolved = getattr(module, attr_name)
             if not isinstance(self._resolved, ComponentGenerator):

--- a/openspec/changes/feat/lazy-routing/proposal.md
+++ b/openspec/changes/feat/lazy-routing/proposal.md
@@ -1,0 +1,285 @@
+# Proposal: Lazy Routing — Deferred Module Import and Route Preloading
+
+## Summary
+
+Add lazy route import capability to the Router so that page component modules are imported only when their route is first matched, reducing the initial Python import burden at startup. This is implemented via a new `lazy` helper function that wraps a module path string into a `ComponentGenerator`. Additionally, add `RouterLink` preloading on hover (mouseenter) to speculatively import the target route's module before the user clicks, reducing perceived navigation latency. Finally, add a component "shell" rendering mode to show a loading placeholder while the lazy component's module is being imported.
+
+## Motivation
+
+When a WebComPy app starts, all page modules referenced in the Router are imported immediately — even for pages the user won't visit in the current session. In a PyScript/Pyodide environment where `import` can be expensive (disk I/O + module evaluation + dependency resolution), this adds unnecessary startup delay.
+
+For example, the docs_src app imports 6+ page modules at startup, each containing component definitions, reactive state, and potentially heavy logic. If the user only visits the home page, all other page modules were loaded for nothing.
+
+The current Router API requires passing `ComponentGenerator` objects directly:
+
+```python
+router = Router(
+    {"path": "/", "component": HomePage},        # ← HomePage imported immediately
+    {"path": "/docs", "component": DocsPage},     # ← DocsPage imported immediately
+    {"path": "/demo", "component": DemoPage},      # ← DemoPage imported immediately
+)
+```
+
+## Known Issues Addressed
+
+None directly (this is a new capability).
+
+## Non-goals
+
+- This does not implement JavaScript-style code splitting (Pyodide loads all code from wheels at startup; lazy routing only defers Python `import` within the loaded wheel).
+- This does not implement route guards or before/after navigation hooks.
+- This does not implement nested or lazy-loaded route configurations.
+- This does not add route-level code splitting at the wheel level (that would require multiple wheels per route).
+
+## Dependencies
+
+- **Informed by** `feat/hydration-measurement` — profiling data will show the time saved by deferring imports.
+- **Informs** `feat/hydration-full` — fewer components to hydrate on initial load means faster hydration.
+
+## Design
+
+### Part 1: Lazy Route Import via `lazy()` Helper
+
+#### API
+
+A new function `lazy()` in `webcompy.router` that creates a deferred `ComponentGenerator`:
+
+```python
+from webcompy.router import lazy
+
+router = Router(
+    {"path": "/", "component": HomePage},                                    # eager (existing)
+    {"path": "/docs", "component": lazy("pages.docs:DocsPage", __file__)},    # lazy
+    {"path": "/demo", "component": lazy("pages.demo:DemoPage", __file__)},   # lazy
+)
+```
+
+#### `lazy()` Function Signature
+
+```python
+def lazy(
+    import_path: str,
+    caller_file: str,
+) -> ComponentGenerator:
+    """Create a lazy ComponentGenerator that defers module import until first use.
+    
+    Args:
+        import_path: Dotted module path and attribute name, e.g. "pages.docs:DocsPage"
+        caller_file: The __file__ of the calling module, used to resolve
+                     relative imports. This ensures stable resolution regardless
+                     of the working directory.
+    """
+```
+
+The `caller_file` parameter (passed as `__file__`) is critical for resolving relative imports. In Pyodide, the working directory may differ from the development environment, so absolute module resolution via `__file__` ensures correctness.
+
+#### Implementation
+
+```python
+class LazyComponentGenerator(ComponentGenerator):
+    _import_path: str
+    _caller_file: str
+    _resolved: ComponentGenerator | None
+
+    def __init__(self, import_path: str, caller_file: str) -> None:
+        self._import_path = import_path
+        self._caller_file = caller_file
+        self._resolved = None
+        # Don't call super().__init__() — defer ComponentGenerator creation
+
+    def _resolve(self) -> ComponentGenerator:
+        if self._resolved is None:
+            module_path, attr_name = self._import_path.rsplit(":", 1)
+            # Resolve relative imports using caller's package
+            caller_package = pathlib.Path(self._caller_file).parent
+            # Add caller's parent to sys.path if not already present
+            parent_str = str(caller_package)
+            if parent_str not in sys.path:
+                sys.path.insert(0, parent_str)
+            module = importlib.import_module(module_path)
+            self._resolved = getattr(module, attr_name)
+            if not isinstance(self._resolved, ComponentGenerator):
+                raise WebComPyRouterException(
+                    f"'{self._import_path}' is not a ComponentGenerator"
+                )
+            # Register with the active ComponentStore
+            self._resolved._try_register()
+        return self._resolved
+
+    def __call__(self, props, *, slots=None):
+        return self._resolve()(props, slots=slots)
+
+    @property
+    def scoped_style(self):
+        return self._resolve().scoped_style
+
+    @scoped_style.setter
+    def scoped_style(self, value):
+        self._resolve().scoped_style = value
+```
+
+#### Eager vs. Lazy Behavior Comparison
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  Eager (existing):                                            │
+│                                                               │
+│  # router.py                                                  │
+│  from .pages.docs import DocsPage     # ← import at startup  │
+│  router = Router(                                             │
+│      {"path": "/docs", "component": DocsPage},               │
+│  )                                                            │
+│  → DocPage module evaluated immediately                      │
+│  → ComponentGenerator created immediately                     │
+│  → ComponentStore registration immediate                     │
+│                                                               │
+│  Lazy (proposed):                                             │
+│                                                               │
+│  # router.py                                                  │
+│  router = Router(                                             │
+│      {"path": "/docs", "component": lazy("pages.docs:DocsPage", __file__)},│
+│  )                                                            │
+│  → No import at startup                                       │
+│  → LazyComponentGenerator created (lightweight wrapper)       │
+│  → On first navigation to /docs:                              │
+│    1. importlib.import_module("pages.docs")                   │
+│    2. Resolve DocsPage attribute                               │
+│    3. Register with ComponentStore                             │
+│    4. Render the component                                    │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### Part 2: Route Preloading via RouterLink Hover
+
+To reduce perceived navigation latency, `RouterLink` should preload (resolve) the target route's lazy component when the user hovers over the link.
+
+#### Implementation
+
+```python
+# In RouterLink's component definition
+@define_component
+def RouterLink(context):
+    target_path = context.props.to
+    
+    def on_mouseenter(_ev=None):
+        if isinstance(target_generator := _get_route_generator(target_path), LazyComponentGenerator):
+            target_generator._preload()
+
+    return html.A(
+        {"@click": navigate, "@mouseenter": on_mouseenter},
+        context.slots("default"),
+    )
+```
+
+The `_preload()` method on `LazyComponentGenerator` triggers `_resolve()` without rendering — just importing the module and registering the component. This makes the actual navigation near-instant since the module is already loaded.
+
+### Part 3: Component Shell (Loading Placeholder)
+
+When a lazy route is first navigated to and the module import takes noticeable time (rare for pure-Python imports within an already-loaded wheel, but possible for complex modules), the RouterView should show a loading placeholder.
+
+#### Shell Rendering Strategy
+
+When `LazyComponentGenerator.__call__()` is invoked:
+
+1. **If already resolved**: Render normally (no shell needed)
+2. **If not yet resolved**:
+   - Show the shell component (a configurable placeholder, default: a simple `<div>` with `webcompy-loading` styling)
+   - Schedule the import via `setTimeout(0)` to avoid blocking the main thread
+   - Once resolved, replace the shell with the real component
+
+However, since Python `import` within Pyodide is synchronous and fast for already-loaded wheel contents, the shell rendering is primarily useful for:
+
+- Complex modules with heavy initialization (e.g., matplotlib rendering setup)
+- Future compatibility with async module loading
+- Providing a visual placeholder for slow network conditions if wheel splitting enables per-route wheel downloads
+
+#### Shell API
+
+```python
+class LazyComponentGenerator(ComponentGenerator):
+    def __init__(
+        self,
+        import_path: str,
+        caller_file: str,
+        shell: ComponentGenerator | None = None,
+    ) -> None:
+        ...
+        self._shell = shell
+```
+
+Usage:
+
+```python
+def LoadingShell(context):
+    return html.DIV({"class": "route-loading"}, "Loading...")
+
+router = Router(
+    {"path": "/demo", "component": lazy(
+        "pages.demo:DemoPage",
+        __file__,
+        shell=LoadingShell,
+    )},
+)
+```
+
+When the shell is not provided, the lazy component renders synchronously on first navigation (import + render in one step). When a shell is provided, the lazy component shows the shell first and swaps to the real component after import.
+
+#### Shell Integration with SwitchElement
+
+The `SwitchElement` that `RouterView` uses needs to handle `LazyComponentGenerator` specially:
+
+```python
+# In Router._get_elements_generator():
+def _get_elements_generator(self, args):
+    ...
+    if match:
+        component = args[3]  # RouteType[3] = ComponentGenerator
+        if isinstance(component, LazyComponentGenerator) and component._shell and not component._resolved:
+            return (match, lambda: component._shell(None))
+        else:
+            return (match, lambda: component(props))
+    ...
+```
+
+After the lazy component resolves, a signal change triggers `SwitchElement._refresh()`, which then renders the real component instead of the shell.
+
+### Part 4: SSG Compatibility
+
+For static site generation, all lazy routes must be eagerly resolved so that `AppDocumentRoot._render_html()` can produce the correct HTML output. This requires:
+
+1. During SSG, `LazyComponentGenerator._resolve()` is called for the current route before rendering
+2. The `Router.__set_path__()` method triggers resolution via the existing `SwitchElement._refresh()` path
+
+Since SSG already sets the path and renders, this should work naturally — `LazyComponentGenerator.__call__()` will call `_resolve()` when the component is instantiated during SSG rendering.
+
+### Migration Path
+
+Existing code using eager imports continues to work without changes. The `lazy()` function is opt-in:
+
+```python
+# Before (still works):
+from .pages.home import HomePage
+from .pages.docs import DocsPage
+router = Router(
+    {"path": "/", "component": HomePage},
+    {"path": "/docs", "component": DocsPage},
+)
+
+# After (opt-in lazy):
+from .pages.home import HomePage  # home is eager (initial page)
+router = Router(
+    {"path": "/", "component": HomePage},
+    {"path": "/docs", "component": lazy("pages.docs:DocsPage", __file__)},
+    {"path": "/demo", "component": lazy("pages.demo:DemoPage", __file__, shell=LoadingShell)},
+)
+```
+
+Recommended pattern: Keep the initial/home route eager (it's needed at startup anyway) and make all other routes lazy.
+
+## Specs Affected
+
+- `router` — adds `lazy()` function; updates `RouterPage` type to accept `LazyComponentGenerator`; adds route preloading via `RouterLink` hover; adds shell placeholder support
+- `components` — no changes needed (`LazyComponentGenerator` is a `ComponentGenerator` subclass, compatible with existing APIs)
+- `wheel-builder` — no changes needed
+- `cli` — no changes needed
+- `app` — no changes needed

--- a/openspec/changes/feat/lazy-routing/proposal.md
+++ b/openspec/changes/feat/lazy-routing/proposal.md
@@ -90,13 +90,9 @@ class LazyComponentGenerator(ComponentGenerator):
     def _resolve(self) -> ComponentGenerator:
         if self._resolved is None:
             module_path, attr_name = self._import_path.rsplit(":", 1)
-            # Resolve relative imports using caller's package
-            caller_package = pathlib.Path(self._caller_file).parent
-            # Add caller's parent to sys.path if not already present
-            parent_str = str(caller_package)
-            if parent_str not in sys.path:
-                sys.path.insert(0, parent_str)
-            module = importlib.import_module(module_path)
+            # Resolve using caller's package for relative imports
+            caller_package = pathlib.Path(self._caller_file).parent.name
+            module = importlib.import_module(module_path, package=caller_package)
             self._resolved = getattr(module, attr_name)
             if not isinstance(self._resolved, ComponentGenerator):
                 raise WebComPyRouterException(
@@ -108,6 +104,10 @@ class LazyComponentGenerator(ComponentGenerator):
 
     def __call__(self, props, *, slots=None):
         return self._resolve()(props, slots=slots)
+
+    def __getattr__(self, name: str):
+        """Delegate all attribute access to the resolved ComponentGenerator."""
+        return getattr(self._resolve(), name)
 
     @property
     def scoped_style(self):

--- a/openspec/changes/feat/switch-patch/proposal.md
+++ b/openspec/changes/feat/switch-patch/proposal.md
@@ -186,14 +186,16 @@ def _patch_children(
     for old_idx, old_child in enumerate(old_children):
         if old_idx in matched_old_indices:
             # Node was adopted — only destroy the Python-side state
+            # Save node reference BEFORE clearing cache for event handler cleanup
+            saved_node = old_child._node_cache
+            if isinstance(old_child, ElementBase):
+                for name, handler in old_child._event_handlers_added.items():
+                    if saved_node:
+                        saved_node.removeEventListener(name, handler)
+                    handler.destroy()
             old_child._callback_nodes_clear()
             old_child.__purge_signal_members__()
             old_child._clear_node_cache(False)
-            # Remove event handlers from adopted node (new element will add its own)
-            if isinstance(old_child, ElementBase):
-                for name, handler in old_child._event_handlers_added.items():
-                    node = old_child._node_cache  # note: cache was cleared
-                    # handler cleanup happens via _remove_element pattern
         else:
             # No adoption — standard removal
             old_child._remove_element(recursive=True, remove_node=True)

--- a/openspec/changes/feat/switch-patch/proposal.md
+++ b/openspec/changes/feat/switch-patch/proposal.md
@@ -1,0 +1,365 @@
+# Proposal: Switch Patch — DOM Node Reuse on Structural Changes
+
+## Summary
+
+Add a DOM node adoption and patching mechanism to `SwitchElement._refresh()` so that when a conditional branch changes, existing DOM nodes that match the new tree structure are reused rather than destroyed and recreated. This is implemented via `_adopt_node()` on `ElementBase` (shared with the full hydration proposal) and `_patch_children()` which recursively compares old and new element trees by tag name. The optimization targets the runtime performance of navigation and conditional UI switching, complementing the hydration proposals which focus on initial load performance.
+
+## Motivation
+
+Currently, `SwitchElement._refresh()` completely destroys all children of the old branch and generates entirely new children from the winning generator. Every DOM node in the outgoing subtree is removed, and every DOM node in the incoming subtree is created from scratch — even when the two subtrees share a large common structure.
+
+The most impactful scenario is page routing via `RouterView`, which uses `SwitchElement` internally. When navigating between pages, common UI elements (navigation bars, sidebars, footers, layout containers) that exist in both the outgoing and incoming page components are needlessly destroyed and recreated. This causes:
+
+1. **Unnecessary DOM API calls** — `createElement`, `appendChild`, `remove` for nodes that structurally exist in both branches
+2. **Unnecessary Signal re-initialization** — reactive subscriptions are torn down and re-created for elements that haven't meaningfully changed
+3. **Visual disruption** — the browser must re-layout elements that had identical structure, potentially causing a flash
+4. **Wasted time in PyScript/Pyodide** — every DOM API call crosses the Python↔JavaScript FFI bridge, which is the most expensive operation in the WebComPy runtime
+
+The existing fine-grained reactivity system (Signal → direct attribute/text update) already handles non-structural changes efficiently. What is missing is structural diffing — recognizing when two element trees overlap and reusing their shared DOM nodes.
+
+## Known Issues Addressed
+
+- **SwitchElement completely regenerates children on change** (from config.yaml known issues) — fully addressed by `_patch_children()` which performs structural comparison and only creates/destroys nodes that actually differ.
+- **No virtual DOM diffing — direct DOM manipulation only** (from config.yaml known issues) — partially addressed. This is not a full virtual DOM diffing system (the fine-grained reactivity model remains), but it adds structural diffing at the points where structural changes occur (DynamicElement refresh).
+
+## Non-goals
+
+- This does not implement a React-style virtual DOM with full-tree diffing. The fine-grained reactivity model remains the primary update mechanism for attribute and text changes.
+- This does not add component re-rendering or dynamic props propagation. Components are still initialized once; signal-based props remain the mechanism for propagating reactive data.
+- This does not change RepeatElement's unkeyed mode — that is addressed in a separate follow-up proposal (`feat/repeat-patch`).
+- This does not implement progressive or partial hydration (addressed by `feat/hydration-partial` and `feat/hydration-full`).
+- This does not add template-level structural hashing or compile-time analysis. The initial implementation uses tag-name comparison only; template hashing is a future optimization path.
+- This does not guarantee that the rollback path (abandoning patch in favor of full rebuild) will never be needed. If Component patching proves too complex, the implementation may fall back to leaf-only patching.
+
+## Dependencies
+
+- **Informed by** `feat/hydration-full` — the `_adopt_node()` method developed here is designed to be the same API that full hydration uses for prerendered node adoption. The two proposals should converge on a single `_adopt_node()` implementation.
+- **Informs** `feat/hydration-full` — the `_adopt_node()` design validated here will inform the full hydration implementation.
+- **Informed by** `feat/hydration-measurement` — profiling data will validate the runtime performance improvement.
+- **Informs** `feat/repeat-patch` (follow-up) — `_patch_children()` and `_adopt_node()` will be reused for RepeatElement's unkeyed mode.
+
+## Design
+
+### Core Concept: Node Adoption
+
+The central operation is `_adopt_node()`, which assigns an existing DOM node to a new `ElementBase` instance without creating a new DOM node. This is the same operation as hydration — the difference is only where the existing DOM node comes from:
+
+| Context | DOM Node Source |
+|---------|----------------|
+| Hydration | SSR-parsed DOM tree (prerendered HTML) |
+| Patch | Previous render's element tree (old branch) |
+
+Both contexts need the same operations on the new Element:
+1. Set `_node_cache` to the existing node
+2. Set `_mounted = True`
+3. Apply attribute diff (set changed attributes, remove stale attributes)
+4. Register Signal callbacks for reactive attributes
+5. Attach event handlers (new proxies via `create_proxy`)
+6. Initialize DomNodeRef if present
+
+### `_adopt_node()` on `ElementBase`
+
+```python
+class ElementBase(ElementWithChildren):
+    def _adopt_node(self, node: DOMNode) -> None:
+        """Adopt an existing DOM node instead of creating a new one.
+
+        The node is assumed to already be in the DOM at the correct position.
+        Attributes, event handlers, and Signal callbacks are rebound to this element.
+        """
+        self._node_cache = node
+        self._mounted = True
+        node.__webcompy_node__ = True
+
+        # Attribute diff: apply current attrs, remove stale ones
+        current_attrs = self._get_processed_attrs()
+        existing_attr_names = set(node.getAttributeNames())
+        new_attr_names = set(current_attrs.keys())
+        for name in existing_attr_names - new_attr_names - WEBCOMPY_INTERNAL_ATTRS:
+            node.removeAttribute(name)
+        for name, value in current_attrs.items():
+            if value is not None:
+                existing = node.getAttribute(name)
+                if existing != value:
+                    node.setAttribute(name, value)
+            elif name in existing_attr_names:
+                node.removeAttribute(name)
+
+        # Signal callbacks for reactive attributes
+        for name, value in self._attrs.items():
+            if isinstance(value, SignalBase):
+                self._add_callback_node(
+                    value.on_after_updating(self._generate_attr_updater(name))
+                )
+
+        # Event handlers
+        self._event_handlers_added = {}
+        for name, func in self._event_handlers.items():
+            event_handler = _generate_event_handler(func)
+            node.addEventListener(name, event_handler, False)
+            self._event_handlers_added[name] = event_handler
+
+        # DomNodeRef
+        if self._ref:
+            self._ref.__init_node__(node)
+```
+
+### `_adopt_node()` on `TextElement`
+
+```python
+class TextElement(ElementAbstract):
+    def _adopt_node(self, node: DOMNode) -> None:
+        """Adopt an existing text node."""
+        self._node_cache = node
+        self._mounted = True
+        node.__webcompy_node__ = True
+        current_text = self._get_text()
+        if node.textContent != current_text:
+            node.textContent = current_text
+        # Signal callback already registered in __init__
+```
+
+### `_is_patchable()` Predicate
+
+```python
+def _is_patchable(old: ElementAbstract, new: ElementAbstract) -> bool:
+    """Determine whether an old element's DOM node can be reused by a new element."""
+    if isinstance(old, TextElement) and isinstance(new, TextElement):
+        return True
+    if isinstance(old, DynamicElement) or isinstance(new, DynamicElement):
+        return False  # DynamicElements have no own DOM node
+    if isinstance(old, ElementBase) and isinstance(new, ElementBase):
+        return old._tag_name == new._tag_name
+    return False
+```
+
+This includes `Component` (a subclass of `ElementBase`) in the patchable set. When two Components share the same root tag name, their internal element trees are recursively compared. This is the key decision that enables navigation-time DOM reuse for common layout structures.
+
+**Rollback path:** If Component-inclusive patching proves too complex or fragile, `_is_patchable()` can be restricted to exclude `Component` instances:
+
+```python
+    if isinstance(old, Component) or isinstance(new, Component):
+        return False  # Fallback: treat Components as unpatchable
+```
+
+This would reduce patching to leaf Elements only, deferring Component support to a future phase.
+
+### `_patch_children()` Algorithm
+
+```python
+def _patch_children(
+    old_children: list[ElementAbstract],
+    new_children: list[ElementAbstract],
+) -> list[ElementAbstract]:
+    """Compare old and new element lists, adopting DOM nodes where possible.
+
+    Returns the new_children list (with DOM nodes adopted where matched).
+    Unmatched old elements must be cleaned up by the caller.
+    Unmatched new elements must be rendered by the caller.
+    """
+    matched_old_indices: set[int] = set()
+
+    for new_idx, new_child in enumerate(new_children):
+        # Try to find a patchable match in old_children
+        for old_idx, old_child in enumerate(old_children):
+            if old_idx in matched_old_indices:
+                continue
+            if _is_patchable(old_child, new_child):
+                matched_old_indices.add(old_idx)
+
+                # Adopt the DOM node
+                if isinstance(new_child, TextElement) and isinstance(old_child, TextElement):
+                    new_child._adopt_node(old_child._node_cache)
+                elif isinstance(new_child, ElementBase) and isinstance(old_child, ElementBase):
+                    new_child._adopt_node(old_child._node_cache)
+                    # Recursively patch children
+                    _patch_children(old_child._children, new_child._children)
+
+                # Re-anchor at correct position in DOM
+                _reposition_node(new_child, new_idx)
+                break
+        else:
+            # No match found — new_child will need _render()
+            pass
+
+    # Cleanup unmatched old children (DOM nodes not adopted)
+    for old_idx, old_child in enumerate(old_children):
+        if old_idx in matched_old_indices:
+            # Node was adopted — only destroy the Python-side state
+            old_child._callback_nodes_clear()
+            old_child.__purge_signal_members__()
+            old_child._clear_node_cache(False)
+            # Remove event handlers from adopted node (new element will add its own)
+            if isinstance(old_child, ElementBase):
+                for name, handler in old_child._event_handlers_added.items():
+                    node = old_child._node_cache  # note: cache was cleared
+                    # handler cleanup happens via _remove_element pattern
+        else:
+            # No adoption — standard removal
+            old_child._remove_element(recursive=True, remove_node=True)
+
+    return new_children
+```
+
+**Note on old element cleanup:** When an old element's DOM node is adopted by a new element, the old element must release its Python-side resources (Signal callbacks, event handler proxies via `destroy()`) without removing the DOM node. This requires a new cleanup method — `_detach_from_node()` — that:
+
+1. Calls `consumer_destroy()` on all `CallbackConsumerNode` instances
+2. Calls `handler.destroy()` on all PyScript FFI event handler proxies
+3. Calls `__purge_signal_members__()` for SignalReceivable cleanup
+4. Calls `DomNodeRef.__reset_node__()` if a ref exists
+5. Does NOT call `node.remove()` on the DOM node
+6. Does NOT recurse into children (their nodes may also be adopted)
+
+### SwitchElement._refresh() Rewrite
+
+```
+CURRENT:
+  _refresh():
+    idx = _select_generator()
+    if idx == _rendered_idx: return
+    for child in _children: child._remove_element()       # ← full destroy
+    _children = _generate_children(generator)              # ← full generate
+    for child in _children: child._render()               # ← full DOM create
+    _parent._re_index_children()
+
+PROPOSED:
+  _refresh():
+    idx = _select_generator()
+    if idx == _rendered_idx: return
+    new_children = _generate_children(generator)           # ← full Python generate
+    old_children = self._children
+    self._children = _patch_children(old_children, new_children)
+    # _patch_children handles adoption + cleanup of old + marking of new
+    for child in self._children:
+        if not child._mounted:
+            child._render()                                # ← only unadopted new children
+    _parent._re_index_children()
+```
+
+### Key Concern: Event Handler Proxy Cleanup
+
+In the PyScript environment, event handlers are JavaScript proxies created via `browser.pyscript.ffi.create_proxy()`. These proxies must be explicitly destroyed via `.destroy()` to avoid memory leaks.
+
+The current `_remove_element()` on `ElementBase` handles this:
+
+```python
+for name, event_handler in self._event_handlers_added.items():
+    node.removeEventListener(name, event_handler)
+    event_handler.destroy()
+```
+
+In the patch scenario, when an old element's DOM node is adopted by a new element, the old element's event handlers must be removed from the node and their proxies destroyed. But the node itself stays in the DOM. This is handled by `_detach_from_node()`:
+
+```python
+class ElementBase:
+    def _detach_from_node(self) -> None:
+        """Release Python-side resources without removing the DOM node.
+
+        Called when the DOM node is being adopted by another element.
+        """
+        node = self._node_cache
+        if node:
+            # Remove old event handlers from the node
+            for name, handler in self._event_handlers_added.items():
+                node.removeEventListener(name, handler)
+                handler.destroy()
+        # Destroy Signal callbacks
+        for cb in self._callback_nodes:
+            consumer_destroy(cb)
+        self._callback_nodes.clear()
+        # Reset ref
+        if self._ref:
+            self._ref.__reset_node__()
+        # Clear caches (but don't touch the DOM node — new owner needs it)
+        self._node_cache = None
+        self._mounted = None
+        self.__purge_signal_members__()
+```
+
+### Key Concern: Component-specific Lifecycle
+
+When a `Component` is the target of patching (i.e., `new_child` is a `Component`), the new Component has already been fully initialized via `__init__()` → `__setup()` → `__init_component()`. This means:
+
+- The new Component's `EffectScope` has been created
+- The new Component's DI child scope has been created (if any)
+- The new Component's `on_before_rendering` / `on_after_rendering` / `on_before_destroy` hooks have been registered
+- The new Component's `HeadPropsStore` entries have been registered
+
+When the old `Component` is cleaned up via `_detach_from_node()` (recursive: no DOM removal), its `on_before_destroy` must still be called to dispose the EffectScope and DI scope. This is already handled because the old Component's `_remove_element()` is called with `recursive=True, remove_node=False`, which triggers `on_before_destroy`.
+
+The key subtlety: `_remove_element(recursive=True, remove_node=False)` on the old Component recurses into its children, calling their `_remove_element()` as well. But some of those children have been adopted by the new tree. Therefore, the cleanup must happen at the `_patch_children()` level rather than via simple recursive `_remove_element()`.
+
+**Resolution:** `_patch_children()` is responsible for cleaning up old elements. For matched (adopted) old elements, it calls `_detach_from_node()` instead of `_remove_element()`. For unmatched old elements, it calls `_remove_element(recursive=True, remove_node=True)` as usual. The old Component at the top level of the old branch is cleaned up after `_patch_children()` has processed its children — its `_detach_from_node()` handles the Component-specific lifecycle (dispose EffectScope, DI scope, head props).
+
+### Rollback Strategy
+
+If Component-inclusive patching proves too complex during implementation, the rollback path is:
+
+1. **Restrict `_is_patchable()`** to exclude `Component` instances — this immediately reduces patching to leaf Elements only without changing any other code.
+2. **Remove `_detach_from_node()` from Component** — the Component-specific lifecycle handling is the most complex part. Without Component patching, it becomes unnecessary.
+3. **Keep `_adopt_node()` and `_patch_children()` for leaf Elements** — these are still useful for `switch` cases that return raw element trees (not wrapped in Components), and they remain reusable for the `feat/repeat-patch` follow-up.
+
+The rollback does not invalidate the work done on `_adopt_node()` for `ElementBase` and `TextElement`, as these are also needed by the full hydration proposal.
+
+## Implementation Steps
+
+### Step 1: Add `_adopt_node()` to `ElementBase` and `TextElement`
+
+- Implement `ElementBase._adopt_node(node)` with attribute diff, Signal callback registration, event handler attachment, and DomNodeRef initialization.
+- Implement `TextElement._adopt_node(node)` with text content update.
+- Write unit tests verifying DOM node reuse (no `createElement` calls) and correct attribute/event/Signal rebinding.
+- Estimated: 1.5 hours.
+
+### Step 2: Add `_detach_from_node()` to `ElementBase`
+
+- Implement the cleanup method that releases Python-side resources without removing the DOM node.
+- Handle Component-specific cleanup (call `on_before_destroy` for EffectScope and DI scope disposal).
+- Handle event handler proxy `destroy()` calls.
+- Write unit tests verifying no DOM node removal and complete Signal/callback cleanup.
+- Estimated: 1.5 hours.
+
+### Step 3: Implement `_patch_children()` and `_is_patchable()`
+
+- Implement the recursive patching algorithm with Component-inclusive `_is_patchable()`.
+- Handle matched/unmatched element tracking and cleanup.
+- Handle DOM node repositioning (adopted nodes may need to move to their new position in the parent's `childNodes`).
+- Write unit tests for various tree shapes: identical structure, partial overlap, complete replacement, Component-to-Component patching.
+- Estimated: 2 hours.
+
+### Step 4: Integrate into `SwitchElement._refresh()`
+
+- Replace the full-destroy-and-regenerate logic with `_patch_children()`.
+- Only call `_render()` on new children that were not adopted.
+- Handle the deferred rendering mechanism (`start_defer_after_rendering` / `end_defer_after_rendering`).
+- Write integration tests including routing scenarios via Playwright MCP.
+- Estimated: 1 hour.
+
+### Step 5: Evaluate and decide on Component patching
+
+- Run integration tests for Component patching scenarios.
+- If issues arise, restrict `_is_patchable()` to exclude `Component` and document the limitation.
+- If successful, proceed with the full B-2 approach.
+- Estimated: 1 hour.
+
+## Metrics Expected
+
+For a navigation between two pages that share a common layout structure (e.g., `div > (nav > ...) + (main > ...)`):
+
+| Metric | Before | After |
+|--------|--------|-------|
+| `createElement` calls | ~N (entire subtree) | ~D (only differing nodes) |
+| `removeChild` calls | ~N (entire subtree) | ~D (only removed nodes) |
+| Signal callback registrations | ~N (all destroyed + recreated) | ~N (still recreated, but on adopted nodes) |
+| Event handler proxies | ~N (all destroyed + recreated) | ~N (all destroyed + recreated on adopted nodes) |
+| FFI bridge crossings | ~3N (create + mount + attrs) | ~3D + N_attrs (diff + rebind) |
+
+Where N = total nodes in the subtree, D = number of nodes that differ between branches.
+
+For a typical page with 50 shared layout nodes and 30 content-specific nodes: ~130 fewer `createElement`/`appendChild`/`removeChild` calls, each crossing the Python↔JavaScript FFI bridge.
+
+## Specs Affected
+
+- `elements` — adds `_adopt_node()` method to `ElementBase` and `TextElement`; adds `_detach_from_node()` to `ElementBase`; updates the "Conditional rendering shall display one branch at a time" requirement to include DOM node reuse behavior; updates the "Pre-rendered DOM nodes shall be reused during hydration" requirement to reference `_adopt_node()` as the shared mechanism
+- `components` — no API changes; internal lifecycle (`on_before_destroy`) is called during patch cleanup
+- `app` — no changes needed
+- `router` — no API changes; `RouterView` automatically benefits from `SwitchElement` patching

--- a/openspec/changes/feat/wheel-split/proposal.md
+++ b/openspec/changes/feat/wheel-split/proposal.md
@@ -1,0 +1,275 @@
+# Proposal: Wheel Split — Browser-Only Framework Wheel, Dependency Bundling, and Browser Cache Strategy
+
+## Summary
+
+Split the current single bundled wheel (webcompy + app) into a browser-only webcompy framework wheel and a separate app wheel. The browser-only wheel excludes CLI-only code (`webcompy/cli/`, `webcompy/cli/template_data/`) that is never needed in the browser. Additionally, bundle user-specified pure-Python dependencies into the app wheel to reduce the number of Pyodide package installations. Leverage browser HTTP caching with stable URLs and proper cache headers to ensure repeated visits skip wheel re-downloads.
+
+## Motivation
+
+1. **Download size and caching**: The entire webcompy framework (~220KB of Python source) is currently bundled inside every app wheel. This means every app update requires re-downloading the entire framework. Splitting allows the framework wheel to be cached independently.
+
+2. **Unnecessary browser code**: `webcompy/cli/` (server, generate, init, wheel builder, argparser) is never used in the browser but is included in the bundle. Removing it reduces the framework wheel size.
+
+3. **Pyodide install overhead**: Each package listed in `py-config.packages` triggers a separate `micropip.install()` call. Bundling pure-Python dependencies into the app wheel reduces the number of install calls.
+
+4. **Browser cache**: Currently, app versions change every second (`generate_app_version()` produces timestamps), meaning the wheel URL changes every time, defeating browser caching. Using stable URLs with content hashes or version-based paths enables the browser to cache wheels across visits.
+
+## Known Issues Addressed
+
+None directly (this is a new capability).
+
+## Non-goals
+
+- This does not use external CDN hosting. All wheels are served from the same origin (dev server or static site), leveraging the browser's built-in HTTP cache rather than a CDN.
+- This does not bundle C-extension packages (numpy, matplotlib etc.) into wheels — Pyodide provides those as built-in packages.
+- This does not change the `py-config` format beyond updating the packages list.
+- This does not implement service workers or offline caching.
+
+## Dependencies
+
+- **Informed by** `feat/hydration-measurement` — profiling data will validate download/install time savings.
+
+## Design
+
+### Part 1: Browser-Only WebComPy Wheel
+
+#### Current State
+
+`make_webcompy_app_package()` in `_wheel_builder.py` creates a single wheel containing:
+- `webcompy/` — entire framework source (including `cli/`)
+- `{app_name}/` — application source
+- Shared `.dist-info/`
+
+#### Proposed State
+
+Two separate wheels:
+
+**WebComPy framework wheel** (browser-only):
+```
+webcompy-{version}-py3-none-any.whl
+├── webcompy/
+│   ├── app/
+│   ├── components/
+│   ├── elements/
+│   ├── signal/
+│   ├── router/
+│   ├── di/
+│   ├── _browser/
+│   ├── aio/
+│   ├── ajax/
+│   ├── assets.py
+│   ├── exception/
+│   ├── logging.py
+│   ├── utils/
+│   ├── __init__.py
+│   ├── __main__.py
+│   ├── _version.py
+│   └── py.typed
+├── webcompy-{version}.dist-info/
+│   ├── METADATA
+│   ├── WHEEL
+│   ├── top_level.txt    (contains: webcompy)
+│   └── RECORD
+```
+
+**Application wheel** (app code + optional dependencies):
+```
+{app_name}-{version}-py3-none-any.whl
+├── {app_name}/           (application source)
+├── {dep1}/               (bundled pure-Python dependencies)
+├── {dep2}/
+├── {app_name}-{version}.dist-info/
+│   ├── METADATA
+│   ├── WHEEL
+│   ├── top_level.txt    (contains: {app_name}\n{dep1}\n{dep2})
+│   └── RECORD
+```
+
+#### New Function: `make_browser_webcompy_wheel()`
+
+```python
+_BROWSER_ONLY_EXCLUDE = {"cli", "cli"}
+
+def make_browser_webcompy_wheel(
+    webcompy_package_dir: pathlib.Path,
+    dest: pathlib.Path,
+    version: str,
+) -> pathlib.Path:
+    """Build a webcompy wheel excluding CLI-only modules."""
+    # Collect webcompy files, excluding webcompy/cli/
+    ...
+```
+
+#### Updated `make_webcompy_app_package()`
+
+The app wheel no longer includes `webcompy/`. It bundles app code and pure-Python dependencies.
+
+```python
+def make_webcompy_app_package(
+    dest: pathlib.Path,
+    package_dir: pathlib.Path,
+    app_version: str,
+    assets: dict[str, str] | None = None,
+    bundled_deps: list[tuple[str, pathlib.Path]] | None = None,
+) -> pathlib.Path:
+    package_dirs = [(package_dir.name, package_dir)]
+    if bundled_deps:
+        package_dirs.extend(bundled_deps)
+    return make_bundled_wheel(
+        name=package_dir.name,
+        package_dirs=package_dirs,
+        dest=dest,
+        version=app_version,
+        package_data=package_data,
+        extra_files=extra_files,
+    )
+```
+
+### Part 2: Dependency Bundling
+
+#### Strategy
+
+Instead of listing pure-Python dependencies in `py-config.packages` (which triggers separate `micropip.install()` calls per package), bundle their source files directly into the app wheel.
+
+This requires:
+
+1. **Discovery**: Given `AppConfig.dependencies`, determine which are pure-Python (installable via `micropip`) vs. C-extension (provided by Pyodide).
+2. **Resolution**: For pure-Python dependencies, locate their installed source files on the server.
+3. **Bundling**: Include the dependency's package directory in the app wheel.
+
+Since the dev server and SSG generator run in a standard Python environment, installed packages are available via `importlib.util.find_spec()`.
+
+#### Implementation
+
+```python
+def _discover_dependency_package_dirs(
+    dependencies: list[str],
+) -> tuple[list[tuple[str, pathlib.Path]], list[str]]:
+    """Resolve dependencies to package directories.
+    
+    Returns:
+        (bundled, pyodide_builtin)
+        - bundled: list of (package_name, package_dir) for pure-Python deps
+        - pyodide_builtin: list of package names for C-extension deps (Pyodide built-ins)
+    """
+    bundled = []
+    pyodide_builtin = []
+    for dep in dependencies:
+        try:
+            spec = importlib.util.find_spec(dep)
+            if spec and spec.origin:
+                # Pure Python — include in bundle
+                pkg_dir = pathlib.Path(spec.origin).parent
+                bundled.append((dep, pkg_dir))
+            else:
+                # C extension or unavailable — defer to Pyodide
+                pyodide_builtin.append(dep)
+        except (ModuleNotFoundError, ValueError):
+            pyodide_builtin.append(dep)
+    return bundled, pyodide_builtin
+```
+
+#### Updated `py-config.packages`
+
+The generated HTML's PyScript config will list:
+1. The webcompy framework wheel URL
+2. The app wheel URL (containing app code + bundled deps)
+3. Only the C-extension / Pyodide built-in package names (e.g., `numpy`, `matplotlib`)
+
+```json
+{
+  "packages": [
+    "/_webcompy-app-package/webcompy-{ver}-py3-none-any.whl",
+    "/_webcompy-app-package/{app_name}-{ver}-py3-none-any.whl",
+    "numpy",
+    "matplotlib"
+  ]
+}
+```
+
+### Part 3: Browser Cache Strategy
+
+#### Problem
+
+Currently, `generate_app_version()` produces a timestamp-based version like `25.107.43200`, which changes every second. This means every deploy/dev-server-restart produces a different wheel URL, defeating browser caching.
+
+#### Solution
+
+Use **content-addressable URLs** for framework wheels and **version-stable URLs** for app wheels.
+
+**Framework wheel URL**: Since the webcompy framework changes infrequently, use a stable URL path that the browser can cache:
+
+```
+/_webcompy-app-package/webcompy-py3-none-any.whl
+```
+
+The same URL path always serves the current framework wheel. When the framework is updated, the file content changes but the URL stays the same — the browser revalidates using `ETag` / `Last-Modified` headers (set by Starlette's static file serving in dev mode, or by the hosting server in production).
+
+**App wheel URL**: Similarly:
+
+```
+/_webcompy-app-package/{app_name}-py3-none-any.whl
+```
+
+#### Cache Headers (Dev Server)
+
+In `create_asgi_app()`, set appropriate cache headers for wheel files:
+
+- **Framework wheel**: `Cache-Control: max-age=86400, must-revalidate` — cache for 1 day, revalidate on next request
+- **App wheel in dev mode**: `Cache-Control: no-cache` — always revalidate (app code changes frequently in dev)
+- **App wheel in production (SSG)**: `Cache-Control: max-age=604800, immutable` — cache for 1 week (app version only changes on deploy)
+
+#### Cache Headers (Static Site / GitHub Pages)
+
+For SSG, the static files are served by GitHub Pages (or similar), which sets `ETag` and `Last-Modified` automatically. Since the wheel URLs are now stable (not versioned by timestamp), the browser will cache them and revalidate with `If-None-Match` / `If-Modified-Since`.
+
+#### Version Tracking
+
+The app version is still generated (for build metadata / cache busting when needed), but the wheel **filename** in the URL no longer includes it. Instead:
+
+- The `AppConfig` or `GenerateConfig` can specify a `version` that becomes part of METADATA
+- The URL path is stable: `/_webcompy-app-package/webcompy-py3-none-any.whl`
+- Only when a full cache-bust is needed (e.g., after a major framework update), an optional `?v=` query parameter can be appended
+
+### Updated HTML Generation
+
+`generate_html()` in `_html.py` must be updated to reference two wheel URLs instead of one:
+
+```python
+def generate_html(app, dev_mode, prerender, app_version, app_package_name):
+    # ...
+    py_packages = [
+        f"{app.config.base_url}_webcompy-app-package/webcompy-py3-none-any.whl",
+        f"{app.config.base_url}_webcompy-app-package/{_normalize_name(app_package_name)}-py3-none-any.whl",
+        *pyodide_builtin_deps,  # C-extension deps only
+    ]
+    # ...
+```
+
+### Server Route Updates
+
+`create_asgi_app()` must serve both wheel files:
+
+```python
+# Build both wheels at startup
+webcompy_wheel = make_browser_webcompy_wheel(
+    get_webcompy_packge_dir(), temp_path, webcompy_version
+)
+app_wheel = make_webcompy_app_package(
+    temp_path, package_dir, app_version, assets, bundled_deps
+)
+
+# Serve at stable URLs
+app_package_files = {
+    "webcompy-py3-none-any.whl": (webcompy_wheel_content, "application/zip"),
+    f"{_normalize_name(app_name)}-py3-none-any.whl": (app_wheel_content, "application/zip"),
+}
+```
+
+## Specs Affected
+
+- `wheel-builder` — adds `make_browser_webcompy_wheel()`; updates `make_webcompy_app_package()` to accept `bundled_deps`
+- `cli` — updates dev server and SSG to produce two wheels; updates cache headers; updates `generate_html()` to reference two wheels
+- `app-config` — may add `version` field to `AppConfig` for explicit versioning
+- `app-lifecycle` — no API changes
+- `app` — no spec changes needed

--- a/openspec/changes/feat/wheel-split/proposal.md
+++ b/openspec/changes/feat/wheel-split/proposal.md
@@ -88,7 +88,7 @@ webcompy-{version}-py3-none-any.whl
 #### New Function: `make_browser_webcompy_wheel()`
 
 ```python
-_BROWSER_ONLY_EXCLUDE = {"cli", "cli"}
+_BROWSER_ONLY_EXCLUDE = {"cli"}
 
 def make_browser_webcompy_wheel(
     webcompy_package_dir: pathlib.Path,


### PR DESCRIPTION
## Summary

- Add 6 performance improvement proposals for WebComPy, covering startup performance and runtime performance
- Proposals include dependency graphs and implementation ordering guidance

### Proposals

| # | Change | Focus | Dependencies |
|---|--------|-------|-------------|
| 1 | `feat/hydration-measurement` | Startup — opt-in profiling for app lifecycle phases | None (foundation) |
| 2 | `feat/hydration-partial` | Startup — skip redundant DOM operations on prerendered nodes | → ① |
| 3 | `feat/hydration-full` | Startup — DOM-first component reconstruction via node adoption | → ①② |
| 4 | `feat/wheel-split` | Startup — browser-only framework wheel, dependency bundling, browser HTTP cache | ← ① |
| 5 | `feat/lazy-routing` | Startup + Runtime — deferred module import, RouterLink hover preload, component shell | ← ①, → ③ |
| 6 | `feat/switch-patch` | Runtime — structural diffing for SwitchElement DOM node reuse on branch changes | ← ①③, → repeat-patch |

### Dependency Graph

```
① hydration-measurement (foundation)
├→ ② hydration-partial
│  ├→ ③ hydration-full
│  └→ ⑤ lazy-routing
└→ ④ wheel-split

⑥ switch-patch ← ①③, → feat/repeat-patch (follow-up)
```

### Recommended Implementation Order

① → ② → ④ → ⑤ → ③ → ⑥
(low effort → high effort, measure first → optimize → defer → full hydration → runtime patching)

These are proposals only — no implementation code is included in this PR.