### PR TITLE
docs: wheel split design update with dependency resolution, lock file, and standalone build plan

### DIFF
--- a/openspec/changes/feat-standalone-build/design.md
+++ b/openspec/changes/feat-standalone-build/design.md
@@ -1,0 +1,130 @@
+# Design: Standalone Build — Same-Origin Serving of All Assets
+
+## Design Decisions
+
+### D1: `standalone` is opt-in, not default
+The default mode continues to use CDN for PyScript/Pyodide. `standalone=True` must be explicitly set in `GenerateConfig` or `ServerConfig`, or via `--standalone` CLI flag.
+
+### D2: Assets are downloaded at build time, not bundled in the framework
+PyScript/Pyodide assets are fetched from CDN during `webcompy generate --standalone` or at dev server startup. They are not part of the WebComPy package itself.
+
+### D3: Asset downloads are driven by `webcompy-lock.json`
+The lock file's `pyodide_packages` section determines which Pyodide wheels to download. The `pyscript_version` and `pyodide_version` determine which Pyodide runtime files to download.
+
+### D4: The lock file gains a `standalone_assets` section
+When in standalone mode, the lock file records which Pyodide runtime files were downloaded (with SHA256 hashes for verification):
+
+```jsonc
+{
+  "version": 1,
+  "pyodide_version": "0.29.3",
+  "pyscript_version": "2026.3.1",
+  "pyodide_packages": { ... },
+  "bundled_packages": { ... },
+  "standalone_assets": {
+    "core_js": { "url": "...", "sha256": "..." },
+    "core_css": { "url": "...", "sha256": "..." },
+    "pyodide_mjs": { "url": "...", "sha256": "..." },
+    "pyodide_asm_wasm": { "url": "...", "sha256": "..." },
+    "pyodide_asm_js": { "url": "...", "sha256": "..." },
+    "python_stdlib_zip": { "url": "...", "sha256": "..." }
+  }
+}
+```
+
+### D5: HTML generation switches asset URLs to local paths
+In standalone mode, `generate_html()` replaces CDN URLs with local paths:
+- `https://pyscript.net/releases/2026.3.1/core.js` → `/_webcompy-assets/core.js`
+- `https://pyscript.net/releases/2026.3.1/core.css` → `/_webcompy-assets/core.css`
+- `py-config.packages` entries reference `/_webcompy-assets/packages/{filename}` for Pyodide wheels
+- `py-config.lockFileURL` is set to `/_webcompy-assets/pyodide-lock.json`
+
+### D6: Dev server serves standalone assets with immutable cache headers
+In standalone dev mode, all assets in `/_webcompy-assets/` are served with `Cache-Control: max-age=86400, must-revalidate`.
+
+## Architecture
+
+### Build Pipeline (Standalone SSG)
+
+```
+webcompy generate --standalone
+        │
+        ▼
+  Load/generate webcompy-lock.json
+        │
+        ▼
+  Download PyScript assets (core.js, core.css)
+  Download Pyodide runtime (pyodide.mjs, .wasm, .js, stdlib.zip)
+  Download Pyodide wheels from lock file
+  Build framework wheel
+  Build app wheel (with bundled deps)
+        │
+        ▼
+  dist/
+  ├── _webcompy-assets/
+  │   ├── core.js, core.css
+  │   ├── pyodide.mjs, pyodide.asm.wasm, pyodide.asm.js
+  │   ├── pyodide-lock.json
+  │   ├── python_stdlib.zip
+  │   └── packages/
+  │       ├── numpy-2.2.5-...wasm32.whl
+  │       └── ...
+  ├── _webcompy-app-package/
+  │   ├── webcompy-py3-none-any.whl
+  │   └── myapp-py3-none-any.whl
+  └── index.html (with local URLs)
+```
+
+### Build Pipeline (Standalone Dev Server)
+
+```
+webcompy start --dev --standalone
+        │
+        ▼
+  Load/generate webcompy-lock.json
+  Download assets (cached in ~/.cache/webcompy/)
+        │
+        ▼
+  Serve at:
+    /_webcompy-assets/core.js
+    /_webcompy-assets/core.css
+    /_webcompy-assets/pyodide.mjs
+    /_webcompy-assets/pyodide-lock.json
+    /_webcompy-assets/packages/*
+    /_webcompy-app-package/webcompy-py3-none-any.whl
+    /_webcompy-app-package/myapp-py3-none-any.whl
+```
+
+## Config Changes
+
+```python
+@dataclass
+class GenerateConfig:
+    dist: str = "dist"
+    cname: str = ""
+    static_files_dir: str = "static"
+    standalone: bool = False  # NEW
+
+@dataclass
+class ServerConfig:
+    port: int = 8080
+    dev: bool = False
+    static_files_dir: str = "static"
+    standalone: bool = False  # NEW
+```
+
+## CLI Changes
+
+```bash
+webcompy start --dev --standalone
+webcompy generate --standalone
+webcompy lock --standalone  # pre-download assets
+```
+
+## Non-goals (This Change)
+
+- ServiceWorker generation
+- PWA manifest generation
+- Offline caching strategy
+- Asset integrity verification (beyond SHA256 in lock file)
+- Incremental asset updates

--- a/openspec/changes/feat-standalone-build/proposal.md
+++ b/openspec/changes/feat-standalone-build/proposal.md
@@ -1,0 +1,107 @@
+# Proposal: Standalone Build — Same-Origin Serving of All Assets for PWA/Offline Support
+
+## Summary
+
+Add a standalone build mode that serves PyScript runtime, Pyodide engine, and all Python packages from the same origin (the WebComPy server or static site), eliminating all external CDN dependencies. This enables PWA/ServiceWorker configuration and full offline support.
+
+## Motivation
+
+1. **Offline capability**: Current builds depend on CDN availability for PyScript/Pyodide. A standalone build enables offline PWA applications.
+
+2. **PWA/ServiceWorker**: Same-origin assets are required for ServiceWorker caching and `Cache-Control` policies. Cross-origin CDN resources cannot be cached by a ServiceWorker in many configurations.
+
+3. **Air-gapped environments**: Intranet deployments or environments without internet access need all assets served locally.
+
+4. **Privacy/compliance**: No external requests means no CDN tracking or data leakage.
+
+## Known Issues Addressed
+
+None (new capability).
+
+## Non-goals
+
+- This does not change the default build mode (CDN mode remains default).
+- This does not implement ServiceWorker registration or PWA manifest generation — those are future enhancements.
+- This does not bundle C extension packages not available in the Pyodide CDN (they would need separate Pyodide wheel hosting).
+
+## Dependencies
+
+- **Requires** `feat-wheel-split` — the lock file and dependency classification are prerequisites for knowing which Pyodide CDN assets to download.
+
+## Design
+
+### Overview
+
+```
+DEFAULT MODE (feat-wheel-split):
+  PyScript CDN ────── core.js, core.css
+  Pyodide CDN ─────── numpy-2.2.5-...wasm32.whl, httpx-0.28.1-py3-none-any.whl, ...
+  WebComPy server ─── framework wheel, app wheel
+
+STANDALONE MODE (feat-standalone-build):
+  WebComPy server ─── core.js, core.css, pyodide.mjs, pyodide-lock.json,
+                       numpy-2.2.5-...wasm32.whl, httpx-0.28.1-py3-none-any.whl,
+                       framework wheel, app wheel
+                       (ALL assets from same origin)
+```
+
+### Implementation Sketch
+
+- `GenerateConfig` and `ServerConfig` gain a `standalone: bool = False` field.
+- When `standalone=True`:
+  1. PyScript `core.js`, `core.css` are downloaded at build time and served locally.
+  2. Pyodide `pyodide.mjs`, `pyodide.asm.wasm`, `pyodide.asm.js`, `python_stdlib.zip` are downloaded and served locally.
+  3. `pyodide-lock.json` is served locally (so micropip resolves against it).
+  4. All Pyodide CDN wheels (WASM and pure-Python) referenced in the lock file are downloaded and served locally.
+  5. Generated HTML references all assets via same-origin URLs.
+  6. `py-config` `lockFileURL` is pointed at the local `pyodide-lock.json`.
+
+### Asset Size Estimate
+
+- PyScript core.js: ~170KB
+- Pyodide runtime: ~8MB (wasm + js + stdlib)
+- Pyodide packages: varies (typically 100KB–10MB per package)
+- Framework wheel: ~180KB
+- App wheel: varies
+
+Total standalone build could be 10–30MB depending on dependencies.
+
+### Download Strategy
+
+At build time, `webcompy generate --standalone` (or equivalent) downloads all required assets from CDN and places them in `dist/_webcompy-assets/`:
+
+```
+dist/
+├── _webcompy-assets/
+│   ├── core.js
+│   ├── core.css
+│   ├── pyodide.mjs
+│   ├── pyodide.asm.wasm
+│   ├── pyodide.asm.js
+│   ├── pyodide-lock.json
+│   ├── python_stdlib.zip
+│   └── packages/
+│       ├── numpy-2.2.5-cp313-cp313-pyodide_2025_0_wasm32.whl
+│       ├── httpx-0.28.1-py3-none-any.whl
+│       └── ...
+├── _webcompy-app-package/
+│   ├── webcompy-py3-none-any.whl
+│   └── myapp-py3-none-any.whl
+├── index.html
+└── ...
+```
+
+### PWA Extension (Future)
+
+A subsequent change could add:
+- `GenerateConfig.service_worker = True` to generate a ServiceWorker script.
+- `GenerateConfig.manifest = {...}` to generate a PWA manifest.
+- Offline caching strategies for same-origin assets.
+
+These are explicitly out of scope for this change but the standalone mode is a prerequisite.
+
+## Specs Affected
+
+- `cli` — add `standalone` flag, asset download logic
+- `app-config` — add `standalone` to `GenerateConfig` and `ServerConfig`
+- `lockfile` — add `standalone_assets` lock file section

--- a/openspec/changes/feat-standalone-build/specs/app-config/spec.md
+++ b/openspec/changes/feat-standalone-build/specs/app-config/spec.md
@@ -1,0 +1,11 @@
+# Application Configuration — Delta: feat-standalone-build
+
+## ADDED Requirements
+
+### Requirement: GenerateConfig and ServerConfig shall include a standalone flag
+`GenerateConfig` and `ServerConfig` SHALL include `standalone: bool = False`. When `True`, all PyScript and Pyodide assets are served from the same origin instead of external CDN.
+
+#### Scenario: Enabling standalone mode
+- **WHEN** a developer creates `GenerateConfig(standalone=True)` or `ServerConfig(standalone=True)`
+- **THEN** the `standalone` flag SHALL be stored as `True`
+- **AND** the CLI SHALL download and serve all assets locally

--- a/openspec/changes/feat-standalone-build/specs/cli/spec.md
+++ b/openspec/changes/feat-standalone-build/specs/cli/spec.md
@@ -1,0 +1,39 @@
+# CLI — Delta: feat-standalone-build
+
+## ADDED Requirements
+
+### Requirement: The CLI shall support standalone build mode
+When `standalone=True` is set in `GenerateConfig` or `ServerConfig`, or the `--standalone` CLI flag is provided, the CLI SHALL download all required PyScript and Pyodide assets at build time and configure the application to serve them from the same origin instead of external CDN URLs.
+
+#### Scenario: Generating a standalone static site
+- **WHEN** a developer runs `python -m webcompy generate --standalone`
+- **THEN** all PyScript and Pyodide runtime assets SHALL be downloaded to `dist/_webcompy-assets/`
+- **AND** all Pyodide package wheels referenced in the lock file SHALL be downloaded to `dist/_webcompy-assets/packages/`
+- **AND** the generated HTML SHALL reference local asset URLs instead of CDN URLs
+
+#### Scenario: Starting a standalone dev server
+- **WHEN** a developer runs `python -m webcompy start --dev --standalone`
+- **THEN** the dev server SHALL serve PyScript and Pyodide assets from `/_webcompy-assets/`
+- **AND** the generated HTML SHALL reference local asset URLs
+
+### Requirement: Standalone HTML shall reference local asset URLs
+In standalone mode, `generate_html()` SHALL replace all CDN URLs with same-origin paths under `/_webcompy-assets/`. The PyScript `py-config` SHALL include a `lockFileURL` pointing to the local `pyodide-lock.json`.
+
+#### Scenario: Standalone PyScript configuration
+- **WHEN** standalone mode is enabled
+- **THEN** the `<script type="module" src="...">` tag SHALL reference `/_webcompy-assets/core.js`
+- **AND** the CSS link SHALL reference `/_webcompy-assets/core.css`
+- **AND** `py-config.packages` SHALL reference local wheel URLs under `/_webcompy-assets/packages/`
+
+#### Scenario: Standalone Pyodide lock URL
+- **WHEN** standalone mode is enabled
+- **THEN** `py-config` SHALL include `lockFileURL` pointing to `/_webcompy-assets/pyodide-lock.json`
+
+## MODIFIED Requirements
+
+### Requirement: ServerConfig and GenerateConfig shall include a standalone flag
+`ServerConfig` and `GenerateConfig` SHALL include a `standalone: bool = False` field.
+
+#### Scenario: Enabling standalone mode in config
+- **WHEN** a developer creates `GenerateConfig(standalone=True)`
+- **THEN** the SSG SHALL produce a standalone build with all assets served locally

