### PR TITLE
chore: relax openspec CI check to warn instead of fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,8 @@ jobs:
         run: |
           unarchived=$(find openspec/changes/ -mindepth 1 -maxdepth 1 -type d ! -name archive)
           if [ -n "$unarchived" ]; then
-            echo "::error::Unarchived changes found. Run /opsx-archive before merging to main."
+            echo "::warning::Unarchived changes found. Run /opsx-archive before merging to main."
             echo "$unarchived"
-            exit 1
           fi
 
   lint:


### PR DESCRIPTION
## Summary

- Change the openspec CI check from a hard failure (`::error::` + `exit 1`) to a warning (`::warning::`) when unarchived changes exist under `openspec/changes/`
- This allows CI to pass even when in-progress change artifacts are present on the branch, while still surfacing a visible reminder to archive them before merging to main

🤖 Generated with opencode