--- a/openspec/changes/feat-standalone-build/specs/lockfile/spec.md
+++ b/openspec/changes/feat-standalone-build/specs/lockfile/spec.md
@@ -1,0 +1,15 @@
+# Lock File — Delta: feat-standalone-build
+
+## ADDED Requirements
+
+### Requirement: The lock file shall include standalone asset information
+When `standalone=True` is set, `webcompy-lock.json` SHALL include a `standalone_assets` section recording the URLs and SHA256 hashes of downloaded PyScript and Pyodide runtime files.
+
+#### Scenario: Lock file with standalone assets
+- **WHEN** a lock file is generated with `standalone=True`
+- **THEN** the `standalone_assets` section SHALL contain entries for `core_js`, `core_css`, `pyodide_mjs`, `pyodide_asm_wasm`, `pyodide_asm_js`, and `python_stdlib_zip`
+- **AND** each entry SHALL include the download `url` and `sha256` hash
+
+#### Scenario: Lock file without standalone assets
+- **WHEN** a lock file is generated without standalone mode
+- **THEN** the `standalone_assets` section SHALL be an empty object `{}`

--- a/openspec/changes/feat-standalone-build/tasks.md
+++ b/openspec/changes/feat-standalone-build/tasks.md
@@ -1,0 +1,123 @@
+# Tasks: Standalone Build — Same-Origin Serving of All Assets
+
+- [ ] **Task 1: Add `standalone` flag to `ServerConfig` and `GenerateConfig`**
+
+**Estimated time: ~0.5 hours**
+
+### Steps
+
+1. Add `standalone: bool = False` to `ServerConfig` dataclass in `webcompy/app/_config.py`.
+2. Add `standalone: bool = False` to `GenerateConfig` dataclass.
+3. Add `--standalone` flag to `webcompy start` and `webcompy generate` subcommands in `_argparser.py`.
+4. Update `_server.py` and `_generate.py` to pass the flag through.
+5. Write unit tests for config dataclass.
+
+### Acceptance Criteria
+
+- `ServerConfig(standalone=True)` stores the flag.
+- `GenerateConfig(standalone=True)` stores the flag.
+- `--standalone` CLI flag is parsed correctly.
+
+---
+
+- [ ] **Task 2: Implement asset download and caching**
+
+**Estimated time: ~2 hours**
+
+### Steps
+
+1. Create `webcompy/cli/_standalone_assets.py`.
+2. Define `PYSCRIPT_ASSETS` dict mapping asset names to URL templates.
+3. Define `PYODIDE_RUNTIME_ASSETS` dict for runtime files (`pyodide.mjs`, `pyodide.asm.wasm`, `pyodide.asm.js`, `python_stdlib.zip`).
+4. Implement `download_standalone_assets(pyodide_version, pyscript_version, dest_dir, lockfile)`:
+   - Download each PyScript asset from CDN.
+   - Download each Pyodide runtime asset from CDN.
+   - Download each Pyodide package wheel from CDN (using lock file's `pyodide_packages` entries).
+   - Cache downloads in `~/.cache/webcompy/assets/`.
+   - Verify SHA256 hashes.
+   - Copy to `dest_dir/_webcompy-assets/`.
+5. Write unit tests with mocked HTTP.
+
+### Acceptance Criteria
+
+- All specified assets are downloaded to the target directory.
+- Cached assets are reused without network requests.
+- SHA256 hash mismatches cause errors.
+
+---
+
+- [ ] **Task 3: Update `generate_html()` for standalone mode**
+
+**Estimated time: ~1 hour**
+
+### Steps
+
+1. Add `standalone: bool = False` parameter to `generate_html()`.
+2. When `standalone=True`:
+   - Replace `PYSCRIPT_BASE_URL/core.js` → `/_webcompy-assets/core.js`.
+   - Replace `PYSCRIPT_BASE_URL/core.css` → `/_webcompy-assets/core.css`.
+   - Add `lockFileURL` to PyScript config: `/_webcompy-assets/pyodide-lock.json`.
+   - Pyodide package URLs → `/_webcompy-assets/packages/{filename}`.
+3. Write unit tests.
+
+### Acceptance Criteria
+
+- Standalone HTML references `/_webcompy-assets/core.js`.
+- Standalone HTML includes `lockFileURL` in PyScript config.
+- Non-standalone HTML is unchanged.
+
+---
+
+- [ ] **Task 4: Update `generate_static_site()` and `create_asgi_app()` for standalone**
+
+**Estimated time: ~1.5 hours**
+
+### Steps
+
+1. In `generate_static_site()`:
+   - When `standalone=True`, call `download_standalone_assets()`.
+   - Configure `generate_html()` with `standalone=True`.
+2. In `create_asgi_app()`:
+   - When `standalone=True`, serve `/_webcompy-assets/` routes from cached assets.
+3. Write integration tests.
+
+### Acceptance Criteria
+
+- `webcompy generate --standalone` produces all assets in `dist/_webcompy-assets/`.
+- Dev server with `standalone=True` serves assets from `/_webcompy-assets/`.
+
+---
+
+- [ ] **Task 5: Update lock file schema for standalone assets**
+
+**Estimated time: ~0.5 hours**
+
+### Steps
+
+1. Add `standalone_assets` field to `Lockfile` dataclass.
+2. When `standalone=True`, populate with downloaded asset URLs and hashes.
+3. When `standalone=False`, leave as empty dict.
+4. Write unit tests.
+
+### Acceptance Criteria
+
+- Lock file with `standalone=True` contains asset URLs and hashes.
+- Lock file without standalone mode has empty `standalone_assets`.
+
+---
+
+- [ ] **Task 6: E2E test for standalone mode**
+
+**Estimated time: ~1 hour**
+
+### Steps
+
+1. Create E2E test that starts dev server in standalone mode.
+2. Verify all assets are served locally.
+3. Verify PyScript config references local URLs.
+4. Verify the application boots correctly in the browser.
+
+### Acceptance Criteria
+
+- Standalone mode E2E test passes.
+- No external CDN requests are made.

--- a/openspec/changes/feat-standalone-build/tasks.md
+++ b/openspec/changes/feat-standalone-build/tasks.md
@@ -20,9 +20,9 @@
 
 ---
 
-- [ ] **Task 2: Implement asset download and caching**
+- [ ] **Task 2: Implement asset download logic**
 
-**Estimated time: ~2 hours**
+**Estimated time: ~1 hour**
 
 ### Steps
 
@@ -33,20 +33,41 @@
    - Download each PyScript asset from CDN.
    - Download each Pyodide runtime asset from CDN.
    - Download each Pyodide package wheel from CDN (using lock file's `pyodide_packages` entries).
-   - Cache downloads in `~/.cache/webcompy/assets/`.
-   - Verify SHA256 hashes.
    - Copy to `dest_dir/_webcompy-assets/`.
 5. Write unit tests with mocked HTTP.
 
 ### Acceptance Criteria
 
 - All specified assets are downloaded to the target directory.
-- Cached assets are reused without network requests.
-- SHA256 hash mismatches cause errors.
+- Non-existent assets cause clear error messages.
 
 ---
 
-- [ ] **Task 3: Update `generate_html()` for standalone mode**
+- [ ] **Task 3: Implement asset caching and verification**
+
+**Estimated time: ~1 hour**
+
+### Steps
+
+1. Implement `cache_dir()` returning `~/.cache/webcompy/assets/` (XDG-aware).
+2. Implement `download_with_cache(url, cache_key, dest_dir)`:
+   - Check cache directory first. If cached, copy and return.
+   - Otherwise, download from CDN, save to cache, and copy to `dest_dir`.
+   - Cache key includes version to avoid stale assets.
+3. Implement SHA256 hash verification against `pyodide-lock.json` hashes.
+   - For Pyodide packages, use the `sha256` field from the lock.
+   - For runtime assets, verify against known hashes or skip if unavailable.
+4. Write unit tests.
+
+### Acceptance Criteria
+
+- Cached assets are reused without network requests.
+- SHA256 hash mismatches cause errors.
+- Cache follows XDG conventions.
+
+---
+
+- [ ] **Task 4: Update `generate_html()` for standalone mode**
 
 **Estimated time: ~1 hour**
 
@@ -68,7 +89,7 @@
 
 ---
 
-- [ ] **Task 4: Update `generate_static_site()` and `create_asgi_app()` for standalone**
+- [ ] **Task 5: Update `generate_static_site()` and `create_asgi_app()` for standalone**
 
 **Estimated time: ~1.5 hours**
 
@@ -83,12 +104,12 @@
 
 ### Acceptance Criteria
 
-- `webcompy generate --standalone` produces all assets in `dist/_webcompy-assets/`.
+- `webcompy generate --standalone` produces all assets in `dist/_webcomby-assets/`.
 - Dev server with `standalone=True` serves assets from `/_webcompy-assets/`.
 
 ---
 
-- [ ] **Task 5: Update lock file schema for standalone assets**
+- [ ] **Task 6: Update lock file schema for standalone assets**
 
 **Estimated time: ~0.5 hours**
 
@@ -106,18 +127,20 @@
 
 ---
 
-- [ ] **Task 6: E2E test for standalone mode**
+- [ ] **Task 7: E2E test for standalone mode**
 
 **Estimated time: ~1 hour**
 
 ### Steps
 
 1. Create E2E test that starts dev server in standalone mode.
-2. Verify all assets are served locally.
+2. Verify all asset URLs in generated HTML are local (starting with `/_webcompy-assets/`).
 3. Verify PyScript config references local URLs.
 4. Verify the application boots correctly in the browser.
+5. Intercept network requests and assert no external CDN requests are made (use Playwright's route interception to verify all requests go to localhost).
 
 ### Acceptance Criteria
 
 - Standalone mode E2E test passes.
-- No external CDN requests are made.
+- All asset URLs in rendered HTML are local paths.
+- Network request interception confirms no external CDN calls during page load.

--- a/openspec/changes/feat-standalone-build/tasks.md
+++ b/openspec/changes/feat-standalone-build/tasks.md
@@ -104,7 +104,7 @@
 
 ### Acceptance Criteria
 
-- `webcompy generate --standalone` produces all assets in `dist/_webcomby-assets/`.
+- `webcompy generate --standalone` produces all assets in `dist/_webcompy-assets/`.
 - Dev server with `standalone=True` serves assets from `/_webcompy-assets/`.
 
 ---

--- a/openspec/changes/feat-wheel-split/design.md
+++ b/openspec/changes/feat-wheel-split/design.md
@@ -1,77 +1,125 @@
-# Design: Wheel Split — Browser-Only Wheel, Dependency Bundling, and Browser Cache Strategy
+# Design: Wheel Split — Browser-Only Wheel, Dependency Resolution, Lock File, and Browser Cache Strategy
 
 ## Design Decisions
 
 ### D1: Two separate wheels instead of one bundled wheel
 The current single bundled wheel (framework + app) is split into:
 - **WebComPy framework wheel** (browser-only, excludes `cli/`)
-- **Application wheel** (app code + bundled pure-Python dependencies)
+- **Application wheel** (app code + bundled pure-Python dependencies not in Pyodide CDN)
 
 This allows the framework wheel to be cached independently across app updates.
 
 ### D2: Browser-only wheel excludes `cli/` directory
-The `webcompy/cli/` subtree contains server-only tools (server, generate, init, wheel builder, argparser). It is never used in the browser but adds ~XXKB to the bundled wheel. The new `make_browser_webcompy_wheel()` excludes this directory.
+The `webcompy/cli/` subtree contains server-only tools (server, generate, init, wheel builder, argparser). It is never used in the browser but adds ~size to the bundled wheel. The new `make_browser_webcompy_wheel()` excludes this directory.
 
-### D3: Pure-Python dependencies are bundled into the app wheel
-Instead of listing each pure-Python dependency in `py-config.packages` (triggering separate `micropip.install()` calls), their source files are included directly in the app wheel. Only C-extension packages (numpy, matplotlib, etc.) remain in `py-config.packages` as Pyodide built-ins.
+### D3: Dependency classification uses Pyodide lock as primary source
+Dependencies listed in `AppConfig.dependencies` are classified by consulting `pyodide-lock.json` first:
+1. **In Pyodide lock** → `pyodide_cdn` (listed by name in `py-config.packages`, Pyodide CDN provides the wheel)
+2. **Not in Pyodide lock** → resolved locally:
+   - Pure Python (no `.so`/`.pyd` files) → `bundled` (included in app wheel)
+   - C extension → `error` (not usable in browser, user is notified)
 
-### D4: Stable wheel URLs enable HTTP caching
-Wheel filenames no longer include the timestamp-based version string. Instead, they use fixed URLs:
-- `/_webcompy-app-package/webcompy-py3-none-any.whl`
-- `/_webcompy-app-package/{app_name}-py3-none-any.whl`
+This avoids the `importlib.util.find_spec()` heuristic alone, which misclassifies `numpy` as pure Python. The Pyodide lock file is fetched from `https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json` and cached locally at `~/.cache/webcompy/pyodide-lock-{version}.json`.
 
-The browser caches these using `ETag`/`Last-Modified` headers (dev server sets them automatically; GitHub Pages sets them for static files).
+The Pyodide version is derived from the PyScript version via a mapping:
+```
+PYSCRIPT_TO_PYODIDE = {"2026.3.1": "0.29.3"}
+```
 
-### D5: Dev server uses `no-cache` for app wheel, `must-revalidate` for framework wheel
-- **Framework wheel** (`webcompy-*.whl`): `Cache-Control: max-age=86400, must-revalidate` — cache for 1 day, revalidate on next request.
-- **App wheel (dev mode)**: `Cache-Control: no-cache` — always revalidate (app code changes frequently in dev).
-- **App wheel (SSG/production)**: `Cache-Control: max-age=604800, immutable` — cache for 1 week (app version only changes on deploy).
+### D4: Transitive dependency resolution via importlib.metadata
+Packages not in the Pyodide CDN need their transitive dependencies resolved. `importlib.metadata` is used to walk `Requires-Dist` metadata recursively. Each transitive dependency is then classified using the same logic (Pyodide lock → local .so check).
 
-### D6: `AppConfig` version field is optional and used for wheel METADATA only
-The `version` field in `AppConfig` is an optional string. If unset, the existing `generate_app_version()` timestamp-based version is used as a fallback for wheel METADATA, but the wheel **URL path** remains stable.
+The `source` field in the lock file distinguishes user-specified (`explicit`) from auto-resolved (`transitive`) dependencies, enabling clean updates when the user removes a dependency.
+
+### D5: `webcompy-lock.json` ensures reproducibility and offline capability
+A lock file at the project root (next to `webcompy_config.py`) records:
+- Pyodide version and package versions from CDN
+- Bundled package names, versions, and sources (explicit/transitive)
+- Whether each bundled package is pure Python
+
+The lock file is version-controlled (like `uv.lock` or `poetry.lock`). It is auto-generated on `webcompy start` and `webcompy generate` if missing or stale, and can be explicitly generated/updated via `webcompy lock`.
+
+### D6: Stable wheel URLs enable HTTP caching
+Wheel URLs no longer include version suffixes:
+- Framework: `/_webcompy-app-package/webcompy-py3-none-any.whl`
+- Application: `/_webcompy-app-package/{app_name}-py3-none-any.whl`
+
+Cache headers:
+| Wheel | Dev Server | Production (SSG) | Rationale |
+|-------|-----------|-------------------|-----------|
+| Framework | `max-age=86400, must-revalidate` | ETag by hosting | Changes infrequently |
+| App (dev) | `no-cache` | N/A | Changes frequently |
+| App (SSG) | N/A | ETag by hosting | Changes on deploy |
+
+### D7: `AppConfig.version` is optional, for METADATA only
+The `version` field in `AppConfig` is an optional string. If unset, `generate_app_version()` provides a timestamp-based fallback. The version is used in wheel METADATA only, not in URLs.
+
+### D8: Standalone build mode is a future extension
+The current design supports a single-server mode where PyScript/Pyodide assets are loaded from CDN. A future `standalone` mode will serve all assets from the same origin, enabling PWA/offline support. The lock file schema includes a `standalone_assets` placeholder for this.
 
 ## Architecture
 
-### Build Pipeline (Current vs. Proposed)
+### Build Pipeline
 
 ```
-CURRENT (make_webcompy_app_package — single wheel):
-═══════════════════════════════════════════════════════════
-  webcompy/                          ─┬─
-  ├── app/                            │
-  ├── elements/                       │  bundled into one wheel
-  ├── cli/                            │  (including server-only code)
-  ├── ...                             │
-  app_package/                       ─┼─
-  ├── __init__.py                     │
-  └── ...                            ─┘
+CURRENT:
+════════════════════════════════════════════════════════════════════
+  webcompy/ + app_package/ ──→ single wheel ──→ served at timestamp URL
 
-PROPOSED (two wheels):
-═══════════════════════════════════════════════════════════
-  Wheel A: webcompy-{ver}-py3-none-any.whl
-  webcompy/                              ─┬─ browser-only
-  ├── app/                                │  (excludes cli/)
-  ├── elements/                           │
-  ├── router/                             │
-  └── ...                                ─┘
+PROPOSED:
+════════════════════════════════════════════════════════════════════
+  webcompy/ (excl. cli/)  ──→ framework wheel ──→ stable URL
+  app_package/ + bundled/  ──→ app wheel       ──→ stable URL
+  Pyodide CDN packages    ──→ py-config.packages (by name)
 
-  Wheel B: {app_name}-{ver}-py3-none-any.whl
-  {app_name}/                            ─┬─
-  ├── __init__.py                         │ app + bundled deps
-  └── ...                                ─┘
-  {dep1}/                                 ─┬─ pure-Python deps
-  └── ...                                ─┘
+  webcompy-lock.json  ──→ classification cache ──→ reproducible builds
 ```
 
-### PyScript Config (Current vs. Proposed)
+### Dependency Classification Flow
+
+```
+AppConfig.dependencies = ["flask", "numpy"]
+        │
+        ▼
+  ┌─ webcompy-lock.json exists? ─┐
+  │                               │
+  YES                             NO
+  │                               │
+  ▼                               ▼
+  Validate against             Fetch pyodide-lock.json
+  current dependencies          from CDN (with cache)
+  │                               │
+  ├─ valid ──→ use lock          ▼
+  │                          Classify each dependency:
+  └─ stale ──→ regenerate    ┌────────────────────────────┐
+                             │                            │
+                        In Pyodide lock?                 Not in lock
+                             │                            │
+                        pyodide_cdn                importlib.util.find_spec()
+                        (micropip installs         │                │
+                         from CDN)            .so/.pyd found    Pure Python
+                                                │                │
+                                             ERROR             bundled
+                                            (notify user)     (app wheel)
+                                                    │
+                                              Resolve transitive deps
+                                              via importlib.metadata
+                                              (classify each the same way)
+
+                                            ┌─── In Pyodide lock ──→ pyodide_cdn
+                                            ├─── Pure Python ──────→ bundled (transitive)
+                                            └─── C extension ──────→ ERROR
+```
+
+### PyScript Config (Current vs Proposed)
 
 ```json
 // CURRENT
 {
   "packages": [
-    "/_webcompy-app-package/myapp-25.107.43200-py3-none-any.whl",
     "numpy",
-    "matplotlib"
+    "matplotlib",
+    "/_webcompy-app-package/myapp-25.107.43200-py3-none-any.whl"
   ]
 }
 
@@ -96,16 +144,7 @@ def make_browser_webcompy_wheel(
     dest: pathlib.Path,
     version: str,
 ) -> pathlib.Path:
-    """Build a webcompy wheel excluding CLI-only modules."""
-    # Collect files, excluding webcompy/cli/ and webcompy/cli/template_data/
-    files_to_include = []
-    for root, dirs, files in os.walk(webcompy_package_dir):
-        rel = root.relative_to(webcompy_package_dir)
-        if any(part in _BROWSER_ONLY_EXCLUDE for part in rel.parts):
-            continue
-        for f in files:
-            ...
-    return _make_wheel(name="webcompy", version=version, ...)
+    pass
 ```
 
 ### `make_webcompy_app_package()` update
@@ -118,131 +157,193 @@ def make_webcompy_app_package(
     assets: dict[str, str] | None = None,
     bundled_deps: list[tuple[str, pathlib.Path]] | None = None,
 ) -> pathlib.Path:
-    package_dirs = [(package_dir.name, package_dir)]
-    if bundled_deps:
-        package_dirs.extend(bundled_deps)
-    return _make_wheel(
-        name=package_dir.name,
-        package_dirs=package_dirs,
-        dest=dest,
-        version=app_version,
-        ...
-    )
+    pass
 ```
 
-### `_discover_dependency_package_dirs()`
+### `webcompy-lock.json` Schema
 
-```python
-def _discover_dependency_package_dirs(
-    dependencies: list[str],
-) -> tuple[list[tuple[str, pathlib.Path]], list[str]]:
-    bundled = []
-    pyodide_builtin = []
-    for dep in dependencies:
-        try:
-            spec = importlib.util.find_spec(dep)
-            if spec and spec.origin:
-                pkg_dir = pathlib.Path(spec.origin).parent
-                bundled.append((dep, pkg_dir))
-            else:
-                pyodide_builtin.append(dep)
-        except (ModuleNotFoundError, ValueError):
-            pyodide_builtin.append(dep)
-    return bundled, pyodide_builtin
+```jsonc
+{
+  "version": 1,
+  "pyodide_version": "0.29.3",
+  "pyscript_version": "2026.3.1",
+  "pyodide_packages": {
+    "numpy": {
+      "version": "2.2.5",
+      "file_name": "numpy-2.2.5-cp313-cp313-pyodide_2025_0_wasm32.whl"
+    },
+    "httpx": {
+      "version": "0.28.1",
+      "file_name": "httpx-0.28.1-py3-none-any.whl"
+    }
+  },
+  "bundled_packages": {
+    "flask": {
+      "version": "3.1.0",
+      "source": "explicit",
+      "is_pure_python": true
+    },
+    "click": {
+      "version": "8.2.1",
+      "source": "transitive",
+      "is_pure_python": true
+    }
+  }
+}
 ```
 
 ### Dev Server Route Updates
 
-`create_asgi_app()` must build and serve both wheels:
-
 ```python
-def create_asgi_app(app=None, server_config=None):
-    # ...
-    webcompy_wheel = make_browser_webcompy_wheel(
-        get_webcompy_package_dir(), temp_path, webcompy_version
-    )
+def create_asgi_app(app, server_config=None):
+    lockfile = resolve_lockfile(app.config)
+    classified = classify_from_lockfile(lockfile)
+
+    webcompy_wheel = make_browser_webcompy_wheel(...)
     app_wheel = make_webcompy_app_package(
-        temp_path, package_dir, app_version, assets, bundled_deps
+        ...,
+        bundled_deps=[(name, path) for name, (ver, path) in classified.bundled.items()],
     )
-    
+
     app_package_files = {
-        "webcompy-py3-none-any.whl": (webcompy_wheel, "application/zip"),
-        f"{_normalize_name(app_name)}-py3-none-any.whl": (app_wheel, "application/zip"),
+        "webcompy-py3-none-any.whl": (webcompy_wheel_bytes, "application/zip"),
+        f"{_normalize_name(app_name)}-py3-none-any.whl": (app_wheel_bytes, "application/zip"),
     }
-    
-    @app.route("/_webcompy-app-package/{filename}")
-    async def serve_wheel(request):
-        ...
+
+    # Cache headers per wheel type
 ```
 
-### SSG Route Updates
-
-`generate_static_site()` must produce both wheels in the output:
+### SSG Updates
 
 ```python
-def generate_static_site(app=None, generate_config=None):
-    ...
+def generate_static_site(app, generate_config=None):
+    lockfile = resolve_lockfile(app.config)
+    classified = classify_from_lockfile(lockfile)
+
     webcompy_wheel = make_browser_webcompy_wheel(...)
     app_wheel = make_webcompy_app_package(...)
-    
+
     dist = pathlib.Path(generate_config.dist)
     pkg_dir = dist / "_webcompy-app-package"
-    shutil.copy(webcompy_wheel, pkg_dir / "webcompy-py3-none-any.whl")
-    shutil.copy(app_wheel, pkg_dir / f"{_normalize_name(app_name)}-py3-none-any.whl")
+    shutil.copy2(webcompy_wheel, pkg_dir / "webcompy-py3-none-any.whl")
+    shutil.copy2(app_wheel, pkg_dir / f"{_normalize_name(app_name)}-py3-none-any.whl")
 ```
 
 ### HTML Generation Updates
 
 ```python
-def generate_html(app, dev_mode, app_version, app_package_name):
-    bundled, pyodide_builtin = _discover_dependency_package_dirs(
-        app.config.dependencies
-    )
-    py_packages = [
+def generate_html(app, dev_mode, prerender, app_version, app_package_name,
+                  pyodide_package_names=None):
+    wheel_urls = [
         f"{app.config.base_url}_webcompy-app-package/webcompy-py3-none-any.whl",
         f"{app.config.base_url}_webcompy-app-package/{_normalize_name(app_package_name)}-py3-none-any.whl",
-        *[dep for dep in pyodide_builtin],  # C-extension deps only
     ]
-    ...
+    py_packages = [
+        *wheel_urls,
+        *(pyodide_package_names or []),
+    ]
+```
+
+## Dependency Resolution Implementation
+
+### `_pyodide_lock.py`
+
+```python
+PYODIDE_LOCK_URL_TEMPLATE = (
+    "https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json"
+)
+CACHE_DIR = pathlib.Path.home() / ".cache" / "webcompy"
+
+PYSCRIPT_TO_PYODIDE = {
+    "2026.3.1": "0.29.3",
+}
+
+def fetch_pyodide_lock(pyodide_version: str) -> dict: ...
+def get_pyodide_version(pyscript_version: str) -> str: ...
+```
+
+### `_dependency_resolver.py`
+
+```python
+@dataclass
+class ClassifiedDependency:
+    name: str
+    version: str
+    source: Literal["pyodide_cdn", "explicit", "transitive"]
+    is_pure_python: bool
+    pkg_dir: pathlib.Path | None
+
+def classify_dependencies(
+    dependencies: list[str],
+    pyodide_lock: dict,
+) -> tuple[list[ClassifiedDependency], list[str]]: ...
+
+def _resolve_transitive_deps(package_name: str) -> list[str]: ...
+def _is_pure_python_package(pkg_dir: pathlib.Path) -> bool: ...
+def _find_package_dir(package_name: str) -> pathlib.Path | None: ...
+```
+
+### `_lockfile.py`
+
+```python
+LOCKFILE_VERSION = 1
+LOCKFILE_NAME = "webcompy-lock.json"
+
+@dataclass
+class Lockfile:
+    pyodide_version: str
+    pyscript_version: str
+    pyodide_packages: dict[str, PyodidePackageEntry]
+    bundled_packages: dict[str, BundledPackageEntry]
+
+def load_lockfile(path: pathlib.Path) -> Lockfile | None: ...
+def save_lockfile(lockfile: Lockfile, path: pathlib.Path) -> None: ...
+def generate_lockfile(dependencies, pyscript_version, pyodide_version=None) -> tuple[Lockfile, list[str]]: ...
+def validate_lockfile(lockfile, dependencies) -> list[str]: ...
 ```
 
 ## Browser Cache Headers
 
 | Wheel | Dev Server Cache-Control | SSG/Production | Rationale |
 |-------|-------------------------|---------------|-----------|
-| Framework | `max-age=86400, must-revalidate` | `max-age=31536000, immutable` (via GitHub Pages ETag) | Framework changes infrequently |
-| App (dev) | `no-cache` | N/A | App code changes frequently during development |
-| App (SSG) | N/A | `max-age=604800, immutable` | App version changes only on deploy |
+| Framework | `max-age=86400, must-revalidate` | ETag by hosting | Changes infrequently |
+| App (dev) | `no-cache` | N/A | Changes frequently during development |
+| App (SSG) | N/A | ETag by hosting | Changes only on deploy |
 
 ## Version Handling
 
 - `AppConfig.version: str | None = None` (optional)
-- If `version` is set, it becomes part of the wheel's METADATA (`Name: ...`, `Version: {version}`).
-- The wheel **URL** is always stable: `...-py3-none-any.whl`.
-- `generate_app_version()` continues to return a timestamp-based string, but it is only used as the METADATA version (fallback when `AppConfig.version` is None).
-- **Cache busting:** If a full cache bust is needed (e.g., after a major framework update), the dev can append `?v={version}` to the wheel URL in the generated HTML. This is not automated but documented.
+- If `version` is set, it becomes the wheel METADATA version
+- The wheel URL is always stable (no version suffix)
+- `generate_app_version()` is the fallback when `version` is `None`
+- Version is used only in METADATA and for lock file records
 
-## Rollback Path
+## Hot Reload Fix (Incidental)
 
-If the two-wheel approach introduces issues:
-1. Set `SINGLE_WHEEL_MODE = True` in a config flag to revert to the old single-wheel bundling.
-2. The `generate_html()` function can fall back to a single wheel URL if needed.
+The current dev server builds the wheel once at startup and caches HTML in hash mode. With stable URLs, the wheel filename no longer changes between restarts, fixing the stale-URL bug in hash mode. The app wheel content changes on restart, and `Cache-Control: no-cache` ensures the browser revalidates.
 
-## Metrics Expected
+## Standalone Mode (Future Extension)
 
-| Metric | Before | After | Notes |
-|--------|--------|-------|-------|
-| Wheel download (first visit) | ~220KB + app | ~180KB + app + deps | CLI code removed from framework wheel |
-| Wheel download (repeat visit) | ~220KB + app (timestamp defeats cache) | ~0KB (framework cached) + ~app (if changed) | Stable URLs enable browser cache |
-| `micropip.install()` calls | N deps + 1 wheel | ~C-extension deps only | Pure-Python deps bundled in app wheel |
-| Total startup network time | High (no cache) | Low (framework cached) | Significant on repeat visits |
+The lock file schema includes `standalone_assets` as a placeholder. A future `feat-standalone-build` change will:
+- Download PyScript/Pyodide assets at build time
+- Serve all assets from the same origin
+- Add `GenerateConfig.standalone` flag
+- Enable PWA/ServiceWorker configuration
 
-## Dependencies
-
-- **Informed by:** `feat/hydration-measurement` — profiling validates download/install time savings.
+This is out of scope for the current change but the schema is designed to accommodate it.
 
 ## Specs to Update
 
-- `openspec/specs/wheel-builder/spec.md` — add `make_browser_webcompy_wheel()` and `bundled_deps` requirements.
-- `openspec/specs/cli/spec.md` — update "The dev server shall serve application packages" requirement to mention two wheels and cache headers; update "Generated HTML shall include PyScript bootstrapping" requirement to mention two wheel URLs.
-- `openspec/specs/app-config/spec.md` — add `AppConfig.version` field.
+- `openspec/specs/app-config/spec.md` — add `version` field requirement (already in delta)
+- `openspec/specs/cli/spec.md` — update for two-wheel serving, lock file CLI, cache headers
+- `openspec/specs/wheel-builder/spec.md` — add `make_browser_webcompy_wheel()`, `bundled_deps`
+- `openspec/specs/lockfile/spec.md` — new spec for lock file
+- `openspec/specs/dependency-resolver/spec.md` — new spec for dependency classification
+
+## Non-goals
+
+- Standalone/PWA build mode (future `feat-standalone-build`)
+- Service Worker caching strategy (future)
+- CDN hosting of wheels (same-origin only)
+- C extension package bundling (Pyodide provides these)
+- `py-config` format changes beyond `packages` list

--- a/openspec/changes/feat-wheel-split/design.md
+++ b/openspec/changes/feat-wheel-split/design.md
@@ -10,7 +10,7 @@ The current single bundled wheel (framework + app) is split into:
 This allows the framework wheel to be cached independently across app updates.
 
 ### D2: Browser-only wheel excludes `cli/` directory
-The `webcompy/cli/` subtree contains server-only tools (server, generate, init, wheel builder, argparser). It is never used in the browser but adds ~size to the bundled wheel. The new `make_browser_webcompy_wheel()` excludes this directory.
+The `webcompy/cli/` subtree (including `webcompy/cli/template_data/`) contains server-only tools (server, generate, init, wheel builder, argparser). It is never used in the browser but adds ~size to the bundled wheel. The new `make_browser_webcompy_wheel()` excludes this directory by filtering out any path whose relative parts contain `"cli"`. Since `template_data` is under `cli/`, it is automatically excluded.
 
 ### D3: Dependency classification uses Pyodide lock as primary source
 Dependencies listed in `AppConfig.dependencies` are classified by consulting `pyodide-lock.json` first:
@@ -19,12 +19,14 @@ Dependencies listed in `AppConfig.dependencies` are classified by consulting `py
    - Pure Python (no `.so`/`.pyd` files) → `bundled` (included in app wheel)
    - C extension → `error` (not usable in browser, user is notified)
 
-This avoids the `importlib.util.find_spec()` heuristic alone, which misclassifies `numpy` as pure Python. The Pyodide lock file is fetched from `https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json` and cached locally at `~/.cache/webcompy/pyodide-lock-{version}.json`.
+This avoids the `importlib.util.find_spec()` heuristic alone, which misclassifies `numpy` as pure Python. The Pyodide lock file is fetched from `https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json` and cached locally. The cache directory follows XDG conventions: `$XDG_CACHE_HOME/webcompy/` (defaulting to `~/.cache/webcompy/`).
 
-The Pyodide version is derived from the PyScript version via a mapping:
+The Pyodide version is derived from the PyScript version via a hardcoded mapping:
 ```
 PYSCRIPT_TO_PYODIDE = {"2026.3.1": "0.29.3"}
 ```
+
+**Tradeoff**: This mapping requires manual updates on every PyScript/Pyodide version bump. Unknown PyScript versions raise `ValueError`, prompting the developer to update the mapping. This is acceptable because WebComPy pins the PyScript version (`PYSCRIPT_VERSION = "2026.3.1"`) and updates are infrequent and deliberate.
 
 ### D4: Transitive dependency resolution via importlib.metadata
 Packages not in the Pyodide CDN need their transitive dependencies resolved. `importlib.metadata` is used to walk `Requires-Dist` metadata recursively. Each transitive dependency is then classified using the same logic (Pyodide lock → local .so check).
@@ -185,7 +187,8 @@ def make_webcompy_app_package(
     },
     "click": {
       "version": "8.2.1",
-      "source": "transitive",
+      "source": "transitive",  // "explicit" = user-specified, "transitive" = auto-resolved
+      "is_pure_python": true   // informational; records classification result, not used during resolution,
       "is_pure_python": true
     }
   }
@@ -252,7 +255,7 @@ def generate_html(app, dev_mode, prerender, app_version, app_package_name,
 PYODIDE_LOCK_URL_TEMPLATE = (
     "https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json"
 )
-CACHE_DIR = pathlib.Path.home() / ".cache" / "webcompy"
+CACHE_DIR = pathlib.Path(os.environ.get("XDG_CACHE_HOME", pathlib.Path.home() / ".cache")) / "webcompy"
 
 PYSCRIPT_TO_PYODIDE = {
     "2026.3.1": "0.29.3",
@@ -309,6 +312,8 @@ def validate_lockfile(lockfile, dependencies) -> list[str]: ...
 | Framework | `max-age=86400, must-revalidate` | ETag by hosting | Changes infrequently |
 | App (dev) | `no-cache` | N/A | Changes frequently during development |
 | App (SSG) | N/A | ETag by hosting | Changes only on deploy |
+
+**Note on SSG hosting**: The "ETag by hosting" column assumes the hosting provider (GitHub Pages, Cloudflare Pages, etc.) supports ETag/Last-Modified headers. Some static hosting providers do not set cache headers. For those, the stable URL design means the browser will at worst re-download the wheel on each visit (same as the current timestamp-based approach), but never fail with a 404.
 
 ## Version Handling
 

--- a/openspec/changes/feat-wheel-split/design.md
+++ b/openspec/changes/feat-wheel-split/design.md
@@ -187,8 +187,7 @@ def make_webcompy_app_package(
     },
     "click": {
       "version": "8.2.1",
-      "source": "transitive",  // "explicit" = user-specified, "transitive" = auto-resolved
-      "is_pure_python": true   // informational; records classification result, not used during resolution,
+      "source": "transitive",
       "is_pure_python": true
     }
   }

--- a/openspec/changes/feat-wheel-split/proposal.md
+++ b/openspec/changes/feat-wheel-split/proposal.md
@@ -1,29 +1,32 @@
-# Proposal: Wheel Split — Browser-Only Framework Wheel, Dependency Bundling, and Browser Cache Strategy
+# Proposal: Wheel Split — Browser-Only Framework Wheel, Dependency Resolution, Lock File, and Browser Cache Strategy
 
 ## Summary
 
-Split the current single bundled wheel (webcompy + app) into a browser-only webcompy framework wheel and a separate app wheel. The browser-only wheel excludes CLI-only code (`webcompy/cli/`, `webcompy/cli/template_data/`) that is never needed in the browser. Additionally, bundle user-specified pure-Python dependencies into the app wheel to reduce the number of Pyodide package installations. Leverage browser HTTP caching with stable URLs and proper cache headers to ensure repeated visits skip wheel re-downloads.
+Split the current single bundled wheel into a browser-only webcompy framework wheel (excluding `cli/`) and a separate application wheel (app code + bundled pure-Python dependencies). Introduce dependency classification using the Pyodide lock file to determine which packages come from the CDN vs. which are bundled locally. Generate a `webcompy-lock.json` file for reproducible builds. Use stable URLs and cache headers for browser caching.
 
 ## Motivation
 
-1. **Download size and caching**: The entire webcompy framework (~220KB of Python source) is currently bundled inside every app wheel. This means every app update requires re-downloading the entire framework. Splitting allows the framework wheel to be cached independently.
+1. **Download size and caching**: The entire webcompy framework is currently bundled inside every app wheel. Splitting allows the framework wheel to be cached independently across app updates.
 
-2. **Unnecessary browser code**: `webcompy/cli/` (server, generate, init, wheel builder, argparser) is never used in the browser but is included in the bundle. Removing it reduces the framework wheel size.
+2. **Unnecessary browser code**: `webcompy/cli/` is never used in the browser but is included in the bundle. Removing it reduces the framework wheel size.
 
-3. **Pyodide install overhead**: Each package listed in `py-config.packages` triggers a separate `micropip.install()` call. Bundling pure-Python dependencies into the app wheel reduces the number of install calls.
+3. **Pyodide package optimization**: Packages available in the Pyodide CDN (like `numpy`, `httpx`) should be served from the CDN rather than bundled. Only packages not in the CDN need bundling, reducing the app wheel size and installation calls.
 
-4. **Browser cache**: Currently, app versions change every second (`generate_app_version()` produces timestamps), meaning the wheel URL changes every time, defeating browser caching. Using stable URLs with content hashes or version-based paths enables the browser to cache wheels across visits.
+4. **Browser cache**: Currently, app versions change every second (timestamp-based), defeating browser caching. Stable URLs with proper cache headers enable efficient caching.
+
+5. **Reproducibility**: A lock file (`webcompy-lock.json`) records exact package versions and classification, ensuring consistent builds across environments.
 
 ## Known Issues Addressed
 
-None directly (this is a new capability).
+- Fixes the stale-wheel-URL bug in hash mode dev server (stable URLs eliminate the version-mismatch issue on hot reload).
 
 ## Non-goals
 
-- This does not use external CDN hosting. All wheels are served from the same origin (dev server or static site), leveraging the browser's built-in HTTP cache rather than a CDN.
-- This does not bundle C-extension packages (numpy, matplotlib etc.) into wheels — Pyodide provides those as built-in packages.
-- This does not change the `py-config` format beyond updating the packages list.
-- This does not implement service workers or offline caching.
+- Standalone/PWA build mode (serving PyScript/Pyodide from same origin) — future `feat-standalone-build`
+- Service Worker caching strategy — future
+- CDN hosting of wheels (same-origin only)
+- C extension package bundling (Pyodide provides these)
+- Lock file version sync with uv/poetry lock files — future enhancement
 
 ## Dependencies
 
@@ -33,243 +36,28 @@ None directly (this is a new capability).
 
 ### Part 1: Browser-Only WebComPy Wheel
 
-#### Current State
+See design.md D1–D2. The framework wheel excludes `webcompy/cli/` and is served at a stable URL.
 
-`make_webcompy_app_package()` in `_wheel_builder.py` creates a single wheel containing:
-- `webcompy/` — entire framework source (including `cli/`)
-- `{app_name}/` — application source
-- Shared `.dist-info/`
+### Part 2: Dependency Classification
 
-#### Proposed State
+See design.md D3–D4. Dependencies are classified by consulting `pyodide-lock.json` first, then local package inspection. Transitive dependencies are resolved via `importlib.metadata`.
 
-Two separate wheels:
+### Part 3: Lock File
 
-**WebComPy framework wheel** (browser-only):
-```
-webcompy-{version}-py3-none-any.whl
-├── webcompy/
-│   ├── app/
-│   ├── components/
-│   ├── elements/
-│   ├── signal/
-│   ├── router/
-│   ├── di/
-│   ├── _browser/
-│   ├── aio/
-│   ├── ajax/
-│   ├── assets.py
-│   ├── exception/
-│   ├── logging.py
-│   ├── utils/
-│   ├── __init__.py
-│   ├── __main__.py
-│   ├── _version.py
-│   └── py.typed
-├── webcompy-{version}.dist-info/
-│   ├── METADATA
-│   ├── WHEEL
-│   ├── top_level.txt    (contains: webcompy)
-│   └── RECORD
-```
+See design.md D5. A `webcompy-lock.json` file records all dependency classifications for reproducible builds.
 
-**Application wheel** (app code + optional dependencies):
-```
-{app_name}-{version}-py3-none-any.whl
-├── {app_name}/           (application source)
-├── {dep1}/               (bundled pure-Python dependencies)
-├── {dep2}/
-├── {app_name}-{version}.dist-info/
-│   ├── METADATA
-│   ├── WHEEL
-│   ├── top_level.txt    (contains: {app_name}\n{dep1}\n{dep2})
-│   └── RECORD
-```
+### Part 4: Browser Cache Strategy
 
-#### New Function: `make_browser_webcompy_wheel()`
+See design.md D6–D7. Stable URLs and `Cache-Control` headers.
 
-```python
-_BROWSER_ONLY_EXCLUDE = {"cli"}
+### Part 5: Standalone Mode (Future)
 
-def make_browser_webcompy_wheel(
-    webcompy_package_dir: pathlib.Path,
-    dest: pathlib.Path,
-    version: str,
-) -> pathlib.Path:
-    """Build a webcompy wheel excluding CLI-only modules."""
-    # Collect webcompy files, excluding webcompy/cli/
-    ...
-```
-
-#### Updated `make_webcompy_app_package()`
-
-The app wheel no longer includes `webcompy/`. It bundles app code and pure-Python dependencies.
-
-```python
-def make_webcompy_app_package(
-    dest: pathlib.Path,
-    package_dir: pathlib.Path,
-    app_version: str,
-    assets: dict[str, str] | None = None,
-    bundled_deps: list[tuple[str, pathlib.Path]] | None = None,
-) -> pathlib.Path:
-    package_dirs = [(package_dir.name, package_dir)]
-    if bundled_deps:
-        package_dirs.extend(bundled_deps)
-    return make_bundled_wheel(
-        name=package_dir.name,
-        package_dirs=package_dirs,
-        dest=dest,
-        version=app_version,
-        package_data=package_data,
-        extra_files=extra_files,
-    )
-```
-
-### Part 2: Dependency Bundling
-
-#### Strategy
-
-Instead of listing pure-Python dependencies in `py-config.packages` (which triggers separate `micropip.install()` calls per package), bundle their source files directly into the app wheel.
-
-This requires:
-
-1. **Discovery**: Given `AppConfig.dependencies`, determine which are pure-Python (installable via `micropip`) vs. C-extension (provided by Pyodide).
-2. **Resolution**: For pure-Python dependencies, locate their installed source files on the server.
-3. **Bundling**: Include the dependency's package directory in the app wheel.
-
-Since the dev server and SSG generator run in a standard Python environment, installed packages are available via `importlib.util.find_spec()`.
-
-#### Implementation
-
-```python
-def _discover_dependency_package_dirs(
-    dependencies: list[str],
-) -> tuple[list[tuple[str, pathlib.Path]], list[str]]:
-    """Resolve dependencies to package directories.
-    
-    Returns:
-        (bundled, pyodide_builtin)
-        - bundled: list of (package_name, package_dir) for pure-Python deps
-        - pyodide_builtin: list of package names for C-extension deps (Pyodide built-ins)
-    """
-    bundled = []
-    pyodide_builtin = []
-    for dep in dependencies:
-        try:
-            spec = importlib.util.find_spec(dep)
-            if spec and spec.origin:
-                # Pure Python — include in bundle
-                pkg_dir = pathlib.Path(spec.origin).parent
-                bundled.append((dep, pkg_dir))
-            else:
-                # C extension or unavailable — defer to Pyodide
-                pyodide_builtin.append(dep)
-        except (ModuleNotFoundError, ValueError):
-            pyodide_builtin.append(dep)
-    return bundled, pyodide_builtin
-```
-
-#### Updated `py-config.packages`
-
-The generated HTML's PyScript config will list:
-1. The webcompy framework wheel URL
-2. The app wheel URL (containing app code + bundled deps)
-3. Only the C-extension / Pyodide built-in package names (e.g., `numpy`, `matplotlib`)
-
-```json
-{
-  "packages": [
-    "/_webcompy-app-package/webcompy-{ver}-py3-none-any.whl",
-    "/_webcompy-app-package/{app_name}-{ver}-py3-none-any.whl",
-    "numpy",
-    "matplotlib"
-  ]
-}
-```
-
-### Part 3: Browser Cache Strategy
-
-#### Problem
-
-Currently, `generate_app_version()` produces a timestamp-based version like `25.107.43200`, which changes every second. This means every deploy/dev-server-restart produces a different wheel URL, defeating browser caching.
-
-#### Solution
-
-Use **content-addressable URLs** for framework wheels and **version-stable URLs** for app wheels.
-
-**Framework wheel URL**: Since the webcompy framework changes infrequently, use a stable URL path that the browser can cache:
-
-```
-/_webcompy-app-package/webcompy-py3-none-any.whl
-```
-
-The same URL path always serves the current framework wheel. When the framework is updated, the file content changes but the URL stays the same — the browser revalidates using `ETag` / `Last-Modified` headers (set by Starlette's static file serving in dev mode, or by the hosting server in production).
-
-**App wheel URL**: Similarly:
-
-```
-/_webcompy-app-package/{app_name}-py3-none-any.whl
-```
-
-#### Cache Headers (Dev Server)
-
-In `create_asgi_app()`, set appropriate cache headers for wheel files:
-
-- **Framework wheel**: `Cache-Control: max-age=86400, must-revalidate` — cache for 1 day, revalidate on next request
-- **App wheel in dev mode**: `Cache-Control: no-cache` — always revalidate (app code changes frequently in dev)
-- **App wheel in production (SSG)**: `Cache-Control: max-age=604800, immutable` — cache for 1 week (app version only changes on deploy)
-
-#### Cache Headers (Static Site / GitHub Pages)
-
-For SSG, the static files are served by GitHub Pages (or similar), which sets `ETag` and `Last-Modified` automatically. Since the wheel URLs are now stable (not versioned by timestamp), the browser will cache them and revalidate with `If-None-Match` / `If-Modified-Since`.
-
-#### Version Tracking
-
-The app version is still generated (for build metadata / cache busting when needed), but the wheel **filename** in the URL no longer includes it. Instead:
-
-- The `AppConfig` or `GenerateConfig` can specify a `version` that becomes part of METADATA
-- The URL path is stable: `/_webcompy-app-package/webcompy-py3-none-any.whl`
-- Only when a full cache-bust is needed (e.g., after a major framework update), an optional `?v=` query parameter can be appended
-
-### Updated HTML Generation
-
-`generate_html()` in `_html.py` must be updated to reference two wheel URLs instead of one:
-
-```python
-def generate_html(app, dev_mode, prerender, app_version, app_package_name):
-    # ...
-    py_packages = [
-        f"{app.config.base_url}_webcompy-app-package/webcompy-py3-none-any.whl",
-        f"{app.config.base_url}_webcompy-app-package/{_normalize_name(app_package_name)}-py3-none-any.whl",
-        *pyodide_builtin_deps,  # C-extension deps only
-    ]
-    # ...
-```
-
-### Server Route Updates
-
-`create_asgi_app()` must serve both wheel files:
-
-```python
-# Build both wheels at startup
-webcompy_wheel = make_browser_webcompy_wheel(
-    get_webcompy_packge_dir(), temp_path, webcompy_version
-)
-app_wheel = make_webcompy_app_package(
-    temp_path, package_dir, app_version, assets, bundled_deps
-)
-
-# Serve at stable URLs
-app_package_files = {
-    "webcompy-py3-none-any.whl": (webcompy_wheel_content, "application/zip"),
-    f"{_normalize_name(app_name)}-py3-none-any.whl": (app_wheel_content, "application/zip"),
-}
-```
+See design.md D8. The lock file schema includes a `standalone_assets` placeholder for future PWA support.
 
 ## Specs Affected
 
-- `wheel-builder` — adds `make_browser_webcompy_wheel()`; updates `make_webcompy_app_package()` to accept `bundled_deps`
-- `cli` — updates dev server and SSG to produce two wheels; updates cache headers; updates `generate_html()` to reference two wheels
-- `app-config` — may add `version` field to `AppConfig` for explicit versioning
-- `app-lifecycle` — no API changes
-- `app` — no spec changes needed
+- `app-config` — adds `version` field
+- `cli` — updates dev server/SSG for two-wheel serving, lock file CLI, cache headers
+- `wheel-builder` — adds `make_browser_webcompy_wheel()`, `bundled_deps`, stable URLs
+- `lockfile` — new spec
+- `dependency-resolver` — new spec

--- a/openspec/changes/feat-wheel-split/specs/cli/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/cli/spec.md
@@ -3,13 +3,14 @@
 ## MODIFIED Requirements
 
 ### Requirement: The dev server and SSG shall produce two separate wheels
-The dev server and SSG SHALL build two separate Python wheels: a browser-only webcompy framework wheel excluding `webcompy/cli/`, and an application wheel containing app code and bundled pure-Python dependencies. The generated HTML PyScript config SHALL reference both wheel URLs plus C-extension/Pyodide built-in package names (not pure-Python dependencies).
+The dev server and SSG SHALL build two separate Python wheels: a browser-only webcompy framework wheel excluding `webcompy/cli/`, and an application wheel containing app code and bundled pure-Python dependencies. The generated HTML PyScript config SHALL reference both wheel URLs plus Pyodide CDN package names (not bundled pure-Python dependencies).
 
 #### Scenario: Starting the dev server with two-wheel architecture
 - **WHEN** a developer runs `python -m webcompy start --dev`
 - **THEN** the server SHALL build two wheels: a framework wheel and an app wheel
 - **AND** the generated HTML SHALL reference both wheel URLs in the PyScript configuration
-- **AND** pure-Python dependencies SHALL NOT appear in `py-config.packages`
+- **AND** pure-Python dependencies bundled in the app wheel SHALL NOT appear in `py-config.packages`
+- **AND** Pyodide CDN package names SHALL appear in `py-config.packages`
 
 #### Scenario: Generating a static site with two-wheel architecture
 - **WHEN** a developer runs `python -m webcompy generate`
@@ -42,10 +43,49 @@ Wheel URLs SHALL NOT include version suffixes. The framework wheel SHALL be serv
 - **THEN** the URL SHALL be `/_webcompy-app-package/myapp-py3-none-any.whl`
 - **AND** no version suffix SHALL appear in the URL
 
-### Requirement: Pure-Python dependencies shall be bundled into the app wheel
-Pure-Python dependencies listed in `AppConfig.dependencies` SHALL be bundled into the app wheel. Only C-extension and Pyodide built-in packages SHALL remain in `py-config.packages`.
+### Requirement: Dependencies shall be classified via lock file resolution
+Dependencies listed in `AppConfig.dependencies` SHALL be classified using Pyodide lock data and local package inspection. Packages available in the Pyodide CDN SHALL be listed in `py-config.packages` by name. Pure-Python packages not in the Pyodide CDN SHALL be bundled into the app wheel. C-extension packages not in the Pyodide CDN SHALL cause an error.
 
-#### Scenario: Bundling pure-Python dependencies
-- **WHEN** `AppConfig.dependencies=["httpx", "numpy"]` and `httpx` is pure-Python while `numpy` is a C-extension
-- **THEN** `httpx` SHALL be bundled into the app wheel
-- **AND** `numpy` SHALL appear in `py-config.packages` in the generated HTML
+#### Scenario: Bundling pure-Python dependencies not in Pyodide CDN
+- **WHEN** `AppConfig.dependencies=["flask"]` and `flask` is pure-Python and not in the Pyodide CDN
+- **AND** `flask`'s transitive dependency `click` is also pure-Python and not in the Pyodide CDN
+- **THEN** `flask` and `click` SHALL be bundled into the app wheel
+- **AND** `flask` SHALL be marked as `source="explicit"` in the lock file
+- **AND** `click` SHALL be marked as `source="transitive"` in the lock file
+
+#### Scenario: C extension not available in Pyodide
+- **WHEN** `AppConfig.dependencies=["some_c_ext"]` and `some_c_ext` is not in the Pyodide CDN and contains `.so` files
+- **THEN** an error SHALL be reported indicating the package is a C extension not available in Pyodide
+
+#### Scenario: Packages in Pyodide CDN
+- **WHEN** `AppConfig.dependencies=["numpy"]` and `numpy` is in the Pyodide CDN
+- **THEN** `numpy` SHALL appear in `py-config.packages` as a plain package name
+- **AND** `numpy` SHALL NOT be bundled into the app wheel
+
+### Requirement: The `webcompy lock` command shall generate or update the lock file
+Running `webcompy lock` SHALL generate or update `webcompy-lock.json` in the project root. The lock file records Pyodide CDN package versions, bundled package versions and sources, and the Pyodide/PyScript versions used for classification.
+
+#### Scenario: Generating a lock file
+- **WHEN** a developer runs `webcompy lock` in a project with `AppConfig.dependencies=["flask", "numpy"]`
+- **THEN** `webcompy-lock.json` SHALL be created in the project root
+- **AND** it SHALL contain `pyodide_packages` with `numpy` and its CDN version
+- **AND** it SHALL contain `bundled_packages` with `flask`, `click` (transitive), and their local versions
+
+#### Scenario: Lock file already exists and dependencies unchanged
+- **WHEN** `webcompy-lock.json` exists and `AppConfig.dependencies` matches
+- **THEN** the existing lock file SHALL be validated and reused without network requests
+
+#### Scenario: Lock file is stale
+- **WHEN** `webcompy-lock.json` exists but `AppConfig.dependencies` has changed
+- **THEN** the lock file SHALL be regenerated
+
+### Requirement: The lock file shall be auto-generated on start and generate
+The `webcompy start` and `webcompy generate` commands SHALL auto-generate `webcompy-lock.json` if it does not exist or is stale.
+
+#### Scenario: Starting dev server without lock file
+- **WHEN** a developer runs `python -m webcompy start --dev` without a `webcompy-lock.json`
+- **THEN** the lock file SHALL be automatically generated before building wheels
+
+#### Scenario: Generating static site with stale lock file
+- **WHEN** a developer runs `python -m webcompy generate` and the lock file is stale
+- **THEN** the lock file SHALL be regenerated before building wheels

--- a/openspec/changes/feat-wheel-split/specs/dependency-resolver/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/dependency-resolver/spec.md
@@ -1,0 +1,62 @@
+# Dependency Resolver — Delta: feat-wheel-split
+
+## ADDED Requirements
+
+### Requirement: Dependencies shall be classified using Pyodide lock data as primary source
+Dependency classification SHALL first consult the Pyodide lock file (`pyodide-lock.json`) to determine if a package is available from the Pyodide CDN. Packages in the Pyodide lock SHALL be listed in `py-config.packages` by name. Packages not in the Pyodide lock SHALL be resolved locally and classified as bundled (pure-Python) or error (C extension).
+
+#### Scenario: Package available in Pyodide CDN
+- **WHEN** a dependency `numpy` is listed in `AppConfig.dependencies`
+- **AND** `numpy` is found in the Pyodide lock
+- **THEN** `numpy` SHALL be classified as `pyodide_cdn`
+- **AND** `numpy` SHALL appear in `py-config.packages` as a plain package name
+- **AND** `numpy` SHALL NOT be bundled into the app wheel
+
+#### Scenario: Pure-Python package not in Pyodide CDN
+- **WHEN** a dependency `flask` is not found in the Pyodide lock
+- **AND** `flask`'s installed package directory contains no `.so` or `.pyd` files
+- **THEN** `flask` SHALL be classified as `bundled` with `source="explicit"`
+- **AND** `flask` SHALL be bundled into the app wheel
+
+#### Scenario: C extension package not in Pyodide CDN
+- **WHEN** a dependency `some_c_ext` is not found in the Pyodide lock
+- **AND** `some_c_ext`'s installed package directory contains `.so` or `.pyd` files
+- **THEN** an error SHALL be reported indicating the package is a C extension not available in Pyodide
+- **AND** the build SHALL fail with a descriptive message
+
+### Requirement: Transitive dependencies shall be resolved recursively
+Dependencies not in the Pyodide CDN SHALL have their transitive dependencies resolved via `importlib.metadata`. Each transitive dependency SHALL be classified using the same logic (Pyodide lock → local `.so` check).
+
+#### Scenario: Transitive pure-Python dependency resolution
+- **WHEN** `flask` is in `AppConfig.dependencies` and not in the Pyodide CDN
+- **AND** `flask` depends on `click`, `itsdangerous`, and `jinja2`
+- **AND** `click` and `itsdangerous` are not in the Pyodide CDN and are pure-Python
+- **AND** `jinja2` is in the Pyodide CDN
+- **THEN** `click` and `itsdangerous` SHALL be classified as `bundled` with `source="transitive"`
+- **AND** `jinja2` SHALL be classified as `pyodide_cdn`
+
+#### Scenario: Transitive C extension dependency
+- **WHEN** a transitive dependency is a C extension not in the Pyodide CDN
+- **THEN** an error SHALL be reported
+
+### Requirement: The Pyodide lock shall be fetched from CDN with local caching
+The Pyodide lock file SHALL be fetched from `https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json` and cached locally at `~/.cache/webcompy/pyodide-lock-{version}.json`. The Pyodide version SHALL be derived from the PyScript version via a mapping table.
+
+#### Scenario: Fetching Pyodide lock for the first time
+- **WHEN** the Pyodide lock cache does not exist for the required version
+- **THEN** it SHALL be fetched from the CDN and saved to the cache directory
+
+#### Scenario: Using cached Pyodide lock
+- **WHEN** the Pyodide lock cache exists for the required version
+- **THEN** the cached file SHALL be used without network requests
+
+#### Scenario: Network failure with no cache
+- **WHEN** the CDN is unreachable and no cache exists
+- **THEN** dependencies SHALL be classified using local heuristics only (fallback to `py-config.packages` for all dependencies)
+
+### Requirement: The PyScript version shall map to a Pyodide version
+The PyScript version used in generated HTML (`PYSCRIPT_VERSION`) SHALL map to a specific Pyodide version for lock file resolution.
+
+#### Scenario: Mapping PyScript 2026.3.1
+- **WHEN** the PyScript version is `2026.3.1`
+- **THEN** the Pyodide version SHALL be `0.29.3`

--- a/openspec/changes/feat-wheel-split/specs/dependency-resolver/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/dependency-resolver/spec.md
@@ -52,7 +52,10 @@ The Pyodide lock file SHALL be fetched from `https://cdn.jsdelivr.net/pyodide/v{
 
 #### Scenario: Network failure with no cache
 - **WHEN** the CDN is unreachable and no cache exists
-- **THEN** dependencies SHALL be classified using local heuristics only (fallback to `py-config.packages` for all dependencies)
+- **THEN** all dependencies SHALL fall back to `py-config.packages` as plain package names
+- **AND** `.so`/`.pyd` detection SHALL still be performed locally for locally-installed packages
+- **AND** C-extension packages not found locally SHALL produce a warning (not an error, since Pyodide may provide them)
+- **AND** pure-Python packages not found locally SHALL also be listed in `py-config.packages`, trusting Pyodide/micropip to resolve them
 
 ### Requirement: The PyScript version shall map to a Pyodide version
 The PyScript version used in generated HTML (`PYSCRIPT_VERSION`) SHALL map to a specific Pyodide version for lock file resolution.

--- a/openspec/changes/feat-wheel-split/specs/lockfile/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/lockfile/spec.md
@@ -1,0 +1,37 @@
+# Lock File — Delta: feat-wheel-split
+
+## ADDED Requirements
+
+### Requirement: The lock file shall record dependency classification for reproducible builds
+`webcompy-lock.json` SHALL be a JSON file placed in the project root (next to `webcompy_config.py`) that records Pyodide CDN package versions, bundled package versions and sources, and the Pyodide/PyScript versions used. The lock file SHALL be version-controlled (like `uv.lock` or `poetry.lock`).
+
+#### Scenario: Lock file schema
+- **WHEN** a lock file is generated
+- **THEN** it SHALL contain `version` (integer), `pyodide_version` (string), `pyscript_version` (string), `pyodide_packages` (object mapping package names to version and file_name), and `bundled_packages` (object mapping package names to version, source, and is_pure_python)
+- **AND** `version` SHALL be `1`
+
+#### Scenario: Pyodide CDN package entry
+- **WHEN** a dependency is classified as `pyodide_cdn`
+- **THEN** the lock file SHALL record it in `pyodide_packages` with `version` and `file_name` from the Pyodide lock
+
+#### Scenario: Bundled package entry
+- **WHEN** a dependency is classified as `bundled`
+- **THEN** the lock file SHALL record it in `bundled_packages` with `version` (from local `importlib.metadata`), `source` (`"explicit"` or `"transitive"`), and `is_pure_python` (boolean)
+
+### Requirement: The lock file shall be validated against current dependencies
+When loading an existing lock file, the CLI SHALL validate that `AppConfig.dependencies` matches the `explicit` entries in `bundled_packages` plus all entries in `pyodide_packages`. If dependencies have changed, the lock file SHALL be regenerated.
+
+#### Scenario: Lock file matches dependencies
+- **WHEN** the lock file's explicit dependencies match `AppConfig.dependencies`
+- **THEN** the lock file SHALL be used as-is
+
+#### Scenario: Lock file is stale
+- **WHEN** `AppConfig.dependencies` has been modified since the lock file was generated
+- **THEN** the lock file SHALL be regenerated automatically
+
+### Requirement: The lock file position shall be next to the app package
+The lock file SHALL be stored at `app_package_path.parent / "webcompy-lock.json"`, which is the project root directory containing `webcompy_config.py`.
+
+#### Scenario: Finding the lock file path
+- **WHEN** the app package is at `/project/myapp/`
+- **THEN** the lock file path SHALL be `/project/webcompy-lock.json`

--- a/openspec/changes/feat-wheel-split/specs/lockfile/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/lockfile/spec.md
@@ -3,7 +3,7 @@
 ## ADDED Requirements
 
 ### Requirement: The lock file shall record dependency classification for reproducible builds
-`webcompy-lock.json` SHALL be a JSON file placed in the project root (next to `webcompy_config.py`) that records Pyodide CDN package versions, bundled package versions and sources, and the Pyodide/PyScript versions used. The lock file SHALL be version-controlled (like `uv.lock` or `poetry.lock`).
+`webcompy-lock.json` SHALL be a JSON file placed in the project root (next to `webcompy_config.py`) that records Pyodide CDN package versions, bundled package versions and sources, and the Pyodide/PyScript versions used. The lock file SHALL be version-controlled (like `uv.lock` or `poetry.lock`). The `bundled_packages` entries include an `is_pure_python` field that is informational — it records the classification result for human readability and debugging, but is not used during the resolution flow. Additional keys (e.g., `standalone_assets`) may be added by other changes.
 
 #### Scenario: Lock file schema
 - **WHEN** a lock file is generated

--- a/openspec/changes/feat-wheel-split/specs/wheel-builder/spec.md
+++ b/openspec/changes/feat-wheel-split/specs/wheel-builder/spec.md
@@ -1,0 +1,39 @@
+# Wheel Builder — Delta: feat-wheel-split
+
+## ADDED Requirements
+
+### Requirement: The wheel builder shall produce a browser-only framework wheel
+`make_browser_webcompy_wheel(webcompy_package_dir, dest, version)` SHALL produce a PEP 427 wheel containing the webcompy framework source but excluding `webcompy/cli/` and `webcompy/cli/template_data/`. The wheel SHALL be named `webcompy-py3-none-any.whl` (no version suffix in filename).
+
+#### Scenario: Building a browser-only wheel
+- **WHEN** `make_browser_webcompy_wheel()` is called
+- **THEN** the resulting wheel SHALL contain `webcompy/app/`, `webcompy/elements/`, `webcompy/reactive/`, etc.
+- **AND** the wheel SHALL NOT contain `webcompy/cli/` or any files under `webcompy/cli/`
+- **AND** `top_level.txt` SHALL list `webcompy`
+- **AND** the wheel filename SHALL be `webcompy-py3-none-any.whl` (without version)
+
+### Requirement: The wheel builder shall support bundled dependencies in the app wheel
+`make_webcompy_app_package()` SHALL accept an optional `bundled_deps` parameter of type `list[tuple[str, pathlib.Path]]`. When provided, each tuple represents a package name and its installed directory path. These directories SHALL be included in the app wheel alongside the app package, and their top-level names SHALL appear in `top_level.txt`.
+
+#### Scenario: Building an app wheel with bundled dependencies
+- **WHEN** `make_webcompy_app_package(..., bundled_deps=[("click", Path("/site-packages/click"))])` is called
+- **THEN** the resulting wheel SHALL contain both the app package and `click/` directory
+- **AND** `top_level.txt` SHALL list both the app name and `click`
+
+#### Scenario: Building an app wheel without bundled dependencies
+- **WHEN** `make_webcompy_app_package(..., bundled_deps=None)` is called
+- **THEN** the resulting wheel SHALL contain only the app package
+- **AND** `bundled_deps` parameter SHALL default to `None`
+
+### Requirement: Wheel URLs shall use stable filenames without version suffixes
+Wheel filenames served to browsers SHALL NOT include version strings. The framework wheel SHALL be named `webcompy-py3-none-any.whl` and the app wheel SHALL be named `{app_name}-py3-none-any.whl`. The version SHALL appear only in the wheel's METADATA, not in the URL.
+
+#### Scenario: Framework wheel filename
+- **WHEN** a framework wheel is built
+- **THEN** the served filename SHALL be `webcompy-py3-none-any.whl`
+- **AND** the METADATA SHALL contain `Version: {version}`
+
+#### Scenario: App wheel filename
+- **WHEN** an app wheel is built for an app named `myapp`
+- **THEN** the served filename SHALL be `myapp-py3-none-any.whl`
+- **AND** the METADATA SHALL contain `Version: {version}`

--- a/openspec/changes/feat-wheel-split/tasks.md
+++ b/openspec/changes/feat-wheel-split/tasks.md
@@ -1,4 +1,4 @@
-# Tasks: Wheel Split — Browser-Only Wheel, Dependency Bundling, and Browser Cache Strategy
+# Tasks: Wheel Split — Browser-Only Wheel, Dependency Resolution, Lock File, and Browser Cache Strategy
 
 - [ ] **Task 1: Implement `make_browser_webcompy_wheel()`**
 
@@ -9,145 +9,278 @@
 1. Open `webcompy/cli/_wheel_builder.py`.
 2. Add `_BROWSER_ONLY_EXCLUDE = {"cli"}` constant.
 3. Implement `make_browser_webcompy_wheel(webcompy_package_dir, dest, version)`:
-   - Walk `webcompy/` directory recursively.
-   - Skip any subdirectory whose relative path contains a part in `_BROWSER_ONLY_EXCLUDE`.
-   - Include `.py`, `.pyi`, `py.typed`, `__init__.py`, `_version.py`, and other standard files.
-   - Call the existing `_make_wheel()` (or equivalent internal function) with `name="webcompy"`.
-4. Add helper `get_webcompy_package_dir()` that returns the absolute `pathlib.Path` to the `webcompy/` package.
-5. Write a unit test: `test_browser_wheel_excludes_cli` that calls `make_browser_webcompy_wheel()`, extracts the ZIP, and asserts that no path contains `cli/`.
+   - Walk `webcompy/` directory recursively, excluding paths containing `cli` in their relative parts.
+   - Include `.py`, `.pyi`, `py.typed`, `__init__.py`, `_version.py` files.
+   - Call `_make_wheel()` or internal logic with `name="webcompy"`.
+   - The wheel filename SHALL be `webcompy-py3-none-any.whl` (no version suffix).
+   - The METADATA SHALL contain `Version: {version}`.
+4. Add a stable-filename variant of `get_wheel_filename` or update it to support versionless filenames.
+5. Write unit tests: `test_browser_wheel_excludes_cli`, `test_browser_wheel_contains_framework_packages`.
 
 ### Acceptance Criteria
 
-- `make_browser_webcompy_wheel()` produces a `.whl` file.
-- Extracting the wheel shows `webcompy/` directory with `app/`, `elements/`, `reactive/`, etc.
+- `make_browser_webcompy_wheel()` produces a valid `.whl` file.
+- Extracting the wheel shows `webcompy/` with `app/`, `elements/`, `reactive/`, etc.
 - No `webcompy/cli/` directory exists in the extracted wheel.
-- Unit test passes.
+- `top_level.txt` lists `webcompy`.
+- Wheel filename is `webcompy-py3-none-any.whl`.
 
 ---
 
-- [ ] **Task 2: Update `make_webcompy_app_package()` for `bundled_deps`**
+- [ ] **Task 2: Implement Pyodide lock fetch and cache**
+
+**Estimated time: ~1 hour**
+
+### Steps
+
+1. Create `webcompy/cli/_pyodide_lock.py`.
+2. Implement `fetch_pyodide_lock(pyodide_version: str) -> dict`:
+   - Check `~/.cache/webcompy/pyodide-lock-{version}.json`.
+   - If cached, return parsed JSON.
+   - Otherwise, fetch from `https://cdn.jsdelivr.net/pyodide/v{version}/full/pyodide-lock.json`.
+   - Save to cache directory, return parsed JSON.
+   - On network failure with no cache, return `None` (caller handles fallback).
+3. Implement `get_pyodide_version(pyscript_version: str) -> str`:
+   - Map PyScript version to Pyodide version via `PYSCRIPT_TO_PYODIDE` dict.
+   - Raise `ValueError` for unknown PyScript versions.
+4. Write unit tests with mocked HTTP responses.
+
+### Acceptance Criteria
+
+- `fetch_pyodide_lock("0.29.3")` returns parsed `pyodide-lock.json`.
+- Cache is used on second call.
+- `get_pyodide_version("2026.3.1")` returns `"0.29.3"`.
+- Network failure with cache returns cached data.
+- Network failure without cache returns `None`.
+
+---
+
+- [ ] **Task 3: Implement dependency classification logic**
+
+**Estimated time: ~1.5 hours**
+
+### Steps
+
+1. Create `webcompy/cli/_dependency_resolver.py`.
+2. Implement `_is_pure_python_package(pkg_dir: pathlib.Path) -> bool`:
+   - Walk `pkg_dir` recursively, check for `.so`, `.pyd`, `.dylib` files.
+   - Return `True` if none found.
+3. Implement `_find_package_dir(package_name: str) -> pathlib.Path | None`:
+   - Use `importlib.util.find_spec()` to locate the package.
+   - Return `spec.origin.parent` if found.
+   - Handle single-file modules (e.g., `typing_extensions.py`).
+4. Implement `_resolve_transitive_deps(package_name: str) -> list[str]`:
+   - Use `importlib.metadata` to walk `Requires-Dist`.
+   - Skip extras-only dependencies.
+   - Return all runtime dependency names (recursive).
+5. Implement `classify_dependencies(dependencies: list[str], pyodide_lock: dict) -> tuple[list[ClassifiedDependency], list[str]]`:
+   - For each direct dependency:
+     - If in `pyodide_lock["packages"]`: classify as `pyodide_cdn`.
+     - If not: find local package dir, check `.so`/`.pyd`.
+       - Pure Python: classify as `bundled` with `source="explicit"`.
+       - C extension: add to errors list.
+   - For each bundled package, resolve transitive deps and classify each.
+   - Transitive deps in Pyodide lock: classify as `pyodide_cdn`.
+   - Transitive deps pure Python not in lock: classify as `bundled` with `source="transitive"`.
+   - Transitive deps C extension: add to errors.
+6. Write comprehensive unit tests.
+
+### Acceptance Criteria
+
+- `classify_dependencies(["numpy"], lock)` classifies `numpy` as `pyodide_cdn`.
+- `classify_dependencies(["httpx"], lock)` classifies `httpx` as `pyodide_cdn` and its transitive deps from lock as `pyodide_cdn`.
+- `classify_dependencies(["flask"], lock)` classifies `flask` as `bundled` (if not in lock) and resolves transitive deps.
+- C extension not in lock produces an error message.
+- `_is_pure_python_package()` returns `False` for `numpy`, `True` for `httpx`.
+
+---
+
+- [ ] **Task 4: Update `make_webcompy_app_package()` for `bundled_deps`**
 
 **Estimated time: ~0.5 hours**
 
 ### Steps
 
 1. Modify `make_webcompy_app_package()` signature to accept `bundled_deps: list[tuple[str, pathlib.Path]] | None = None`.
-2. Pass `package_dirs` to `make_bundled_wheel()` including all bundled dependency directories.
-3. Test that `bundled_deps` packages appear in `top_level.txt`.
+2. When `bundled_deps` is provided, extend `package_dirs` with the bundled dependency directories.
+3. Each bundled dep's top-level package name SHALL appear in `top_level.txt`.
+4. The wheel filename SHALL use the stable format `{app_name}-py3-none-any.whl` (no version in URL, but version in METADATA).
+5. Write unit tests.
 
 ### Acceptance Criteria
 
-- `make_webcompy_app_package()` with `bundled_deps=[("mypackage", path)]` produces a wheel containing the `mypackage/` directory.
-- `top_level.txt` lists both the app package and `mypackage`.
+- `make_webcompy_app_package(..., bundled_deps=[("click", path)])` produces a wheel containing the `click/` directory.
+- `top_level.txt` lists both the app name and `click`.
+- Wheel filename follows the stable naming convention.
 
 ---
 
-- [ ] **Task 3: Implement `_discover_dependency_package_dirs()`**
+- [ ] **Task 5: Implement `webcompy-lock.json` read/write logic**
+
+**Estimated time: ~1.5 hours**
+
+### Steps
+
+1. Create `webcompy/cli/_lockfile.py`.
+2. Define `Lockfile` dataclass with `pyodide_version`, `pyscript_version`, `pyodide_packages`, `bundled_packages`.
+3. Define `PyodidePackageEntry` dataclass with `version`, `file_name`.
+4. Define `BundledPackageEntry` dataclass with `version`, `source`, `is_pure_python`.
+5. Implement `load_lockfile(path: pathlib.Path) -> Lockfile | None`:
+   - Parse JSON, validate `version` field is `1`.
+   - Return `Lockfile` or `None` if file doesn't exist.
+6. Implement `save_lockfile(lockfile: Lockfile, path: pathlib.Path)`:
+   - Serialize to JSON with sorted keys and indentation.
+7. Implement `generate_lockfile(dependencies, pyscript_version, pyodide_version=None)`:
+   - Fetch Pyodide lock (or use cached).
+   - Classify dependencies using `classify_dependencies()`.
+   - Build `Lockfile` from classification results.
+   - Return `(Lockfile, list[str])` where the list contains error messages.
+8. Implement `validate_lockfile(lockfile: Lockfile, dependencies: list[str]) -> list[str]`:
+   - Check that explicit entries in `bundled_packages` plus `pyodide_packages` keys cover all `dependencies`.
+   - Return list of mismatches.
+9. Write unit tests.
+
+### Acceptance Criteria
+
+- `generate_lockfile(["flask", "numpy"], "2026.3.1")` produces a `Lockfile` with `numpy` in `pyodide_packages` and `flask` in `bundled_packages`.
+- `save_lockfile()` + `load_lockfile()` roundtrips correctly.
+- `validate_lockfile()` detects missing dependencies correctly.
+- C-extension errors are returned in the error list.
+
+---
+
+- [ ] **Task 6: Add `webcompy lock` CLI command**
 
 **Estimated time: ~0.5 hours**
 
 ### Steps
 
-1. Add `_discover_dependency_package_dirs()` to `_wheel_builder.py`.
-2. For each dependency:
-   - Try `importlib.util.find_spec(dep)`.
-   - If successful and `spec.origin` exists, treat as pure-Python and add to `bundled`.
-   - If `spec.origin` is None or `find_spec` fails, treat as C-extension/built-in and add to `pyodide_builtin`.
-3. Write a unit test.
+1. Modify `webcompy/cli/_argparser.py` to add a `lock` subcommand.
+2. Create `webcompy/cli/_lock.py` with `lock_command()` function.
+3. `lock_command()` discovers the app, calls `generate_lockfile()`, and saves the result.
+4. Report C-extension errors to stderr and exit with code 1.
+5. Print generated lock file path on success.
+6. Write unit tests.
 
 ### Acceptance Criteria
 
-- Pure-Python packages are discovered as `bundled`.
-- C-extension / unknown packages are listed as `pyodide_builtin`.
-- Tests cover both cases.
+- `webcompy lock` creates `webcompy-lock.json` in the project root.
+- C-extension errors are printed to stderr.
+- Exit code 0 on success, 1 on error.
 
 ---
 
-- [ ] **Task 4: Update `create_asgi_app()` to serve two wheels with cache headers**
+- [ ] **Task 7: Integrate lock file into start/generate commands**
+
+**Estimated time: ~0.5 hours**
+
+### Steps
+
+1. In `create_asgi_app()` and `generate_static_site()`:
+   - Locate `webcompy-lock.json` at `app.config.app_package_path.parent / "webcompy-lock.json"`.
+   - Call `load_lockfile()`.
+   - If not found or stale (`validate_lockfile()` returns mismatches), call `generate_lockfile()`.
+   - Save the new lock file.
+   - Use classification results to build `bundled_deps` for wheel generation.
+   - Use `pyodide_packages` keys as `pyodide_package_names` for HTML generation.
+2. Handle network failures gracefully (fall back to listing all dependencies in `py-config.packages`).
+
+### Acceptance Criteria
+
+- `webcompy start --dev` auto-generates lock file if missing.
+- `webcompy generate` auto-generates lock file if missing.
+- Stale lock files are regenerated.
+- Network failures fall back gracefully.
+
+---
+
+- [ ] **Task 8: Update `generate_html()` for two-wheel packages config**
 
 **Estimated time: ~1 hour**
 
 ### Steps
 
-1. In `webcompy/cli/server.py` (or wherever `create_asgi_app` is defined):
+1. Modify `generate_html()` to accept `pyodide_package_names: list[str] | None = None`.
+2. Construct `py_packages` with two wheel URLs first, then Pyodide CDN package names.
+3. Stable URL format: `{base_url}_webcompy-app-package/webcompy-py3-none-any.whl` and `{base_url}_webcompy-app-package/{app_name}-py3-none-any.whl`.
+4. When `pyodide_package_names` is `None`, fall back to `app.config.dependencies` (backward compatibility).
+5. Update existing HTML generation tests.
+
+### Acceptance Criteria
+
+- Generated HTML contains both wheel URLs.
+- Pyodide CDN packages appear as plain names (e.g., `"numpy"`) in `py-config.packages`.
+- Bundled packages do NOT appear in `py-config.packages`.
+- Backward compatibility when no lock file exists.
+
+---
+
+- [ ] **Task 9: Update server and SSG for two-wheel serving**
+
+**Estimated time: ~1 hour**
+
+### Steps
+
+1. In `create_asgi_app()`:
    - Build both wheels at startup.
-   - Map stable URLs to wheel file contents.
-2. Set `Cache-Control` headers for wheel routes:
-   - Framework wheel: `max-age=86400, must-revalidate`
-   - App wheel: `no-cache` (dev mode)
-3. Ensure `Content-Type: application/zip` is set.
-4. Write a unit test.
+   - Serve at stable URLs: `/_webcompy-app-package/webcompy-py3-none-any.whl` and `/_webcompy-app-package/{app_name}-py3-none-any.whl`.
+   - Set `Cache-Control` headers: framework `max-age=86400, must-revalidate`, app (dev) `no-cache`.
+   - Set `Content-Type: application/zip`.
+2. In `generate_static_site()`:
+   - Build both wheels.
+   - Copy to `dist/_webcompy-app-package/` with stable filenames.
+   - Pass `pyodide_package_names` to `generate_html()`.
+3. Write unit tests.
 
 ### Acceptance Criteria
 
 - `GET /_webcompy-app-package/webcompy-py3-none-any.whl` returns 200.
 - `GET /_webcompy-app-package/{app_name}-py3-none-any.whl` returns 200.
-- Cache-Control headers match the design.
+- Framework wheel response includes `Cache-Control: max-age=86400, must-revalidate`.
+- App wheel (dev) response includes `Cache-Control: no-cache`.
+- SSG output contains both wheel files with stable names.
 
 ---
 
-- [ ] **Task 5: Update `generate_html()` to reference two wheels**
+- [ ] **Task 10: Add `AppConfig.version` and stable URL support**
 
 **Estimated time: ~0.5 hours**
 
 ### Steps
 
-1. In `webcompy/cli/_html.py`, update `generate_html()`:
-   - Receive `bundled, pyodide_builtin` from `_discover_dependency_package_dirs()`.
-   - Build `py_packages` list with two wheel URLs first, then C-extension deps.
-2. In `generate_static_site()`, copy both wheels to `dist/_webcompy-app-package/` without version suffix.
-3. Write a unit test.
+1. Add `version: str | None = None` to `AppConfig` dataclass.
+2. Update `generate_app_version()` or wheel-building code to use `AppConfig.version` when provided, falling back to timestamp.
+3. Ensure wheel METADATA contains the version, but wheel filename does NOT.
+4. Write unit tests.
 
 ### Acceptance Criteria
 
-- Generated HTML contains both wheel URLs.
-- Pure-Python dependencies are NOT listed in `py-config.packages`.
-- C-extension dependencies (e.g., `numpy`) ARE listed.
-
----
-
-- [ ] **Task 6: Add `version` to `AppConfig` and update version handling**
-
-**Estimated time: ~0.5 hours**
-
-### Steps
-
-1. Add `version: str | None = None` to `AppConfig`.
-2. Update `generate_app_version()` to accept an optional `version` override.
-3. Use the version string for wheel METADATA but NOT for wheel URL.
-
-### Acceptance Criteria
-
-- `AppConfig(version="1.0.0")` results in wheel METADATA version `1.0.0`.
+- `AppConfig(version="1.0.0")` results in wheel METADATA `Version: 1.0.0`.
 - Wheel URL remains stable without version suffix.
-- When `version` is None, timestamp-based fallback is used.
+- `AppConfig()` (no version) falls back to timestamp-based METADATA version.
 
 ---
 
-- [ ] **Task 7: Update unit and e2e tests**
+- [ ] **Task 11: Update unit and E2E tests**
 
-**Estimated time: ~1 hour**
+**Estimated time: ~1.5 hours**
 
 ### Steps
 
-1. Update existing wheel builder tests to confirm `webcompy/cli/` is excluded.
-2. Update existing HTML generation tests to expect two wheel URLs.
-3. Run full test suite (`pytest tests/`) and fix any failures.
+1. Update existing wheel builder tests:
+   - Verify `webcompy/cli/` is excluded from browser wheel.
+   - Verify `bundled_deps` packages appear in app wheel.
+   - Verify stable filename convention.
+2. Add new test files:
+   - `tests/test_dependency_resolver.py` — classification, transitive resolution, `.so` detection.
+   - `tests/test_lockfile.py` — lock file generation, save/load, validation.
+   - `tests/test_pyodide_lock.py` — Pyodide lock fetching and caching (mocked HTTP).
+3. Update existing HTML generation tests for two-wheel URLs.
+4. Update existing server tests for cache headers and two-wheel serving.
+5. Run full test suite (`pytest tests/ --tb=short`) and fix any failures.
 
 ### Acceptance Criteria
 
 - All existing tests pass.
-- New tests for wheel split, cache headers, and HTML generation pass.
+- New test files for dependency resolver, lock file, and Pyodide lock pass.
 - `docs_src` app builds and serves correctly in dev mode.
-
----
-
-## Dependencies
-
-- None. This change is independent of hydration work.
-
-## Specs to Update
-
-- `openspec/specs/wheel-builder/spec.md` — add `make_browser_webcompy_wheel()` requirement.
-- `openspec/specs/cli/spec.md` — update single-wheel requirement to two-wheel requirement, mention cache headers.
-- `openspec/specs/app-config/spec.md` — add `AppConfig.version`.

--- a/openspec/changes/feat-wheel-split/tasks.md
+++ b/openspec/changes/feat-wheel-split/tasks.md
@@ -92,6 +92,7 @@
 - `classify_dependencies(["flask"], lock)` classifies `flask` as `bundled` (if not in lock) and resolves transitive deps.
 - C extension not in lock produces an error message.
 - `_is_pure_python_package()` returns `False` for `numpy`, `True` for `httpx`.
+- When Pyodide lock is unavailable (fallback mode), `_is_pure_python_package()` is still used to detect C extensions locally, and C-extension packages produce warnings rather than errors.
 
 ---
 
@@ -131,6 +132,7 @@
 6. Implement `save_lockfile(lockfile: Lockfile, path: pathlib.Path)`:
    - Serialize to JSON with sorted keys and indentation.
 7. Implement `generate_lockfile(dependencies, pyscript_version, pyodide_version=None)`:
+   - If `pyodide_version` is `None`, call `get_pyodide_version(pyscript_version)` to derive it.
    - Fetch Pyodide lock (or use cached).
    - Classify dependencies using `classify_dependencies()`.
    - Build `Lockfile` from classification results.


### PR DESCRIPTION
## Summary

- **feat-wheel-split**: Rewrite all OpenSpec artifacts (proposal, design, specs, tasks) for the expanded 11-task plan covering browser-only wheel, Pyodide lock-based dependency classification, transitive dependency resolution, `webcompy-lock.json`, stable URLs, and browser cache headers
- **feat-standalone-build**: New change proposal for future same-origin PWA/offline support (serving PyScript/Pyodide assets from the same origin)

### Key design decisions in this update

1. **Pyodide lock as primary classification source** — Dependencies are first checked against `pyodide-lock.json` (fetched from CDN with local cache). Packages in the Pyodide CDN are listed by name in `py-config.packages`. Only packages not in the CDN are bundled locally.

2. **`webcompy-lock.json` for reproducibility** — A lock file at the project root (version-controlled like `uv.lock`) records Pyodide CDN packages, bundled packages with versions and sources (explicit/transitive), and Pyodide/PyScript versions.

3. **Transitive dependency resolution via `importlib.metadata`** — Dependencies not in the Pyodide CDN have their transitive dependencies resolved recursively. Each is classified (CDN vs. bundled vs. error) using the same logic.

4. **`.so`/`.pyd` detection as fallback** — For packages not in the Pyodide lock, local `.so`/`.pyd` file detection distinguishes pure-Python from C extensions. C extensions not in Pyodide cause build errors.

5. **Stable wheel URLs** — Wheel filenames no longer include version suffixes (`webcompy-py3-none-any.whl` instead of `webcompy-25.107.43200-py3-none-any.whl`), enabling browser caching with `Cache-Control` headers.

6. **`webcompy lock` CLI command** — Explicit lock file generation/update, mirroring `uv lock`/`poetry lock` patterns.

7. **Hot reload bug fix** — Stable URLs naturally fix the hash-mode dev server bug where stale wheel URLs caused 404s on reload.

### Files changed

- `openspec/changes/feat-wheel-split/` — All artifacts rewritten: proposal, design, tasks, and 4 delta specs (cli, app-config, dependency-resolver, lockfile, wheel-builder)
- `openspec/changes/feat-standalone-build/` — New change: proposal, design, tasks, 3 delta specs (cli, app-config, lockfile)

🤖 Generated with opencode

Co-Authored-By: opencode <noreply@opencode.ai>