### PR TITLE
docs: add browser port abstraction and virtual DOM change proposals

### DIFF
--- a/openspec/changes/feat-port-abstraction/.openspec.yaml
+++ b/openspec/changes/feat-port-abstraction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/feat-port-abstraction/design.md
+++ b/openspec/changes/feat-port-abstraction/design.md
@@ -34,9 +34,21 @@ The goal is to introduce function-specific port abstractions injected via the ex
 
 ### Decision 1: DOMNode as explicit-method Protocol
 
-**Chosen**: `DOMNode` Protocol with explicit method signatures (`appendChild`, `setAttribute`, `addEventListener`, `textContent`, `nodeName`, etc.)
+**Chosen**: `DOMNode` Protocol with explicit method signatures:
+- Tree: `appendChild(child)`, `removeChild(child)`, `insertBefore(new, ref)`, `replaceChild(new, old)`, `remove()`
+- Attributes: `setAttribute(name, value)`, `getAttribute(name)`, `removeAttribute(name)`, `hasAttribute(name)`, `getAttributeNames()`
+- Events: `addEventListener(event, handler, capture=False)`, `removeEventListener(event, handler)`
+- Content: `textContent` (get/set property), `nodeName` (property), `nodeType` (property)
+- Children: `childNodes` returns `DOMNodeList` (supports `.length` and `__getitem__`)
+- Metadata: `__webcompy_node__: bool`
 
-**Rationale**: The current `__getattr__`/`__setattr__` Protocol requires the node to be a raw JS proxy object. An explicit Protocol allows both `BrowserDOMNode` (thin JS adapter) and `VirtualDOMNode` (server-side tree) to satisfy the same interface without code changes at the call site. This preserves the existing `node.method()` call pattern across the entire element system.
+`DOMNodeList` is a Protocol with `length: int` (property) and `__getitem__(index: int) -> DOMNode`.
+
+**Rationale**: The current `__getattr__`/`__setattr__` Protocol requires the node to be a raw JS proxy object. An explicit Protocol allows both `BrowserDOMNode` (thin JS adapter) and `VirtualDOMNode` (server-side tree) to satisfy the same interface without code changes at the call site.
+
+`addEventListener` includes `capture=False` to match existing call sites (`_element.py:67,110` which pass `False` as the third argument). `BrowserDOMPort` passes through to the JS API; `VirtualDOMNode` ignores it.
+
+`childNodes` returns `DOMNodeList` (not a plain `list`) so both `.length` and indexing `[idx]` work identically across `BrowserDOMNode` (real JS NodeList) and `VirtualDOMNode` (custom list-like object).
 
 **Alternative considered**: Opaque handle + all operations through DOMPort. Rejected because it would require rewriting hundreds of `node.appendChild(child)` calls to `dom_port.append_child(node, child)` and makes the code significantly more verbose.
 
@@ -110,7 +122,92 @@ webcompy/ports/
     └── _fetch.py            # ServerFetchPort via httpx
 ```
 
-`HistoryPort` Protocol at `webcompy/router/_history_port.py` (internal). Browser implementation at `webcompy/router/_browser_history_port.py`. Server implementation inline or in `webcompy/router/_server_history_port.py`.
+`HistoryPort` Protocol at `webcompy/router/_history_port.py` (internal). Browser implementation at `webcompy/router/_browser_history.py`. Server implementation at `webcompy/router/_server_history.py`.
+
+### Decision 8: Migration pattern for `if browser:` branching logic
+
+The current codebase uses `if browser:` for two distinct purposes. Each requires a different migration strategy.
+
+**Pattern A — Guarding browser-only operations (most common):**
+```python
+# Before
+if browser:
+    browser.document.createElement("div")
+else:
+    raise WebComPyException(...)
+# After
+dom = inject(DOM_PORT_KEY)
+dom.create_element("div")  # ServerDOMPort raises in phase 1, VirtualDOMNode in phase 2
+```
+No branching needed — the port handles the difference internally.
+
+**Pattern B — Branching between browser and server rendering paths:**
+```python
+# Before (_switch.py, _repeat.py, _view.py, _dynamic.py, _component.py)
+if browser:
+    # Browser path: use setTimeout for deferred callbacks, real DOM mounting
+else:
+    # Server path: synchronous callbacks, no DOM mounting
+# After (phase 1: feat-port-abstraction)
+dom = inject(DOM_PORT_KEY)
+dom.schedule_macro_task(callback)  # Browser: setTimeout, Server: synchronous
+# Server-only shortcuts (_on_set_parent server branches) remain unchanged;
+# they are addressed in phase 2 (feat-virtual-dom) when render() is unified.
+```
+
+**Pattern C — `browser is not None` checks for effect scheduling:**
+```python
+# Before (_effect.py)
+if browser is not None:
+    browser.window.setTimeout(_flush_pending_effects, 0)
+# After
+inject(DOM_PORT_KEY).schedule_macro_task(_flush_pending_effects)
+# Browser: setTimeout(0), Server: synchronous execution
+```
+
+For cases where code genuinely needs to know the current environment (e.g., deferring lifecycle hooks differently), use `ENVIRONMENT` from `webcompy.utils`:
+```python
+from webcompy.utils import ENVIRONMENT
+if ENVIRONMENT == "pyscript":
+    # browser-specific logic
+```
+
+### Decision 9: Router initialization order — ports provided before Location creation
+
+**Chosen**: `WebComPyApp` provides all port implementations into `app.di_scope` BEFORE creating the `AppDocumentRoot` (which instantiates `Router` → `Location`). The initialization order is:
+
+```
+WebComPyApp.__init__:
+  1. Create DIScope
+  2. Provide ports into DIScope (all port implementations)
+  3. Create Router (requires DI scope active for HistoryPort injection)
+  4. Create AppDocumentRoot (root component, router, di_scope)
+```
+
+**Rationale**: The `Router.__init__` creates `Location()` which currently calls `browser.pyscript.ffi.create_proxy()` in its constructor. After migration, `Location` will use `inject(FFI_PORT_KEY)` and `inject(HISTORY_PORT_KEY)`. This requires the DI scope to be active with ports provided BEFORE `Router` is instantiated. The fix is to move port provision to occur before `Router` is created — this is a reordering of existing `__init__` steps, not a new architectural pattern.
+
+**Alternative considered**: Deferred Location initialization (create Router first, call `Location.init()` post-bootstrap). Rejected because it adds lifecycle complexity. The simple reordering works because port implementation classes have no dependencies themselves.
+
+### Decision 10: signal/_effect.py DI timing — use lazy inject() at call time
+
+**Chosen**: `_effect.py` removes the module-level `browser` import and instead calls `inject(DOM_PORT_KEY)` lazily at the point of use (inside `_schedule_effect()`). This avoids the module-import-time vs DI-bootstrap-time race condition.
+
+**Rationale**: `inject()` looks up the active DI scope from `ContextVar` at call time, not at module import time. Effects are only scheduled during rendering (after `app.run()` or SSG render), at which point the DI scope is active and ports are provided. The try/except ImportError guard is replaced by catching `InjectionError` from a failed inject — if no DI scope exists, effects execute synchronously as a safe fallback.
+
+```python
+# Before (_effect.py)
+from webcompy._browser._modules import browser
+if browser is not None:
+    browser.window.setTimeout(_flush_pending_effects, 0)
+
+# After
+try:
+    dom = inject(DOM_PORT_KEY)
+except InjectionError:
+    _flush_pending_effects()  # synchronous fallback
+else:
+    dom.schedule_macro_task(_flush_pending_effects)
+```
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/feat-port-abstraction/design.md
+++ b/openspec/changes/feat-port-abstraction/design.md
@@ -1,0 +1,121 @@
+## Context
+
+WebComPy currently routes all browser API access through a single `browser` object (`_PyScriptBrowserModule`) that flattens the entire `js` (Pyodide) namespace into one module-like object. Twenty files import this object directly and guard every access with `if browser:` truthiness checks. This design has served well but has clear limitations:
+
+- Testing DOM operations requires an actual browser (PyScript/Emscripten) environment
+- The all-or-nothing `browser` monolith cannot distinguish "DOM manipulation" from "history navigation" from "HTTP requests"
+- No server-side DOM can exist, forcing a parallel `_render_html()` HTML string generation path that diverges from the main render path
+- Direct `import js` / `dir(js)` flattening bypasses PyScript's official `pyscript.context` and `pyscript.ffi` APIs, which provide thread-safe access and Worker support
+
+The goal is to introduce function-specific port abstractions injected via the existing DI system, enabling:
+1. Mock-based testing of all browser-API-dependent code
+2. A unified `render()` path that works in both environments (phase 2: virtual DOM)
+3. Use of official PyScript APIs (`pyscript.context`, `pyscript.ffi`, `pyscript.fetch`)
+4. Clear separation of concerns between framework subsystems
+
+## Goals / Non-Goals
+
+**Goals:**
+- Create typed port Protocol interfaces for DOM, FFI, HTTP, and history operations
+- Inject port implementations into `WebComPyApp.di_scope` at bootstrap, selected by environment
+- Replace all direct `browser` imports in framework code with `inject(PORT_KEY)` calls
+- Enable unit testing of DOM/event/fetch logic via mock port injection
+- Browser implementations use `pyscript.context` and `pyscript.ffi` as their foundation
+- `DOMNode` becomes an explicit-method Protocol enabling dual-environment node implementations
+
+**Non-Goals:**
+- Virtual DOM tree construction (deferred to `feat-virtual-dom` change)
+- Worker thread support (ports lay groundwork but won't be tested in Workers yet)
+- ConsolePort or TimerPort (logging.py and asyncio handle these sufficiently)
+- Plugin system for custom port implementations (ports are framework-internal for now)
+- Removing `browser` from the public API entirely (deprecated shim, not removal)
+
+## Decisions
+
+### Decision 1: DOMNode as explicit-method Protocol
+
+**Chosen**: `DOMNode` Protocol with explicit method signatures (`appendChild`, `setAttribute`, `addEventListener`, `textContent`, `nodeName`, etc.)
+
+**Rationale**: The current `__getattr__`/`__setattr__` Protocol requires the node to be a raw JS proxy object. An explicit Protocol allows both `BrowserDOMNode` (thin JS adapter) and `VirtualDOMNode` (server-side tree) to satisfy the same interface without code changes at the call site. This preserves the existing `node.method()` call pattern across the entire element system.
+
+**Alternative considered**: Opaque handle + all operations through DOMPort. Rejected because it would require rewriting hundreds of `node.appendChild(child)` calls to `dom_port.append_child(node, child)` and makes the code significantly more verbose.
+
+### Decision 2: DOMPort as Factory + Query + Schedule (not full node API)
+
+**Chosen**: DOMPort provides `create_element`, `create_text_node`, `query_selector`, `get_element_by_id`, `set_title`, and `schedule_macro_task`. Node operations (`appendChild`, `setAttribute`, etc.) live on `DOMNode` itself.
+
+**Rationale**: Separating concerns keeps both interfaces small. `DOMPort` is the "document-level" gateway — creating nodes, querying the DOM, and providing scheduling. `DOMNode` is the "node-level" interface for tree manipulation. This maps naturally to the Web API where `document.createElement()` returns a node you then operate on directly.
+
+**Alternative considered**: Everything on DOMPort. Rejected for verbosity reasons (see Decision 1).
+
+### Decision 3: Port dependency pattern — app→port via inject(), intra-port via direct import
+
+The framework code layer (elements, router, app, etc.) resolves ports through DI:
+```python
+dom = inject(DOM_PORT_KEY)  # framework code
+```
+
+Browser port implementations import each other directly within the same implementation layer:
+```python
+# BrowserDOMPort uses BrowserFFIPort directly
+from webcompy.ports._browser._ffi import BrowserFFIPort
+```
+
+**Rationale**: App-layer code needs swappable implementations (browser vs server vs test mock). Browser-layer implementations are always deployed together and share the same runtime environment — they are implementation details of the browser platform, not independently swappable units. This matches Angular's pattern where `Renderer2` is injected but its internal use of `document` is direct.
+
+**Alternative considered**: DI injection for port-to-port dependencies. Rejected because it creates unnecessary initialization ordering constraints, adds DI keys for internal implementation details, and over-abstracts dependencies that only exist within one platform layer.
+
+### Decision 4: Browser implementations use pyscript.context + pyscript.ffi
+
+**Chosen**: BrowserDOMPort uses `pyscript.context.document`/`pyscript.context.window`, BrowserFFIPort wraps `pyscript.ffi`, BrowserFetchPort wraps `pyscript.fetch`.
+
+**Rationale**: These are the official PyScript APIs. `pyscript.context` transparently handles main thread vs Worker differences. `pyscript.ffi` works across Pyodide and MicroPython. The current approach of `import js` / `dir(js)` flattening is a legacy pattern that bypasses these abstractions and only works in the main thread.
+
+### Decision 5: Server implementations — Spy for phase 1, Virtual DOM for phase 2
+
+**Phase 1 (this change)**: ServerDOMPort raises descriptive exceptions on node creation with clear messages. ServerFFIPort returns functions as-is (no proxy wrapping needed on server). ServerFetchPort uses `httpx` for actual HTTP requests. ServerHistoryPort stores path in a simple string attribute.
+
+**Phase 2 (future change)**: ServerDOMPort creates `VirtualDOMNode` instances that build an in-memory tree and generate HTML strings. This replaces the current `_render_html()` parallel path.
+
+### Decision 6: DI key structure
+
+Five internal DI keys defined in `webcompy/ports/_keys.py`:
+
+```python
+DOM_PORT_KEY = InjectKey[DOMPort]("webcompy-port-dom")
+FFI_PORT_KEY = InjectKey[FFIPort]("webcompy-port-ffi")
+FETCH_PORT_KEY = InjectKey[FetchPort]("webcompy-port-fetch")
+HISTORY_PORT_KEY = InjectKey[HistoryPort]("webcompy-port-history")
+```
+
+`HistoryPort` and its key live in `webcompy/router/` since it is router-internal. All other keys are in `webcompy/ports/`.
+
+### Decision 7: Directory structure
+
+```
+webcompy/ports/
+├── __init__.py              # Public API: Protocol re-exports
+├── _dom.py                  # DOMPort Protocol + DOMNode Protocol
+├── _ffi.py                  # FFIPort Protocol
+├── _fetch.py                # FetchPort Protocol
+├── _keys.py                 # DI key definitions
+├── _browser/
+│   ├── __init__.py
+│   ├── _dom.py              # BrowserDOMPort + BrowserDOMNode
+│   ├── _ffi.py              # BrowserFFIPort
+│   └── _fetch.py            # BrowserFetchPort
+└── _server/
+    ├── __init__.py
+    ├── _dom.py              # ServerDOMPort
+    ├── _ffi.py              # ServerFFIPort
+    └── _fetch.py            # ServerFetchPort via httpx
+```
+
+`HistoryPort` Protocol at `webcompy/router/_history_port.py` (internal). Browser implementation at `webcompy/router/_browser_history_port.py`. Server implementation inline or in `webcompy/router/_server_history_port.py`.
+
+## Risks / Trade-offs
+
+- **[Large code change]** 20 files need migration from `browser` to port injection. → Mitigation: phased migration — introduce ports alongside browser, migrate file by file, run full test suite after each.
+- **[Performance]** BrowserDOMNode adapter adds one Python call layer per DOM operation. → Mitigation: adapter methods are thin one-liners delegating to JS objects; overhead is negligible compared to PyScript's existing proxy overhead.
+- **[Backward compatibility]** `browser` is part of `webcompy.__all__` and directly used by applications. → Mitigation: keep `browser` as deprecated shim during migration period with `DeprecationWarning` pointing to port APIs.
+- **[DOMNode Protocol size]** The explicit Protocol has ~20 methods. → Trade-off accepted: this is the standard DOM API surface needed by the element system. Extending `DOMNode` is rare.

--- a/openspec/changes/feat-port-abstraction/design.md
+++ b/openspec/changes/feat-port-abstraction/design.md
@@ -79,16 +79,15 @@ from webcompy.ports._browser._ffi import BrowserFFIPort
 
 ### Decision 6: DI key structure
 
-Five internal DI keys defined in `webcompy/ports/_keys.py`:
+Four internal DI keys defined in `webcompy/ports/_keys.py`:
 
 ```python
 DOM_PORT_KEY = InjectKey[DOMPort]("webcompy-port-dom")
 FFI_PORT_KEY = InjectKey[FFIPort]("webcompy-port-ffi")
 FETCH_PORT_KEY = InjectKey[FetchPort]("webcompy-port-fetch")
-HISTORY_PORT_KEY = InjectKey[HistoryPort]("webcompy-port-history")
 ```
 
-`HistoryPort` and its key live in `webcompy/router/` since it is router-internal. All other keys are in `webcompy/ports/`.
+`HISTORY_PORT_KEY` lives in `webcompy/router/_keys.py` since HistoryPort is router-internal. All other keys are in `webcompy/ports/`.
 
 ### Decision 7: Directory structure
 

--- a/openspec/changes/feat-port-abstraction/design.md
+++ b/openspec/changes/feat-port-abstraction/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-WebComPy currently routes all browser API access through a single `browser` object (`_PyScriptBrowserModule`) that flattens the entire `js` (Pyodide) namespace into one module-like object. Twenty files import this object directly and guard every access with `if browser:` truthiness checks. This design has served well but has clear limitations:
+WebComPy currently routes all browser API access through a single `browser` object (`_PyScriptBrowserModule`) that flattens the entire `js` (Pyodide) namespace into one module-like object. Eighteen consumer files import this object directly and guard every access with `if browser:` truthiness checks. This design has served well but has clear limitations:
 
 - Testing DOM operations requires an actual browser (PyScript/Emscripten) environment
 - The all-or-nothing `browser` monolith cannot distinguish "DOM manipulation" from "history navigation" from "HTTP requests"
@@ -201,6 +201,8 @@ if browser is not None:
     browser.window.setTimeout(_flush_pending_effects, 0)
 
 # After
+from webcompy.di import inject, InjectionError
+
 try:
     dom = inject(DOM_PORT_KEY)
 except InjectionError:
@@ -211,7 +213,7 @@ else:
 
 ## Risks / Trade-offs
 
-- **[Large code change]** 20 files need migration from `browser` to port injection. → Mitigation: phased migration — introduce ports alongside browser, migrate file by file, run full test suite after each.
+- **[Large code change]** 18 files need migration from `browser` to port injection. → Mitigation: phased migration — introduce ports alongside browser, migrate file by file, run full test suite after each.
 - **[Performance]** BrowserDOMNode adapter adds one Python call layer per DOM operation. → Mitigation: adapter methods are thin one-liners delegating to JS objects; overhead is negligible compared to PyScript's existing proxy overhead.
 - **[Backward compatibility]** `browser` is part of `webcompy.__all__` and directly used by applications. → Mitigation: keep `browser` as deprecated shim during migration period with `DeprecationWarning` pointing to port APIs.
 - **[DOMNode Protocol size]** The explicit Protocol has ~20 methods. → Trade-off accepted: this is the standard DOM API surface needed by the element system. Extending `DOMNode` is rare.

--- a/openspec/changes/feat-port-abstraction/proposal.md
+++ b/openspec/changes/feat-port-abstraction/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-WebComPy currently accesses browser APIs through a single `browser` monolith object imported directly by 20 files across the codebase. This creates tight coupling: every piece of rendering, routing, HTTP, and logging code depends on one opaque object and guards every call with `if browser:` checks. Testing DOM operations requires an actual browser environment, server-side code crashes on any DOM access, and the abstraction is all-or-nothing — there is no way to provide mock implementations per capability.
+WebComPy currently accesses browser APIs through a single `browser` monolith object imported directly by 18 files across the codebase. This creates tight coupling: every piece of rendering, routing, HTTP, and logging code depends on one opaque object and guards every call with `if browser:` checks. Testing DOM operations requires an actual browser environment, server-side code crashes on any DOM access, and the abstraction is all-or-nothing — there is no way to provide mock implementations per capability.
 
 Introducing function-specific port abstractions injected via DI separates browser API concerns (DOM, FFI, HTTP, history) into replaceable implementations. The same code runs identically in browser, server, and test environments by swapping the injected port implementation.
 
@@ -12,7 +12,7 @@ Introducing function-specific port abstractions injected via DI separates browse
 - **NEW** `FetchPort` abstraction: HTTP requests backed by `pyscript.fetch` in the browser and `httpx` on the server
 - **NEW** `HistoryPort` abstraction (router-internal, not public): browser history and location, backed by `pyscript.context.window` in the browser
 - **MODIFIED** `DOMNode` Protocol: replaced loose `__getattr__`/`__setattr__` duck-typing with explicit method signatures (`appendChild`, `setAttribute`, `addEventListener`, `textContent`, etc.) enabling dual-environment implementations
-- **MODIFIED** All 20 files currently importing `browser` migrated to inject ports via `inject(PORT_KEY)`
+- **MODIFIED** All 18 files currently importing `browser` migrated to inject ports via `inject(PORT_KEY)`
 - **MODIFIED** `webcompy/_browser/` internals replaced by port implementations; `browser` re-export kept in `__init__.py` as **DEPRECATED** shim directing users to port APIs
 - **MODIFIED** Environment detection consolidated: browser implementations use `pyscript.context.document`/`pyscript.context.window` and `pyscript.ffi` instead of direct `import js` / `dir(js)` flattening
 
@@ -28,7 +28,7 @@ Introducing function-specific port abstractions injected via DI separates browse
 
 ## Impact
 
-- **Affected modules**: `webcompy/ports/` (new), `webcompy/_browser/` (refactored), all elements types, router, app, ajax, components, signal, aio, logging (~20 consumer files)
+- **Affected modules**: `webcompy/ports/` (new), `webcompy/_browser/` (refactored), all elements types, router, app, ajax, components, signal, aio, logging (~18 consumer files)
 - **Breaking**: `browser` is **DEPRECATED** — direct consumers should migrate to port injection (`inject(DOM_PORT_KEY)` etc.). The `browser` object remains accessible during a deprecation period
 - **Dependencies**: New production dependency `httpx` (server-side FetchPort), `pyscript.context` and `pyscript.ffi` become the standard browser API entry points
 - **Testing**: All browser-dependent code becomes testable via mock port injection — no browser environment required for unit tests

--- a/openspec/changes/feat-port-abstraction/proposal.md
+++ b/openspec/changes/feat-port-abstraction/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+WebComPy currently accesses browser APIs through a single `browser` monolith object imported directly by 20 files across the codebase. This creates tight coupling: every piece of rendering, routing, HTTP, and logging code depends on one opaque object and guards every call with `if browser:` checks. Testing DOM operations requires an actual browser environment, server-side code crashes on any DOM access, and the abstraction is all-or-nothing — there is no way to provide mock implementations per capability.
+
+Introducing function-specific port abstractions injected via DI separates browser API concerns (DOM, FFI, HTTP, history) into replaceable implementations. The same code runs identically in browser, server, and test environments by swapping the injected port implementation.
+
+## What Changes
+
+- **NEW** `webcompy/ports/` public package containing port Protocol definitions and DI keys
+- **NEW** `DOMPort` abstraction: DOM node creation/manipulation, event listeners, title, and `setTimeout`-based macro-task scheduling via `schedule_macro_task`
+- **NEW** `FFIPort` abstraction: Python↔JavaScript bridge (`create_proxy`, `destroy_proxy`, `is_none`, `to_js`, `assign`) backed by `pyscript.ffi` in the browser
+- **NEW** `FetchPort` abstraction: HTTP requests backed by `pyscript.fetch` in the browser and `httpx` on the server
+- **NEW** `HistoryPort` abstraction (router-internal, not public): browser history and location, backed by `pyscript.context.window` in the browser
+- **MODIFIED** `DOMNode` Protocol: replaced loose `__getattr__`/`__setattr__` duck-typing with explicit method signatures (`appendChild`, `setAttribute`, `addEventListener`, `textContent`, etc.) enabling dual-environment implementations
+- **MODIFIED** All 20 files currently importing `browser` migrated to inject ports via `inject(PORT_KEY)`
+- **MODIFIED** `webcompy/_browser/` internals replaced by port implementations; `browser` re-export kept in `__init__.py` as **DEPRECATED** shim directing users to port APIs
+- **MODIFIED** Environment detection consolidated: browser implementations use `pyscript.context.document`/`pyscript.context.window` and `pyscript.ffi` instead of direct `import js` / `dir(js)` flattening
+
+## Capabilities
+
+### New Capabilities
+
+- `port-abstraction`: Function-specific port interfaces (DOMPort, FFIPort, FetchPort, HistoryPort) injected via DI with browser and server implementations, replacing the monolithic `browser` object and enabling mock-based testing of all browser-API-dependent code.
+
+### Modified Capabilities
+
+- `browser-api`: Major requirement changes — the `browser` object becomes a deprecated shim; all framework code accesses browser APIs through typed port Protocol interfaces with DI-injectable implementations instead of direct `if browser:`-guarded calls. Environment detection switches from `import js`/`dir(js)` flattening to `pyscript.context` and `pyscript.ffi`.
+
+## Impact
+
+- **Affected modules**: `webcompy/ports/` (new), `webcompy/_browser/` (refactored), all elements types, router, app, ajax, components, signal, aio, logging (~20 consumer files)
+- **Breaking**: `browser` is **DEPRECATED** — direct consumers should migrate to port injection (`inject(DOM_PORT_KEY)` etc.). The `browser` object remains accessible during a deprecation period
+- **Dependencies**: New production dependency `httpx` (server-side FetchPort), `pyscript.context` and `pyscript.ffi` become the standard browser API entry points
+- **Testing**: All browser-dependent code becomes testable via mock port injection — no browser environment required for unit tests

--- a/openspec/changes/feat-port-abstraction/specs/browser-api/spec.md
+++ b/openspec/changes/feat-port-abstraction/specs/browser-api/spec.md
@@ -1,0 +1,99 @@
+# Browser API Abstraction (delta)
+
+## MODIFIED Requirements
+
+### Requirement: The framework shall detect the browser environment at import time
+
+The `ENVIRONMENT` variable SHALL be computed once when the module is imported: `"pyscript"` when running under PyScript (detected by `platform.system() == "Emscripten"`), and `"other"` otherwise. When running in the browser, the `browser` object SHALL remain available as a deprecated shim; framework code SHALL use port Protocol interfaces with DI-injectable implementations instead.
+
+#### Scenario: Running in the browser via PyScript
+- **WHEN** the application runs in PyScript/Emscripten
+- **THEN** `ENVIRONMENT` SHALL equal `"pyscript"`
+- **AND** port implementations (`BrowserDOMPort`, `BrowserFFIPort`, etc.) SHALL be provided into `app.di_scope`
+- **AND** the deprecated `browser` object SHALL still be accessible
+
+#### Scenario: Running on a standard Python server
+- **WHEN** the application runs on a standard Python interpreter
+- **THEN** `ENVIRONMENT` SHALL equal `"other"`
+- **AND** port implementations (`ServerDOMPort`, `ServerFFIPort`, etc.) SHALL be provided into `app.di_scope`
+- **AND** the deprecated `browser` object SHALL be `None`
+
+### Requirement: Browser API access shall be gated with injectable port implementations
+
+Framework code SHALL access browser APIs through `inject(PORT_KEY)` calls to typed port Protocol interfaces, not through direct `if browser:` checks on the monolithic `browser` object. Port implementations SHALL be selected at bootstrap based on environment, enabling the same code path to work with browser JS objects, server-side mock objects, or test spy objects. Code that cannot function without browser APIs SHALL raise a clear error when the port implementation does not support the operation.
+
+#### Scenario: Creating a DOM element
+- **WHEN** the framework attempts to create a DOM element
+- **AND** the injected `DOMPort` implementation is `ServerDOMPort` (phase 1)
+- **THEN** `WebComPyException` SHALL be raised with a message indicating DOM operations are not available outside the browser
+
+#### Scenario: Using FFIPort on server
+- **WHEN** framework code calls `ffi.create_proxy(handler)` on the server
+- **THEN** `ServerFFIPort` SHALL return `handler` directly without proxy wrapping
+- **AND** no exception SHALL be raised
+
+### Requirement: The browser proxy shall provide access to all window APIs
+
+When running in the browser, the `browser` object SHALL provide access to `document`, `window`, `pyscript`, `pyodide`, `fetch`, `FormData`, and all other properties of the JavaScript `window` object. This object is **DEPRECATED** — new code SHALL use port Protocol interfaces instead.
+
+#### Scenario: Accessing the document object through ports (recommended)
+- **WHEN** framework code calls `inject(DOM_PORT_KEY).create_element("div")` in the browser
+- **THEN** `BrowserDOMPort` SHALL delegate to `pyscript.context.document.createElement("div")`
+- **AND** return a `BrowserDOMNode` wrapping the JS element
+
+#### Scenario: Accessing the document object through deprecated browser object
+- **WHEN** `browser.document` is accessed in the browser
+- **THEN** a `DeprecationWarning` SHALL be emitted
+- **AND** the actual `window.document` SHALL be returned as before
+
+### Requirement: JavaScript proxy objects shall be created and destroyed through FFIPort
+
+Objects that bridge Python and JavaScript (such as event handlers) SHALL be created via `inject(FFI_PORT_KEY).create_proxy()` and SHALL be destroyed via `inject(FFI_PORT_KEY).destroy_proxy()` when no longer needed. The browser implementation SHALL delegate to `pyscript.ffi.create_proxy()` and `.destroy()` respectively. The server implementation SHALL return the function as-is and make `destroy_proxy` a no-op.
+
+#### Scenario: Registering an event handler in the browser
+- **WHEN** a DOM event handler is registered
+- **THEN** the handler SHALL be wrapped with `BrowserFFIPort.create_proxy()` which delegates to `pyscript.ffi.create_proxy()`
+- **AND** when the element is removed, `BrowserFFIPort.destroy_proxy()` SHALL call `destroy()` on the proxy
+
+#### Scenario: Registering an event handler on the server
+- **WHEN** a DOM event handler is registered on the server
+- **THEN** `ServerFFIPort.create_proxy(handler)` SHALL return `handler` directly
+- **AND** `ServerFFIPort.destroy_proxy()` SHALL be a no-op
+
+#### Scenario: Cleanup on element removal
+- **WHEN** an element with registered event handlers is removed from the DOM
+- **THEN** `removeEventListener` SHALL be called for each handler
+- **AND** each proxy SHALL be released via the injected FFIPort
+
+## ADDED Requirements
+
+### Requirement: HTTP requests shall go through FetchPort
+
+All HTTP requests initiated by the framework SHALL use `inject(FETCH_PORT_KEY)` to obtain a port implementation. The browser implementation SHALL delegate to `pyscript.fetch`; the server implementation SHALL use `httpx`.
+
+#### Scenario: HTTP GET in browser
+- **WHEN** `BrowserFetchPort.request("GET", url)` is called
+- **THEN** it SHALL delegate to `pyscript.fetch(url, method="GET")`
+- **AND** return a `Response` object with the standard properties
+
+#### Scenario: HTTP POST with JSON body in browser
+- **WHEN** `BrowserFetchPort.request("POST", url, json=data)` is called
+- **THEN** it SHALL set `Content-Type: application/json` and serialize `data` as the body
+- **AND** delegate to `pyscript.fetch`
+
+#### Scenario: HTTP GET on server
+- **WHEN** `ServerFetchPort.request("GET", url)` is called
+- **THEN** it SHALL perform the request using `httpx.AsyncClient.get(url)`
+- **AND** return a `Response` object matching the same interface
+
+### Requirement: Macro-task scheduling shall be abstracted through DOMPort
+
+Code that needs to defer execution to a subsequent macro-task (currently via `setTimeout(fn, 0)`) SHALL call `inject(DOM_PORT_KEY).schedule_macro_task(callback)`. The browser implementation SHALL use `pyscript.context.window.setTimeout(callback, 0)`. The server implementation SHALL execute the callback synchronously (phase 1).
+
+#### Scenario: Effect batching in browser
+- **WHEN** `DOMPort.schedule_macro_task(_flush_pending_effects)` is called in the browser
+- **THEN** effects SHALL be flushed in a subsequent macro-task via `setTimeout(..., 0)`
+
+#### Scenario: Effect batching on server
+- **WHEN** `DOMPort.schedule_macro_task(_flush_pending_effects)` is called on the server
+- **THEN** effects SHALL be flushed synchronously

--- a/openspec/changes/feat-port-abstraction/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-port-abstraction/specs/port-abstraction/spec.md
@@ -77,7 +77,7 @@ Server port implementations SHALL provide the same method signatures and return 
 
 ### Requirement: History port shall be internal to the router module
 
-`HistoryPort` SHALL be defined within `webcompy/router/` as an internal abstraction, not in the public `webcompy/ports/` package. It SHALL provide methods `current_path`, `navigate`, `on_popstate`, and `off_popstate`. The browser implementation SHALL use `pyscript.context.window.history` and `pyscript.context.window.location`.
+`HistoryPort` SHALL be defined within `webcompy/router/` as an internal abstraction, not in the public `webcompy/ports/` package. It SHALL provide methods `current_path`, `current_search`, `navigate`, `on_popstate`, `off_popstate`, and `state` (property). The browser implementation SHALL use `pyscript.context.window.history` and `pyscript.context.window.location`.
 
 #### Scenario: HistoryPort provides current path in browser
 - **WHEN** `BrowserHistoryPort.current_path` is accessed

--- a/openspec/changes/feat-port-abstraction/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-port-abstraction/specs/port-abstraction/spec.md
@@ -1,0 +1,129 @@
+# Port Abstraction
+
+## Purpose
+
+WebComPy accesses browser APIs through typed port Protocol interfaces injected via the dependency injection system. Each port covers a specific capability domain — DOM manipulation, FFI bridging, HTTP requests, history navigation — with browser and server implementations selected at bootstrap time. This replaces the monolithic `browser` object and enables unit testing of all browser-dependent code through mock port injection.
+
+## ADDED Requirements
+
+### Requirement: Ports shall be defined as Protocol interfaces with explicit method signatures
+
+Each port SHALL be a Python Protocol class declaring the exact methods and type signatures that consumers depend on. Protocol files SHALL be placed in `webcompy/ports/` for public ports and within their owning package for internal ports.
+
+#### Scenario: DOMPort Protocol definition
+- **WHEN** `webcompy/ports/_dom.py` is imported
+- **THEN** it SHALL export a `DOMPort` Protocol with methods `create_element`, `create_text_node`, `query_selector`, `get_element_by_id`, `set_title`, and `schedule_macro_task`
+- **AND** it SHALL export a `DOMNode` Protocol with methods `appendChild`, `insertBefore`, `replaceChild`, `removeChild`, `remove`, `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`, `addEventListener`, `removeEventListener`, `textContent` (property), `nodeName` (property), `nodeType` (property), and `childNodes` (property)
+- **AND** `DOMNode` SHALL declare `__webcompy_node__: bool`
+
+#### Scenario: FFIPort Protocol definition
+- **WHEN** `webcompy/ports/_ffi.py` is imported
+- **THEN** it SHALL export an `FFIPort` Protocol with methods `create_proxy`, `destroy_proxy`, `is_none`, `to_js`, and `assign`
+
+#### Scenario: FetchPort Protocol definition
+- **WHEN** `webcompy/ports/_fetch.py` is imported
+- **THEN** it SHALL export a `FetchPort` Protocol with an async `request` method accepting `method`, `url`, `headers`, `query_params`, `json`, `body_data`, `form_data`, and `form_element` parameters
+
+### Requirement: Port implementations shall be selected by environment at bootstrap time
+
+`WebComPyApp` SHALL instantiate the appropriate port implementation for each port based on the current environment and provide them into `app.di_scope`. Browser implementations SHALL be used when `ENVIRONMENT == "pyscript"`; server implementations SHALL be used when `ENVIRONMENT == "other"`.
+
+#### Scenario: Ports provided during browser bootstrap
+- **WHEN** `WebComPyApp` is created and `ENVIRONMENT == "pyscript"`
+- **THEN** `BrowserDOMPort`, `BrowserFFIPort`, and `BrowserFetchPort` instances SHALL be provided into `app.di_scope` using `DOM_PORT_KEY`, `FFI_PORT_KEY`, and `FETCH_PORT_KEY`
+- **AND** all ports SHALL be available via `inject()` during rendering
+
+#### Scenario: Ports provided during server bootstrap
+- **WHEN** `WebComPyApp` is created and `ENVIRONMENT == "other"`
+- **THEN** `ServerDOMPort`, `ServerFFIPort`, and `ServerFetchPort` instances SHALL be provided into `app.di_scope`
+- **AND** the DI scope SHALL be entered as a context manager
+
+### Requirement: Browser port implementations shall use pyscript.context and pyscript.ffi
+
+Browser port implementations SHALL access browser APIs through `pyscript.context.document`, `pyscript.context.window`, and `pyscript.ffi` rather than directly importing the `js` module.
+
+#### Scenario: BrowserDOMPort accesses document
+- **WHEN** `BrowserDOMPort.create_element("div")` is called in the browser
+- **THEN** it SHALL delegate to `pyscript.context.document.createElement("div")`
+- **AND** return a `BrowserDOMNode` wrapping the JS element
+
+#### Scenario: BrowserFFIPort creates a proxy
+- **WHEN** `BrowserFFIPort.create_proxy(handler)` is called in the browser
+- **THEN** it SHALL delegate to `pyscript.ffi.create_proxy(handler)`
+- **AND** return the resulting proxy object
+
+#### Scenario: BrowserFetchPort performs a request
+- **WHEN** `BrowserFetchPort.request("GET", url, ...)` is called in the browser
+- **THEN** it SHALL delegate to `pyscript.fetch(url, ...)`
+- **AND** return a `Response` object with `.text`, `.json()`, `.headers`, `.status_code`, `.ok`, and `.raise_for_status()`
+
+### Requirement: Server port implementations shall provide equivalent behavior
+
+Server port implementations SHALL provide the same method signatures and return types as browser implementations for all non-DOM operations. ServerDOMPort SHALL raise descriptive errors for DOM node creation during phase 1, indicating that only HTML string rendering is available.
+
+#### Scenario: ServerFFIPort returns functions as-is
+- **WHEN** `ServerFFIPort.create_proxy(handler)` is called on the server
+- **THEN** it SHALL return `handler` directly without any proxy wrapping
+- **AND** `ServerFFIPort.destroy_proxy(proxy)` SHALL be a no-op
+
+#### Scenario: ServerFetchPort uses httpx
+- **WHEN** `ServerFetchPort.request("GET", url, ...)` is called on the server
+- **THEN** it SHALL perform the request using `httpx.AsyncClient`
+- **AND** return a `Response` object matching the same interface
+
+#### Scenario: ServerDOMPort rejects DOM creation in phase 1
+- **WHEN** `ServerDOMPort.create_element("div")` is called on the server in phase 1
+- **THEN** it SHALL raise `WebComPyException` with a message indicating DOM operations are not available outside the browser
+
+### Requirement: History port shall be internal to the router module
+
+`HistoryPort` SHALL be defined within `webcompy/router/` as an internal abstraction, not in the public `webcompy/ports/` package. It SHALL provide methods `current_path`, `navigate`, `on_popstate`, and `off_popstate`. The browser implementation SHALL use `pyscript.context.window.history` and `pyscript.context.window.location`.
+
+#### Scenario: HistoryPort provides current path in browser
+- **WHEN** `BrowserHistoryPort.current_path` is accessed
+- **THEN** it SHALL return the path from `pyscript.context.window.location.pathname` (history mode) or `pyscript.context.window.location.hash` (hash mode)
+
+#### Scenario: HistoryPort navigates in browser
+- **WHEN** `BrowserHistoryPort.navigate("/new-path", state)` is called
+- **THEN** it SHALL call `pyscript.context.window.history.pushState(state, None, "/new-path")`
+
+#### Scenario: ServerHistoryPort stores path directly
+- **WHEN** `ServerHistoryPort.navigate("/new-path", state)` is called on the server
+- **THEN** it SHALL store the path and state internally
+- **AND** `current_path` SHALL return the stored path
+
+### Requirement: DOMNode Protocol shall have explicit method declarations
+
+`DOMNode` SHALL be a Protocol with explicit method signatures rather than `__getattr__`/`__setattr__` catch-all patterns. This enables dual-environment implementation — `BrowserDOMNode` wrapping a JS DOM node and `VirtualDOMNode` managing an in-memory tree — that satisfy the same Protocol.
+
+#### Scenario: Node tree operations via Protocol
+- **WHEN** framework code calls `parent.appendChild(child)` on a `DOMNode`
+- **THEN** the call SHALL work identically whether `parent` is a `BrowserDOMNode` or `VirtualDOMNode`
+- **AND** no runtime `browser` environment check SHALL be required at the call site
+
+#### Scenario: Attribute operations via Protocol
+- **WHEN** framework code calls `node.setAttribute("id", "foo")` on a `DOMNode`
+- **THEN** the call SHALL work identically across all DOMNode implementations
+
+### Requirement: Framework code shall access ports via inject() or constructor injection
+
+All framework code that currently accesses browser APIs SHALL obtain port references through `inject(PORT_KEY)` from the DI system or through constructor parameter injection, rather than importing `browser` directly.
+
+#### Scenario: Element system accesses DOMPort
+- **WHEN** `ElementBase._create_node()` needs to create a DOM element
+- **THEN** it SHALL call `inject(DOM_PORT_KEY).create_element(self._tag_name)`
+- **AND** not check `if browser:` before the operation
+
+#### Scenario: Signal effect schedules via port
+- **WHEN** `_schedule_effect()` needs to defer effect execution
+- **THEN** it SHALL call `inject(DOM_PORT_KEY).schedule_macro_task(_flush_pending_effects)`
+- **AND** on the server, the callback SHALL execute synchronously
+
+### Requirement: The browser object shall be deprecated but remain accessible
+
+The existing `browser` object SHALL remain accessible via `from webcompy import browser` and `from webcompy._browser import browser` during a deprecation period. Accessing it SHALL emit a `DeprecationWarning` directing users to port APIs. Framework-internal code SHALL NOT import `browser` directly after migration.
+
+#### Scenario: Deprecated browser access
+- **WHEN** application code accesses `from webcompy import browser`
+- **THEN** a `DeprecationWarning` SHALL be emitted
+- **AND** the `browser` object SHALL still function as before

--- a/openspec/changes/feat-port-abstraction/tasks.md
+++ b/openspec/changes/feat-port-abstraction/tasks.md
@@ -45,7 +45,7 @@
 - [ ] 8.1 Migrate `webcompy/elements/types/_element.py` — replace `from webcompy._browser._modules import browser` with `inject(DOM_PORT_KEY)` and `inject(FFI_PORT_KEY)` for DOM operations and event proxy creation/destruction. Refactor `_generate_event_handler()` to use `inject(FFI_PORT_KEY).create_proxy(event_handler)` instead of `browser.pyscript.ffi.create_proxy(event_handler)`
 - [ ] 8.2 Migrate `webcompy/elements/types/_text.py` — use `dom_port.create_text_node()` and `dom_port.create_element("br")`, remove only Pattern A `else: raise WebComPyException` guards (in `_init_node()` and `_create_node()`); keep `_update_text()` server branch (Pattern B) unchanged — it is addressed in `feat-virtual-dom`
 - [ ] 8.3 Migrate `webcompy/elements/types/_abstract.py` — use `dom_port.create_text_node("")` for placeholder node creation in `_detach_node`
-- [ ] 8.4 Migrate `webcompy/elements/types/_switch.py` — use `dom_port.schedule_macro_task()` instead of `browser.window.setTimeout`
+- [ ] 8.4 Migrate `webcompy/elements/types/_switch.py` — use `dom_port.schedule_macro_task()` instead of `browser.window.setTimeout`, and replace `browser is not None` truthiness checks (lines 71, 77) with `ENVIRONMENT == "pyscript"` from `webcompy.utils`
 - [ ] 8.5 Migrate `webcompy/elements/types/_repeat.py` — use `inject(DOM_PORT_KEY)` for `browser` truthiness checks
 - [ ] 8.6 Migrate `webcompy/elements/types/_dynamic.py` — remove `browser` import, use port injection
 

--- a/openspec/changes/feat-port-abstraction/tasks.md
+++ b/openspec/changes/feat-port-abstraction/tasks.md
@@ -2,7 +2,7 @@
 
 - [ ] 1.1 Create `webcompy/ports/` package structure with `__init__.py` and sub-package directories (`_browser/`, `_server/`)
 - [ ] 1.2 Add `httpx` as production dependency via `uv add httpx`
-- [ ] 1.3 Define `DOMNode` Protocol in `webcompy/ports/_dom.py` with explicit method signatures: `appendChild`, `insertBefore`, `replaceChild`, `removeChild`, `remove`, `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`, `addEventListener`, `removeEventListener`, `textContent`, `nodeName`, `nodeType`, `childNodes`, `__webcompy_node__`
+- [ ] 1.3 Define `DOMNode` and `DOMNodeList` Protocol in `webcompy/ports/_dom.py` with explicit method signatures: `appendChild`, `insertBefore`, `replaceChild`, `removeChild`, `remove`, `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`, `addEventListener` (with `capture=False`), `removeEventListener`, `textContent`, `nodeName`, `nodeType`, `childNodes` (returns `DOMNodeList` with `.length` and `__getitem__`), `__webcompy_node__`
 
 ## 2. DOMPort Protocol and implementations
 
@@ -32,7 +32,7 @@
 ## 6. DI keys and bootstrap wiring
 
 - [ ] 6.1 Define DI keys in `webcompy/ports/_keys.py`: `DOM_PORT_KEY`, `FFI_PORT_KEY`, `FETCH_PORT_KEY`
-- [ ] 6.2 Define internal `HISTORY_PORT_KEY` in `webcompy/router/_keys.py` (alongside existing `_ROUTER_KEY`)
+- [ ] 6.2 Define internal `HISTORY_PORT_KEY` in `webcompy/router/_keys.py` (alongside existing keys in that module)
 - [ ] 6.3 Wire port instantiation into `WebComPyApp.__init__` — create and provide all port implementations based on `ENVIRONMENT`, use existing `self._di_scope.provide()` pattern
 
 ## 7. Public API surface
@@ -42,7 +42,7 @@
 
 ## 8. Migrate element system
 
-- [ ] 8.1 Migrate `webcompy/elements/types/_element.py` — replace `from webcompy._browser._modules import browser` with `inject(DOM_PORT_KEY)` and `inject(FFI_PORT_KEY)` for DOM operations and event proxy creation/destruction
+- [ ] 8.1 Migrate `webcompy/elements/types/_element.py` — replace `from webcompy._browser._modules import browser` with `inject(DOM_PORT_KEY)` and `inject(FFI_PORT_KEY)` for DOM operations and event proxy creation/destruction. Refactor `_generate_event_handler()` to use `inject(FFI_PORT_KEY).create_proxy(event_handler)` instead of `browser.pyscript.ffi.create_proxy(event_handler)`
 - [ ] 8.2 Migrate `webcompy/elements/types/_text.py` — use `dom_port.create_text_node()` and `dom_port.create_element("br")`, remove `browser` guards
 - [ ] 8.3 Migrate `webcompy/elements/types/_abstract.py` — use `dom_port.create_text_node("")` for placeholder node creation in `_detach_node`
 - [ ] 8.4 Migrate `webcompy/elements/types/_switch.py` — use `dom_port.schedule_macro_task()` instead of `browser.window.setTimeout`
@@ -68,13 +68,18 @@
 
 ## 11. Migrate ajax (HttpClient → FetchPort)
 
-- [ ] 11.1 Refactor `webcompy/ajax/_fetch.py` — `HttpClient` methods delegate to `inject(FETCH_PORT_KEY).request()`, remove direct `browser.fetch` and `browser.pyscript.ffi` usage
-- [ ] 11.2 Move `Response` and `WebComPyHttpClientException` to `webcompy/ports/_fetch.py` (single source of truth); `ajax/_fetch.py` re-exports from there
+- [ ] 11.1 Move `Response` class and `WebComPyHttpClientException` to `webcompy/ports/_fetch.py` — these are shared types used by both BrowserFetchPort and ServerFetchPort
+- [ ] 11.2 Move all browser-specific fetch logic into `BrowserFetchPort.request()` — JSON serialization, `Content-Type` header, `FormData.new()` construction, `DomNodeRef` form element extraction, `pyscript.fetch` delegation, response header extraction, proxy cleanup
+- [ ] 11.3 Move server-side fetch logic into `ServerFetchPort.request()` — query param encoding, JSON serialization, `httpx.AsyncClient` delegation, response header extraction; raise `NotImplementedError` for `form_element` parameter (browser-only feature)
+- [ ] 11.4 Refactor `HttpClient` classmethods in `webcompy/ajax/_fetch.py` to delegate to `inject(FETCH_PORT_KEY).request()` — each method (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) passes its parameters through
+- [ ] 11.5 Update `webcompy/ajax/__init__.py` to re-export `Response` and `WebComPyHttpClientException` from `webcompy/ports/_fetch.py`
 
 ## 12. Deprecate browser object
 
 - [ ] 12.1 Add deprecation mechanism — `webcompy/_browser/_modules.py` emits `DeprecationWarning` on import when accessed from non-port code (keep existing `browser` functionality intact during deprecation period)
-- [ ] 12.2 Update `webcompy/__init__.py` `browser` export to go through deprecation-aware import path
+- [ ] 12.2 Update `webcompy/__init__.py` `browser` export to go through deprecation-aware import path; remove `browser` from `__all__` or mark as deprecated with a trailing comment
+- [ ] 12.3 Remove legacy `webcompy/_browser/_pyscript/` module after all consumers are migrated — the `browser` shim in `_modules.py` can remain but should delegate to ports internally
+- [ ] 12.4 Update `webcompy/_browser/_modules.pyi` type stub — mark `browser` as deprecated, keep type information for backward compatibility
 
 ## 13. Tests
 
@@ -85,7 +90,8 @@
 - [ ] 13.5 Write tests for `ServerFetchPort` HTTP request delegation through `httpx`
 - [ ] 13.6 Write tests for element system with `MockDOMPort` injected — verify correct DOM API calls during rendering
 - [ ] 13.7 Write tests for router `Location` with `MockFFIPort` and `MockHistoryPort` injected
-- [ ] 13.8 Run existing test suite and fix regressions
+- [ ] 13.8 Run existing test suite: `uv run python -m pytest tests/ --tb=short`
+- [ ] 13.9 Identify and fix test regressions caused by port migration — expected breakage: direct `browser` imports in tests, element creation without active DI scope, tests that call `_render_html()` directly
 
 ## 14. Verification
 

--- a/openspec/changes/feat-port-abstraction/tasks.md
+++ b/openspec/changes/feat-port-abstraction/tasks.md
@@ -43,7 +43,7 @@
 ## 8. Migrate element system
 
 - [ ] 8.1 Migrate `webcompy/elements/types/_element.py` — replace `from webcompy._browser._modules import browser` with `inject(DOM_PORT_KEY)` and `inject(FFI_PORT_KEY)` for DOM operations and event proxy creation/destruction. Refactor `_generate_event_handler()` to use `inject(FFI_PORT_KEY).create_proxy(event_handler)` instead of `browser.pyscript.ffi.create_proxy(event_handler)`
-- [ ] 8.2 Migrate `webcompy/elements/types/_text.py` — use `dom_port.create_text_node()` and `dom_port.create_element("br")`, remove `browser` guards
+- [ ] 8.2 Migrate `webcompy/elements/types/_text.py` — use `dom_port.create_text_node()` and `dom_port.create_element("br")`, remove only Pattern A `else: raise WebComPyException` guards (in `_init_node()` and `_create_node()`); keep `_update_text()` server branch (Pattern B) unchanged — it is addressed in `feat-virtual-dom`
 - [ ] 8.3 Migrate `webcompy/elements/types/_abstract.py` — use `dom_port.create_text_node("")` for placeholder node creation in `_detach_node`
 - [ ] 8.4 Migrate `webcompy/elements/types/_switch.py` — use `dom_port.schedule_macro_task()` instead of `browser.window.setTimeout`
 - [ ] 8.5 Migrate `webcompy/elements/types/_repeat.py` — use `inject(DOM_PORT_KEY)` for `browser` truthiness checks

--- a/openspec/changes/feat-port-abstraction/tasks.md
+++ b/openspec/changes/feat-port-abstraction/tasks.md
@@ -1,0 +1,95 @@
+## 1. Package scaffolding and DOMNode Protocol
+
+- [ ] 1.1 Create `webcompy/ports/` package structure with `__init__.py` and sub-package directories (`_browser/`, `_server/`)
+- [ ] 1.2 Add `httpx` as production dependency via `uv add httpx`
+- [ ] 1.3 Define `DOMNode` Protocol in `webcompy/ports/_dom.py` with explicit method signatures: `appendChild`, `insertBefore`, `replaceChild`, `removeChild`, `remove`, `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`, `addEventListener`, `removeEventListener`, `textContent`, `nodeName`, `nodeType`, `childNodes`, `__webcompy_node__`
+
+## 2. DOMPort Protocol and implementations
+
+- [ ] 2.1 Define `DOMPort` Protocol in `webcompy/ports/_dom.py` with methods: `create_element`, `create_text_node`, `query_selector`, `get_element_by_id`, `set_title`, `schedule_macro_task`
+- [ ] 2.2 Implement `BrowserDOMNode` in `webcompy/ports/_browser/_dom.py` — thin adapter wrapping a JS DOM node, delegating all Protocol methods to the underlying JS object
+- [ ] 2.3 Implement `BrowserDOMPort` in `webcompy/ports/_browser/_dom.py` — factory creating `BrowserDOMNode` instances via `pyscript.context.document`, query methods, `set_title`, and `schedule_macro_task` via `pyscript.context.window.setTimeout`
+- [ ] 2.4 Implement `ServerDOMPort` in `webcompy/ports/_server/_dom.py` (phase 1) — `create_element` and `create_text_node` raise descriptive `WebComPyException`, `query_selector` and `get_element_by_id` return `None`, `set_title` is no-op, `schedule_macro_task` executes callback synchronously
+
+## 3. FFIPort Protocol and implementations
+
+- [ ] 3.1 Define `FFIPort` Protocol in `webcompy/ports/_ffi.py` with methods: `create_proxy`, `destroy_proxy`, `is_none`, `to_js`, `assign`
+- [ ] 3.2 Implement `BrowserFFIPort` in `webcompy/ports/_browser/_ffi.py` — delegates to `pyscript.ffi.create_proxy`, `pyscript.ffi.is_none`, `pyscript.ffi.to_js`, `pyscript.ffi.assign`, and calls `.destroy()` on proxies
+- [ ] 3.3 Implement `ServerFFIPort` in `webcompy/ports/_server/_ffi.py` — `create_proxy` returns the function as-is, `destroy_proxy` is no-op, `is_none` checks Python `None`, `to_js` returns value unchanged, `assign` merges dicts
+
+## 4. FetchPort Protocol and implementations
+
+- [ ] 4.1 Define `FetchPort` Protocol in `webcompy/ports/_fetch.py` with async `request` method accepting `method`, `url`, `headers`, `query_params`, `json`, `body_data`, `form_data`, `form_element` parameters
+- [ ] 4.2 Implement `BrowserFetchPort` in `webcompy/ports/_browser/_fetch.py` — delegates to `pyscript.fetch`, handles JSON serialization, `FormData` construction, query param encoding, returns existing `Response` wrapper
+- [ ] 4.3 Implement `ServerFetchPort` in `webcompy/ports/_server/_fetch.py` — delegates to `httpx.AsyncClient`, returns same `Response` wrapper, raises on `form_element` (browser-only feature)
+
+## 5. HistoryPort (router-internal)
+
+- [ ] 5.1 Define `HistoryPort` Protocol in `webcompy/router/_history_port.py` with methods: `current_path`, `current_search`, `navigate`, `on_popstate`, `off_popstate`, `state` (property)
+- [ ] 5.2 Implement `BrowserHistoryPort` in `webcompy/router/_browser_history.py` — delegates to `pyscript.context.window.history` and `pyscript.context.window.location`, creates `pyscript.ffi` proxies for popstate listener
+- [ ] 5.3 Implement `ServerHistoryPort` in `webcompy/router/_server_history.py` — stores path in a simple string, `on_popstate`/`off_popstate` are no-ops, `navigate` sets internal state
+
+## 6. DI keys and bootstrap wiring
+
+- [ ] 6.1 Define DI keys in `webcompy/ports/_keys.py`: `DOM_PORT_KEY`, `FFI_PORT_KEY`, `FETCH_PORT_KEY`
+- [ ] 6.2 Define internal `HISTORY_PORT_KEY` in `webcompy/router/_keys.py` (alongside existing `_ROUTER_KEY`)
+- [ ] 6.3 Wire port instantiation into `WebComPyApp.__init__` — create and provide all port implementations based on `ENVIRONMENT`, use existing `self._di_scope.provide()` pattern
+
+## 7. Public API surface
+
+- [ ] 7.1 Update `webcompy/ports/__init__.py` to re-export `DOMPort`, `FFIPort`, `FetchPort`, `DOMNode`, `Response`, and all DI keys
+- [ ] 7.2 Update `webcompy/__init__.py` to import and export the `ports` module, add port classes/keys to `__all__`
+
+## 8. Migrate element system
+
+- [ ] 8.1 Migrate `webcompy/elements/types/_element.py` — replace `from webcompy._browser._modules import browser` with `inject(DOM_PORT_KEY)` and `inject(FFI_PORT_KEY)` for DOM operations and event proxy creation/destruction
+- [ ] 8.2 Migrate `webcompy/elements/types/_text.py` — use `dom_port.create_text_node()` and `dom_port.create_element("br")`, remove `browser` guards
+- [ ] 8.3 Migrate `webcompy/elements/types/_abstract.py` — use `dom_port.create_text_node("")` for placeholder node creation in `_detach_node`
+- [ ] 8.4 Migrate `webcompy/elements/types/_switch.py` — use `dom_port.schedule_macro_task()` instead of `browser.window.setTimeout`
+- [ ] 8.5 Migrate `webcompy/elements/types/_repeat.py` — use `inject(DOM_PORT_KEY)` for `browser` truthiness checks
+- [ ] 8.6 Migrate `webcompy/elements/types/_dynamic.py` — remove `browser` import, use port injection
+
+## 9. Migrate router module
+
+- [ ] 9.1 Migrate `webcompy/router/_change_event_handler.py` — use injected `FFIPort` and `HistoryPort` instead of direct `browser.pyscript.ffi.*` and `browser.window.*` calls
+- [ ] 9.2 Migrate `webcompy/router/_link.py` — use `HistoryPort.navigate()` instead of `browser.window.history.pushState()` and `browser.window.location.*`
+- [ ] 9.3 Migrate `webcompy/router/_router.py` — use `dom_port.schedule_macro_task()` in `preload_lazy_routes` instead of `browser.window.setTimeout()`
+- [ ] 9.4 Migrate `webcompy/router/_lazy.py` — use port injection for `browser.console.warn` preload error logging
+- [ ] 9.5 Migrate `webcompy/router/_view.py` — use `inject(DOM_PORT_KEY)` instead of `browser` truthiness check
+
+## 10. Migrate app, components, signal, aio, logging
+
+- [ ] 10.1 Migrate `webcompy/app/_root_component.py` — use `dom_port.query_selector()`, `dom_port.get_element_by_id()`, `dom_port.set_title()` instead of `browser.document.*`
+- [ ] 10.2 Migrate `webcompy/app/_app.py` — port providing is done in task 6.3; update `_emit_profile_summary` to use `inject()` instead of direct `browser` import
+- [ ] 10.3 Migrate `webcompy/components/_component.py` — remove `browser` import, use port injection for truthiness check
+- [ ] 10.4 Migrate `webcompy/signal/_effect.py` — use `inject(DOM_PORT_KEY).schedule_macro_task()` instead of `browser.window.setTimeout()`
+- [ ] 10.5 Migrate `webcompy/aio/_aio.py` — remove `browser` import, use `ENVIRONMENT` condition from `webcompy.utils` for asyncio resolver selection
+- [ ] 10.6 Migrate `webcompy/logging.py` — keep `browser` fallback but add deprecation path; logging handler selection unchanged
+
+## 11. Migrate ajax (HttpClient → FetchPort)
+
+- [ ] 11.1 Refactor `webcompy/ajax/_fetch.py` — `HttpClient` methods delegate to `inject(FETCH_PORT_KEY).request()`, remove direct `browser.fetch` and `browser.pyscript.ffi` usage
+- [ ] 11.2 Move `Response` and `WebComPyHttpClientException` to `webcompy/ports/_fetch.py` (single source of truth); `ajax/_fetch.py` re-exports from there
+
+## 12. Deprecate browser object
+
+- [ ] 12.1 Add deprecation mechanism — `webcompy/_browser/_modules.py` emits `DeprecationWarning` on import when accessed from non-port code (keep existing `browser` functionality intact during deprecation period)
+- [ ] 12.2 Update `webcompy/__init__.py` `browser` export to go through deprecation-aware import path
+
+## 13. Tests
+
+- [ ] 13.1 Create `MockDOMPort` and `MockDOMNode` spy implementations in `tests/` — record all operations for assertion
+- [ ] 13.2 Create `MockFFIPort` spy implementation — record `create_proxy`/`destroy_proxy` calls
+- [ ] 13.3 Create `MockFetchPort` spy implementation — record requests and return canned responses
+- [ ] 13.4 Write tests for `BrowserDOMPort` node creation and attribute operations
+- [ ] 13.5 Write tests for `ServerFetchPort` HTTP request delegation through `httpx`
+- [ ] 13.6 Write tests for element system with `MockDOMPort` injected — verify correct DOM API calls during rendering
+- [ ] 13.7 Write tests for router `Location` with `MockFFIPort` and `MockHistoryPort` injected
+- [ ] 13.8 Run existing test suite and fix regressions
+
+## 14. Verification
+
+- [ ] 14.1 Run lint: `uv run ruff check .`
+- [ ] 14.2 Run type check: `uv run pyright`
+- [ ] 14.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 14.4 Verify dev server starts and renders: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/.openspec.yaml
+++ b/openspec/changes/feat-virtual-dom/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -67,11 +67,11 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 **Rationale**: On the server, event listeners are never actually invoked — they're recorded for structural testing. A simple list is sufficient. No FFI proxy wrapping is needed (handled by `ServerFFIPort` which returns functions as-is).
 
-### Decision 6: VirtualDOMNode does not implement removeChild/insertBefore positioning
+### Decision 6: VirtualDOMNode implements all DOMNode tree operations
 
-**Chosen**: `VirtualDOMNode.appendChild()` appends to the children list. `removeChild()` removes by identity from the list. `insertBefore()` and `replaceChild()` are **not implemented** (raise `NotImplementedError` in phase 2).
+**Chosen**: `VirtualDOMNode` implements all `DOMNode` Protocol tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, and `remove`. All are straightforward list operations on the internal `_children` list.
 
-**Rationale**: The current element system never calls `insertBefore` or `replaceChild` on server-side nodes — those are only called during browser DOM reconciliation (`_reconcile_children` in `_repeat.py`). The virtual tree only needs `appendChild` and `removeChild` for tree construction. Adding unused methods adds complexity without value.
+**Rationale**: The `DOMNode` Protocol contract requires these methods, and they are trivial to implement as list operations. `insertBefore(new, ref)` finds `ref` in the children list and inserts `new` before it. `replaceChild(new, old)` replaces `old` with `new` at the same position. Completing the Protocol ensures `VirtualDOMNode` is a compliant implementation and avoids `NotImplementedError` surprises if the element system ever calls these methods on server-side nodes.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -52,14 +52,13 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 **Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted. A class-by-class approach allows side-by-side comparison during migration.
 
-**Migration order within element types:**
+**Migration ordering within element types:**
 1. `_element.py` — standard elements (most complex, self-closing logic)
 2. `_text.py` — text nodes and `<br>` (simple)
 3. `_switch.py` — conditional rendering (delegates to children)
 4. `_repeat.py` — list rendering (delegates to children)
 5. `_dynamic.py` — dynamic elements (delegates)
-6. `_abstract.py` — abstract base (remove abstract `_render_html`)
-7. `_base.py` — remove `_render_html` from concrete base
+6. `_abstract.py` — abstract base (remove abstract `_render_html`, must be last since other classes inherit from it)
 
 ### Decision 5: VirtualDOMNode.event_listeners is a list of (event_name, handler) tuples
 
@@ -72,6 +71,30 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 **Chosen**: `VirtualDOMNode` implements all `DOMNode` Protocol tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, and `remove`. All are straightforward list operations on the internal `_children` list.
 
 **Rationale**: The `DOMNode` Protocol contract requires these methods, and they are trivial to implement as list operations. `insertBefore(new, ref)` finds `ref` in the children list and inserts `new` before it. `replaceChild(new, old)` replaces `old` with `new` at the same position. Completing the Protocol ensures `VirtualDOMNode` is a compliant implementation and avoids `NotImplementedError` surprises if the element system ever calls these methods on server-side nodes.
+
+### Decision 7: cli/_html.py migration — render_html() on ServerDOMPort
+
+**Chosen**: `cli/_html.py`'s `_HtmlElement` is refactored to use `ServerDOMPort.render_html()` instead of calling `self._render_html()`. The `generate_html()` function injects `ServerDOMPort` from the app's DI scope and calls `port.render_html(root_element)` on the constructed virtual tree.
+
+**Rationale**: `_HtmlElement.render_html()` (line 19) currently calls `self._render_html(False, 0)`. After `_render_html()` is removed from base classes, this no longer works. The migration path:
+
+```
+Before: _HtmlElement.render_html() → self._render_html(False, 0)
+After:  ServerDOMPort.render_html(node) → traverses virtual tree, generates HTML
+```
+
+The `generate_html()` function, which has access to the `WebComPyApp` instance, enters the app's DI scope:
+```python
+with app.di_scope:
+    port = inject(DOM_PORT_KEY)
+    root = ... # build element tree (now creates VirtualDOMNodes)
+    html = port.render_html(root)
+```
+
+**Migration ordering**: Remove `_render_html()` from element base classes LAST (after all callers are updated), not first. This is the opposite of Decision 4 in feat-port-abstraction's design — the correct order is:
+1. Implement VirtualDOMNode + ServerDOMPort.render_html() (task 1-2)
+2. Update cli/_html.py to use ServerDOMPort.render_html() (task 5)
+3. THEN remove _render_html() from element classes (tasks 3-4)
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -1,0 +1,80 @@
+## Context
+
+After `feat-port-abstraction`, framework code accesses all browser APIs through injectable port interfaces. `ServerDOMPort` currently raises exceptions on `create_element()` and `create_text_node()`. The server-side rendering path still depends on `_render_html()` methods scattered across every element type class — a completely separate code path from the browser's `render()` → `_mount_node()` flow.
+
+This change replaces the exception-throwing stubs in `ServerDOMPort` with a virtual DOM tree implementation and unifies the two rendering paths into a single `render()` entry point.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Implement `VirtualDOMNode` satisfying the `DOMNode` Protocol with attribute storage, child management, and `__webcompy_node__` marker
+- `ServerDOMPort` returns `VirtualDOMNode` instances from `create_element()` / `create_text_node()`
+- Remove all `_render_html()` methods from element type classes
+- `render()` becomes the single rendering entry point for both environments
+- `ServerDOMPort.render_html(node)` serializes the virtual tree to HTML for SSG
+- Server-side tests can inspect full virtual DOM tree structure
+
+**Non-Goals:**
+- Browser-side virtual DOM or diffing (remains direct DOM manipulation)
+- Performance optimization of virtual tree operations
+- Worker-thread rendering
+- Hydration of virtual trees (only real DOM nodes are hydrated)
+
+## Decisions
+
+### Decision 1: VirtualDOMNode as a concrete class, not a Protocol
+
+**Chosen**: `VirtualDOMNode` is a concrete class implementing the `DOMNode` Protocol. `BrowserDOMNode` wraps a JS proxy. Both satisfy the same Protocol.
+
+**Rationale**: The Protocol is the contract; implementations are concrete. `VirtualDOMNode` needs mutable state (children list, attribute dict, parent reference) that benefits from a concrete implementation. Making it another Protocol would require mock implementations for tests of the mock, creating infinite regress.
+
+### Decision 2: HTML serialization lives on ServerDOMPort, not VirtualDOMNode
+
+**Chosen**: `ServerDOMPort.render_html(node: DOMNode) -> str` traverses the virtual tree and generates HTML. `VirtualDOMNode` itself has no `to_html()` method.
+
+**Rationale**: HTML formatting concerns (indentation, self-closing tags, attribute escaping, newlines) are serialization logic, not tree structure logic. Keeping serialization on the port allows different serialization strategies (pretty-printed for debugging, minified for production) without modifying the node class. This also keeps `VirtualDOMNode` focused purely on being a DOM tree.
+
+### Decision 3: render() path unification — browser and server share init flow
+
+**Chosen**: Both browser and server execute the same `render()` call chain:
+```
+render() → _mount_node() → _get_node() → _init_node() → _create_node()
+```
+On the server, `_create_node()` calls `ServerDOMPort.create_element()` which returns a `VirtualDOMNode`. On the browser, it calls `BrowserDOMPort.create_element()` which returns a `BrowserDOMNode`. The rest of the init flow (`_init_new_node`, `_adopt_node`) works identically since both implement `DOMNode`.
+
+**Rationale**: This eliminates the `_render_html()` divergence. The element system no longer needs to know whether it's producing real DOM or virtual DOM — it just calls `dom_port.create_element()` and operates on the returned `DOMNode`.
+
+**Alternative considered**: Keep `_render_html()` alongside virtual DOM. Rejected because maintaining two paths defeats the purpose. The whole point is unification.
+
+### Decision 4: _render_html() removal strategy — one class at a time
+
+**Chosen**: Remove `_render_html()` from the base class first, then each subclass, ensuring the virtual DOM path produces identical HTML output before deletion.
+
+**Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted. A class-by-class approach allows side-by-side comparison during migration.
+
+**Migration order within element types:**
+1. `_element.py` — standard elements (most complex, self-closing logic)
+2. `_text.py` — text nodes and `<br>` (simple)
+3. `_switch.py` — conditional rendering (delegates to children)
+4. `_repeat.py` — list rendering (delegates to children)
+5. `_dynamic.py` — dynamic elements (delegates)
+6. `_abstract.py` — abstract base (remove abstract `_render_html`)
+7. `_base.py` — remove `_render_html` from concrete base
+
+### Decision 5: VirtualDOMNode.event_listeners is a list of (event_name, handler) tuples
+
+**Chosen**: Store event listeners as `list[tuple[str, Callable]]` on `VirtualDOMNode`. `addEventListener` appends, `removeEventListener` removes by identity.
+
+**Rationale**: On the server, event listeners are never actually invoked — they're recorded for structural testing. A simple list is sufficient. No FFI proxy wrapping is needed (handled by `ServerFFIPort` which returns functions as-is).
+
+### Decision 6: VirtualDOMNode does not implement removeChild/insertBefore positioning
+
+**Chosen**: `VirtualDOMNode.appendChild()` appends to the children list. `removeChild()` removes by identity from the list. `insertBefore()` and `replaceChild()` are **not implemented** (raise `NotImplementedError` in phase 2).
+
+**Rationale**: The current element system never calls `insertBefore` or `replaceChild` on server-side nodes — those are only called during browser DOM reconciliation (`_reconcile_children` in `_repeat.py`). The virtual tree only needs `appendChild` and `removeChild` for tree construction. Adding unused methods adds complexity without value.
+
+## Risks / Trade-offs
+
+- **[HTML output divergence]** ServerDOMPort.render_html() might produce different HTML than the old _render_html() methods. → Mitigation: generate docs_app with both old and new paths, diff the output, fix discrepancies before deleting _render_html().
+- **[Virtual tree memory]** Large pages build full in-memory trees before serialization. → Trade-off accepted: SSG renders one page at a time, tree fits in memory. Equivalent to the string concatenation approach.
+- **[Protocol compliance]** VirtualDOMNode must match DOMNode Protocol exactly — any mismatch breaks the unified render path. → Mitigation: type checker (`pyright`) validates Protocol conformance at development time.

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -46,19 +46,16 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 **Alternative considered**: Keep `_render_html()` alongside virtual DOM. Rejected because maintaining two paths defeats the purpose. The whole point is unification.
 
-### Decision 4: _render_html() removal strategy — one class at a time
+### Decision 4: _render_html() removal strategy — implement virtual DOM first, remove old methods last
 
-**Chosen**: Remove `_render_html()` from the base class first, then each subclass, ensuring the virtual DOM path produces identical HTML output before deletion.
+**Chosen**: Implement `VirtualDOMNode` and `ServerDOMPort.render_html()`, update callers (`cli/_html.py`), then remove `_render_html()` from element base classes last. Ensure the virtual DOM path produces identical HTML output before deletion.
 
-**Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted. A class-by-class approach allows side-by-side comparison during migration.
+**Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted.
 
-**Migration ordering within element types:**
-1. `_element.py` — standard elements (most complex, self-closing logic)
-2. `_text.py` — text nodes and `<br>` (simple)
-3. `_switch.py` — conditional rendering (delegates to children)
-4. `_repeat.py` — list rendering (delegates to children)
-5. `_dynamic.py` — dynamic elements (delegates)
-6. `_abstract.py` — abstract base (remove abstract `_render_html`, must be last since other classes inherit from it)
+**Correct migration ordering:**
+1. Implement `VirtualDOMNode` + `ServerDOMPort.render_html()` (tasks 1-2)
+2. Update `cli/_html.py` to use `ServerDOMPort.render_html()` (task 5)
+3. THEN remove `_render_html()` from element classes — subclasses first (`_text.py`, `_dynamic.py`), base classes last (`_base.py`, `_abstract.py`) (tasks 3-4)
 
 ### Decision 5: VirtualDOMNode.event_listeners is a list of (event_name, handler) tuples
 

--- a/openspec/changes/feat-virtual-dom/proposal.md
+++ b/openspec/changes/feat-virtual-dom/proposal.md
@@ -6,7 +6,7 @@ Currently, server-side rendering uses a parallel code path (`_render_html()`) th
 
 - **NEW** `VirtualDOMNode` class satisfying the `DOMNode` Protocol — an in-memory DOM tree node with attribute storage, child management, and HTML serialization
 - **MODIFIED** `ServerDOMPort` — replaces exception-throwing stubs with `VirtualDOMNode` factory methods; `create_element()` returns a `VirtualDOMNode`, `create_text_node()` returns a virtual text node
-- **REMOVED** `_render_html()` methods across all element types (`_abstract.py`, `_element.py`, `_text.py`, `_switch.py`, `_repeat.py`, `_dynamic.py`, `_base.py`) — replaced by `render()` + `ServerDOMPort`
+- **REMOVED** `_render_html()` methods from element types (`_abstract.py`, `_base.py`, `_text.py`, `_dynamic.py`) — replaced by `render()` + `ServerDOMPort`
 - **MODIFIED** `render()` path becomes the single unified rendering entry point in both environments
 - **MODIFIED** Server-side rendering tests can validate full DOM tree structure (attribute values, child ordering, text content) instead of just HTML string comparison
 - **NEW** `ServerDOMPort` provides `render_html(node)` method that serializes the virtual tree to an HTML string
@@ -35,7 +35,7 @@ Currently, server-side rendering uses a parallel code path (`_render_html()`) th
 
 ## Impact
 
-- **Affected modules**: `webcompy/ports/_server/_dom.py` (major rewrite), all 8 element type files (remove `_render_html()`), `webcompy/elements/` (unified render path), existing SSG tests (migrate from string comparison to tree inspection)
+- **Affected modules**: `webcompy/ports/_server/_dom.py` (major rewrite), element types with `_render_html()` (`_abstract.py`, `_base.py`, `_text.py`, `_dynamic.py`), `webcompy/cli/_html.py` (caller), existing SSG tests (migrate from string comparison to tree inspection)
 - **Breaking**: `_render_html()` is **REMOVED** — any code calling it externally must migrate to `ServerDOMPort.render_html(node)`
 - **Dependency**: Requires `feat-port-abstraction` to be completed first (depends on `DOMNode` Protocol and `DOMPort.do` interface)
 - **Testing**: Server-side rendering tests gain ability to assert exact DOM tree shape instead of fragile HTML string matching

--- a/openspec/changes/feat-virtual-dom/proposal.md
+++ b/openspec/changes/feat-virtual-dom/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+Currently, server-side rendering uses a parallel code path (`_render_html()`) that generates HTML strings directly, completely separate from the browser's DOM creation path (`_create_node()` / `_mount_node()`). After port abstraction (`feat-port-abstraction`), `ServerDOMPort` merely raises exceptions on DOM operations. This change completes the abstraction by implementing a virtual DOM tree on the server side, unifying both rendering paths through `render()`, and replacing `_render_html()` entirely.
+
+## What Changes
+
+- **NEW** `VirtualDOMNode` class satisfying the `DOMNode` Protocol — an in-memory DOM tree node with attribute storage, child management, and HTML serialization
+- **MODIFIED** `ServerDOMPort` — replaces exception-throwing stubs with `VirtualDOMNode` factory methods; `create_element()` returns a `VirtualDOMNode`, `create_text_node()` returns a virtual text node
+- **REMOVED** `_render_html()` methods across all element types (`_abstract.py`, `_element.py`, `_text.py`, `_switch.py`, `_repeat.py`, `_dynamic.py`, `_base.py`) — replaced by `render()` + `ServerDOMPort`
+- **MODIFIED** `render()` path becomes the single unified rendering entry point in both environments
+- **MODIFIED** Server-side rendering tests can validate full DOM tree structure (attribute values, child ordering, text content) instead of just HTML string comparison
+- **NEW** `ServerDOMPort` provides `render_html(node)` method that serializes the virtual tree to an HTML string
+
+## Capabilities
+
+### New Capabilities
+
+- `virtual-dom`: Server-side virtual DOM tree constructed via `ServerDOMPort.create_element()` / `ServerDOMPort.create_text_node()`, satisfying the `DOMNode` Protocol identically to browser nodes. The tree can be serialized to HTML and inspected in tests for exact DOM structure.
+
+### Modified Capabilities
+
+- `elements`: The dual rendering path (`_render()` for browser DOM, `_render_html()` for server HTML) SHALL be unified into a single `render()` entry point. All element types SHALL remove `_render_html()`. Server-side HTML generation SHALL be handled by `ServerDOMPort.render_html()`. Element system no longer has knowledge of HTML string formatting (indentation, newlines).
+
+- `port-abstraction` (from `feat-port-abstraction` change): `ServerDOMPort` SHALL change from exception-throwing phase-1 stubs to full virtual DOM tree construction. `ServerDOMPort.create_element()` SHALL return a `VirtualDOMNode`. `ServerDOMPort.render_html(node)` SHALL serialize a virtual tree to HTML.
+
+## Known Issues Addressed
+
+- **No virtual DOM diffing** — this change introduces a virtual DOM tree for server-side *construction*, not diffing. Browser-side still uses direct DOM manipulation. The virtual DOM serves as a testable representation, not a diffing algorithm.
+
+## Non-goals
+
+- Browser-side virtual DOM diffing (remains direct DOM manipulation)
+- Incremental/patch-based SSR updates (full tree rebuild per render)
+- Worker thread rendering (virtual DOM builds in main server thread only)
+
+## Impact
+
+- **Affected modules**: `webcompy/ports/_server/_dom.py` (major rewrite), all 8 element type files (remove `_render_html()`), `webcompy/elements/` (unified render path), existing SSG tests (migrate from string comparison to tree inspection)
+- **Breaking**: `_render_html()` is **REMOVED** — any code calling it externally must migrate to `ServerDOMPort.render_html(node)`
+- **Dependency**: Requires `feat-port-abstraction` to be completed first (depends on `DOMNode` Protocol and `DOMPort.do` interface)
+- **Testing**: Server-side rendering tests gain ability to assert exact DOM tree shape instead of fragile HTML string matching

--- a/openspec/changes/feat-virtual-dom/specs/elements/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/elements/spec.md
@@ -1,0 +1,28 @@
+# Elements (Virtual DOM) (delta)
+
+## ADDED Requirements
+
+### Requirement: Rendering shall use a single unified code path in both environments
+
+All element types SHALL use the same `render()` → `_get_node()` → `_init_node()` → `_create_node()` call chain regardless of environment. On the browser, `_create_node()` SHALL delegate to `BrowserDOMPort.create_element()` which returns a `BrowserDOMNode`. On the server, `_create_node()` SHALL delegate to `ServerDOMPort.create_element()` which returns a `VirtualDOMNode`. All subsequent operations (attribute setting, child appending, event listener registration) SHALL work identically through the `DOMNode` Protocol on both implementations.
+
+#### Scenario: Rendering a div in the browser
+- **WHEN** `element.render()` is called in the browser
+- **THEN** `_create_node()` SHALL call `BrowserDOMPort.create_element("div")`
+- **AND** return a `BrowserDOMNode` wrapping a real JS DOM element
+- **AND** `_init_new_node()` SHALL set attributes and event listeners on the returned node
+
+#### Scenario: Rendering a div on the server
+- **WHEN** `element.render()` is called on the server
+- **THEN** `_create_node()` SHALL call `ServerDOMPort.create_element("div")`
+- **AND** return a `VirtualDOMNode` with `nodeName == "DIV"`
+- **AND** `_init_new_node()` SHALL set attributes and event listeners on the returned node
+- **AND** no exception SHALL be raised
+
+## REMOVED Requirements
+
+### Requirement: Elements shall represent DOM nodes and render to HTML strings via _render_html()
+
+**Reason**: The dual rendering path (`render()` for browser DOM, `_render_html()` for server HTML) is unified. Server-side HTML generation is handled by `ServerDOMPort.render_html()` which serializes the virtual DOM tree.
+
+**Migration**: All element types remove their `_render_html()` methods. Callers use `ServerDOMPort.render_html(root_node)` instead. Existing HTML string tests should migrate to virtual DOM tree inspection or retain string comparison against `render_html()` output.

--- a/openspec/changes/feat-virtual-dom/specs/elements/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/elements/spec.md
@@ -21,8 +21,8 @@ All element types SHALL use the same `render()` → `_get_node()` → `_init_nod
 
 ## REMOVED Requirements
 
-### Requirement: Elements shall represent DOM nodes and render to HTML strings via _render_html()
+### Requirement: Elements shall represent DOM nodes and compose into trees
 
-**Reason**: The dual rendering path (`render()` for browser DOM, `_render_html()` for server HTML) is unified. Server-side HTML generation is handled by `ServerDOMPort.render_html()` which serializes the virtual DOM tree.
+**Reason**: The dual rendering path (`_render()` for browser DOM, `_render_html()` for server HTML) is unified into a single `render()` entry point. The requirement that elements "compose into trees" and "are renderable to browser DOM nodes or HTML strings" (existing spec scenario) still holds — the change is that HTML rendering is now handled by `ServerDOMPort.render_html()` instead of per-element `_render_html()` methods.
 
 **Migration**: All element types remove their `_render_html()` methods. Callers use `ServerDOMPort.render_html(root_node)` instead. Existing HTML string tests should migrate to virtual DOM tree inspection or retain string comparison against `render_html()` output.

--- a/openspec/changes/feat-virtual-dom/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/port-abstraction/spec.md
@@ -1,0 +1,19 @@
+# Port Abstraction (delta)
+
+## MODIFIED Requirements
+
+### Requirement: Server port implementations shall provide equivalent behavior
+
+Server port implementations SHALL provide the same method signatures and return types as browser implementations. ServerDOMPort SHALL construct a virtual DOM tree via `VirtualDOMNode` instances instead of raising exceptions. `ServerDOMPort.create_element()` SHALL return a `VirtualDOMNode`. `ServerDOMPort.create_text_node()` SHALL return a virtual text node. `ServerDOMPort.query_selector()` and `get_element_by_id()` SHALL return `None` (SSG does not query existing DOM). `ServerDOMPort.set_title()` SHALL be a no-op. `ServerDOMPort.schedule_macro_task()` SHALL execute the callback synchronously.
+
+ServerDOMPort SHALL additionally provide `render_html(node: DOMNode) -> str` for serializing virtual trees to HTML strings.
+
+#### Scenario: ServerDOMPort creates elements for virtual tree
+- **WHEN** `ServerDOMPort.create_element("div")` is called on the server
+- **THEN** a `VirtualDOMNode` SHALL be returned instead of raising an exception
+- **AND** the node SHALL have `nodeName == "DIV"` and `nodeType == 1`
+
+#### Scenario: ServerDOMPort serializes virtual tree to HTML
+- **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual tree
+- **THEN** a valid HTML string SHALL be returned
+- **AND** void elements SHALL be self-closing and text SHALL be escaped

--- a/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
@@ -26,12 +26,21 @@ The virtual tree can be serialized to HTML for static site generation and inspec
 
 ### Requirement: VirtualDOMNode tree operations shall match DOM semantics
 
-`VirtualDOMNode.appendChild(child)` SHALL append `child` to the node's children list. `childNodes` SHALL return the list of child nodes. `removeChild(child)` SHALL remove `child` from the children list by identity. `remove()` SHALL remove the node from its parent's children.
+`VirtualDOMNode.appendChild(child)` SHALL append `child` to the node's children list. `insertBefore(new, ref)` SHALL insert `new` before `ref` in the children list. `replaceChild(new, old)` SHALL replace `old` with `new` at the same position. `removeChild(child)` SHALL remove `child` from the children list by identity. `remove()` SHALL remove the node from its parent's children. `childNodes` SHALL return the list of child nodes.
 
 #### Scenario: Building a virtual tree
 - **WHEN** `parent.appendChild(child1)` and `parent.appendChild(child2)` are called on a `VirtualDOMNode`
 - **THEN** `parent.childNodes` SHALL contain `[child1, child2]` in order
 - **AND** `child1` and `child2` SHALL have their `_parent` reference pointing to `parent`
+
+#### Scenario: Inserting before a reference node
+- **WHEN** `parent.insertBefore(child3, child2)` is called
+- **THEN** `parent.childNodes` SHALL contain `[child1, child3, child2]` in order
+
+#### Scenario: Replacing a child node
+- **WHEN** `parent.replaceChild(new_child, child1)` is called
+- **THEN** `new_child` SHALL occupy `child1`'s original position in `parent.childNodes`
+- **AND** `parent.childNodes` SHALL no longer contain `child1`
 
 #### Scenario: Removing a child from the virtual tree
 - **WHEN** `parent.removeChild(child1)` is called

--- a/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
@@ -1,0 +1,90 @@
+# Virtual DOM
+
+## Purpose
+
+WebComPy uses a `DOMNode` Protocol to abstract DOM operations. In the browser, `BrowserDOMNode` wraps a real JavaScript DOM node. On the server, `VirtualDOMNode` builds an in-memory DOM tree that satisfies the same Protocol. This enables a single rendering code path that works identically in both environments — the element system calls `dom_port.create_element()` and operates on the returned `DOMNode` without knowing whether it's real or virtual.
+
+The virtual tree can be serialized to HTML for static site generation and inspected in tests to verify exact DOM structure.
+
+## ADDED Requirements
+
+### Requirement: VirtualDOMNode shall satisfy the DOMNode Protocol
+
+`VirtualDOMNode` SHALL be a concrete class that satisfies the `DOMNode` Protocol. It SHALL store tag name, attributes, children, event listeners, text content, and `__webcompy_node__` marker in Python data structures without any browser API access.
+
+#### Scenario: Creating a virtual element node
+- **WHEN** `ServerDOMPort.create_element("div")` is called
+- **THEN** a `VirtualDOMNode` with `nodeName == "DIV"` SHALL be returned
+- **AND** `nodeType == 1` (element node)
+- **AND** `__webcompy_node__ == True`
+
+#### Scenario: Creating a virtual text node
+- **WHEN** `ServerDOMPort.create_text_node("hello")` is called
+- **THEN** a `VirtualDOMNode` with `nodeName == "#text"` SHALL be returned
+- **AND** `textContent == "hello"`
+- **AND** `nodeType == 3` (text node)
+
+### Requirement: VirtualDOMNode tree operations shall match DOM semantics
+
+`VirtualDOMNode.appendChild(child)` SHALL append `child` to the node's children list. `childNodes` SHALL return the list of child nodes. `removeChild(child)` SHALL remove `child` from the children list by identity. `remove()` SHALL remove the node from its parent's children.
+
+#### Scenario: Building a virtual tree
+- **WHEN** `parent.appendChild(child1)` and `parent.appendChild(child2)` are called on a `VirtualDOMNode`
+- **THEN** `parent.childNodes` SHALL contain `[child1, child2]` in order
+- **AND** `child1` and `child2` SHALL have their `_parent` reference pointing to `parent`
+
+#### Scenario: Removing a child from the virtual tree
+- **WHEN** `parent.removeChild(child1)` is called
+- **THEN** `parent.childNodes` SHALL no longer contain `child1`
+
+#### Scenario: Removing a node from its parent
+- **WHEN** `child.remove()` is called
+- **THEN** `child` SHALL be removed from its parent's `childNodes`
+
+### Requirement: VirtualDOMNode shall store attributes and events
+
+`VirtualDOMNode.setAttribute(name, value)` SHALL store the attribute. `getAttribute(name)` SHALL return the stored value or `None`. `removeAttribute(name)` SHALL remove it. `hasAttribute(name)` SHALL return `True` if stored. `getAttributeNames()` SHALL return all stored attribute names.
+
+`VirtualDOMNode.addEventListener(event, handler)` SHALL record the event-handler pair. `removeEventListener(event, handler)` SHALL remove it by identity.
+
+#### Scenario: Setting and reading attributes on a virtual node
+- **WHEN** `node.setAttribute("id", "my-id")` is called
+- **THEN** `node.getAttribute("id")` SHALL return `"my-id"`
+- **AND** `node.hasAttribute("id")` SHALL return `True`
+- **AND** `node.getAttributeNames()` SHALL include `"id"`
+
+#### Scenario: Registering event listeners on a virtual node
+- **WHEN** `node.addEventListener("click", handler)` is called
+- **THEN** the handler SHALL be recorded
+- **WHEN** `node.removeEventListener("click", handler)` is called
+- **THEN** the handler SHALL no longer be recorded
+
+### Requirement: ServerDOMPort.render_html() shall serialize VirtualDOMNode trees to HTML
+
+`ServerDOMPort.render_html(node: DOMNode) -> str` SHALL traverse a virtual DOM tree and produce a valid HTML string. Attributes SHALL be HTML-escaped. Text content SHALL be HTML-escaped. Void elements (br, hr, img, input, link, meta, etc.) SHALL be self-closing. The output SHALL match the element system's expected HTML structure.
+
+#### Scenario: Serializing a simple element tree
+- **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual tree with `div > h1("Hello")`
+- **THEN** the output SHALL be `<div><h1>Hello</h1></div>`
+
+#### Scenario: Serializing elements with attributes
+- **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual `<a href="https://example.com">Click</a>`
+- **THEN** the output SHALL include `href="https://example.com"` in the opening tag
+
+#### Scenario: Serializing void elements
+- **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual `<br>` element
+- **THEN** the output SHALL be `<br>` (self-closing, no children)
+
+#### Scenario: HTML-escaping text content
+- **WHEN** a text node contains `<script>alert("xss")</script>`
+- **THEN** `render_html()` SHALL escape `<`, `>`, `&`, `"` characters
+- **AND** the output SHALL NOT contain executable HTML
+
+### Requirement: VirtualDOMNode shall not require FFI proxy wrapping
+
+Event handlers stored on `VirtualDOMNode` SHALL be plain Python callables without FFI proxy wrapping. `ServerFFIPort.create_proxy(handler)` SHALL return `handler` directly. `ServerFFIPort.destroy_proxy()` SHALL be a no-op.
+
+#### Scenario: Event handler on server-side node uses plain callable
+- **WHEN** `node.addEventListener("click", my_handler)` is called on a `VirtualDOMNode`
+- **THEN** `my_handler` SHALL be stored as-is without `create_proxy` wrapping
+- **AND** the handler SHALL be inspectable in tests

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -21,6 +21,7 @@
 - [ ] 3.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
 - [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
 - [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
+- [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
 
 ## 4. Remove _render_html() from element subclasses
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -36,7 +36,6 @@
 
 - [ ] 6.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
 - [ ] 6.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
-- [ ] 6.3 Remove the `else: raise WebComPyException` branch from `_detach_node()` (`_abstract.py:59-60`) — the unified path always creates nodes via `inject(DOM_PORT_KEY)` regardless of environment
 
 ## 7. Tests
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -23,6 +23,7 @@
 - [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
 - [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
 - [ ] 3.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
+- [ ] 3.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
 
 ## 4. Remove _render_html() from element subclasses
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -1,0 +1,65 @@
+## 1. VirtualDOMNode implementation
+
+- [ ] 1.1 Create `webcompy/ports/_server/_virtual_dom.py` with `VirtualDOMNode` class satisfying `DOMNode` Protocol — store `tag_name`, `attributes: dict`, `children: list`, `event_listeners: list`, `text_content`, `node_type`, `__webcompy_node__`, `_parent`
+- [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `remove` — manage children list and parent references
+- [ ] 1.3 Implement attribute operations: `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`
+- [ ] 1.4 Implement event operations: `addEventListener`, `removeEventListener` — store as `(event_name, handler)` tuples
+- [ ] 1.5 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)
+
+## 2. ServerDOMPort rewrite
+
+- [ ] 2.1 Rewrite `webcompy/ports/_server/_dom.py` — replace exception-throwing stubs with virtual DOM factory: `create_element()` returns `VirtualDOMNode`, `create_text_node()` returns virtual text node
+- [ ] 2.2 Implement `ServerDOMPort.render_html(node: DOMNode) -> str` — traverse virtual tree, serialize to HTML string
+- [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, self-close void elements (`br`, `hr`, `img`, `input`, `link`, `meta`, `source`, `area`, `base`, `col`, `embed`, `track`, `wbr`), omit `None`-valued attributes
+- [ ] 2.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
+
+## 3. Unify render path in element base classes
+
+- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py`
+- [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
+- [ ] 3.3 Update `ElementBase._init_node()` in `_element.py` — remove `else: raise WebComPyException` branch; both browser and server now use `_create_node()` which delegates to `inject(DOM_PORT_KEY)`
+- [ ] 3.4 Update `TextElement._init_node()` in `_text.py` — same unification
+
+## 4. Remove _render_html() from element subclasses
+
+- [ ] 4.1 Remove `_render_html()` from `Element` in `webcompy/elements/types/_element.py`
+- [ ] 4.2 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 4.3 Remove `_render_html()` from `SwitchElement` in `webcompy/elements/types/_switch.py`
+- [ ] 4.4 Remove `_render_html()` from `RepeatElement` in `webcompy/elements/types/_repeat.py`
+- [ ] 4.5 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+
+## 5. Update server-side rendering entry points
+
+- [ ] 5.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
+- [ ] 5.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
+- [ ] 5.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
+
+## 6. Element system adapter for server DOMPort
+
+- [ ] 6.1 In `ElementBase._create_node()`, add `DomNodeRef.__init_node__()` call so virtual nodes can satisfy `DOMNode` contract
+- [ ] 6.2 In `ElementBase._init_new_node()`, verify `setAttribute` / `addEventListener` work on `VirtualDOMNode`
+- [ ] 6.3 Make `DomNodeRef` compatible with `VirtualDOMNode` (current `__init_node__` expects `DOMNode` Protocol — should work)
+
+## 7. Tests
+
+- [ ] 7.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
+- [ ] 7.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
+- [ ] 7.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
+- [ ] 7.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
+- [ ] 7.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
+- [ ] 7.6 Run existing test suite and fix regressions
+
+## 8. Cleanup
+
+- [ ] 8.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 8.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 8.3 Update type stubs if `_render_html` appears in any `.pyi` files
+
+## 9. Verification
+
+- [ ] 9.1 Run lint: `uv run ruff check .`
+- [ ] 9.2 Run type check: `uv run pyright`
+- [ ] 9.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 9.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 9.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 9.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -10,15 +10,16 @@
 
 - [ ] 2.1 Rewrite `webcompy/ports/_server/_dom.py` — replace exception-throwing stubs with virtual DOM factory: `create_element()` returns `VirtualDOMNode`, `create_text_node()` returns virtual text node
 - [ ] 2.2 Implement `ServerDOMPort.render_html(node: DOMNode) -> str` — traverse virtual tree, serialize to HTML string
-- [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, self-close void elements (`br`, `hr`, `img`, `input`, `link`, `meta`, `source`, `area`, `base`, `col`, `embed`, `track`, `wbr`), omit `None`-valued attributes
+- [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, output void elements without closing tags (e.g., `<br>`, `<img>`) per HTML5 convention, omit `None`-valued attributes
 - [ ] 2.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
 
 ## 3. Unify render path in element base classes
 
-- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py`
+- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
 - [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
 - [ ] 3.3 Update `ElementBase._init_node()` in `_element.py` — remove `else: raise WebComPyException` branch; both browser and server now use `_create_node()` which delegates to `inject(DOM_PORT_KEY)`
 - [ ] 3.4 Update `TextElement._init_node()` in `_text.py` — same unification
+- [ ] 3.5 Update `_detach_node()` in `_abstract.py` — remove `else: raise WebComPyException` branch; the unified path calls `dom_port.create_text_node("")` and `parent_node.replaceChild(...)` which works on both BrowserDOMNode (real DOM) and VirtualDOMNode (children list)
 
 ## 4. Remove _render_html() from element subclasses
 
@@ -36,9 +37,9 @@
 
 ## 6. Element system adapter for server DOMPort
 
-- [ ] 6.1 In `ElementBase._create_node()`, add `DomNodeRef.__init_node__()` call so virtual nodes can satisfy `DOMNode` contract
-- [ ] 6.2 In `ElementBase._init_new_node()`, verify `setAttribute` / `addEventListener` work on `VirtualDOMNode`
-- [ ] 6.3 Make `DomNodeRef` compatible with `VirtualDOMNode` (current `__init_node__` expects `DOMNode` Protocol — should work)
+- [ ] 6.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
+- [ ] 6.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
+- [ ] 6.3 Remove the `else: raise WebComPyException` branch from `_detach_node()` (`_abstract.py:59-60`) — the unified path always creates nodes via `inject(DOM_PORT_KEY)` regardless of environment
 
 ## 7. Tests
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -1,7 +1,7 @@
 ## 1. VirtualDOMNode implementation
 
 - [ ] 1.1 Create `webcompy/ports/_server/_virtual_dom.py` with `VirtualDOMNode` class satisfying `DOMNode` Protocol — store `tag_name`, `attributes: dict`, `children: list`, `event_listeners: list`, `text_content`, `node_type`, `__webcompy_node__`, `_parent`
-- [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `remove` — manage children list and parent references
+- [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove` — manage children list and parent references
 - [ ] 1.3 Implement attribute operations: `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`
 - [ ] 1.4 Implement event operations: `addEventListener`, `removeEventListener` — store as `(event_name, handler)` tuples
 - [ ] 1.5 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -23,11 +23,8 @@
 
 ## 4. Remove _render_html() from element subclasses
 
-- [ ] 4.1 Remove `_render_html()` from `Element` in `webcompy/elements/types/_element.py`
-- [ ] 4.2 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
-- [ ] 4.3 Remove `_render_html()` from `SwitchElement` in `webcompy/elements/types/_switch.py`
-- [ ] 4.4 Remove `_render_html()` from `RepeatElement` in `webcompy/elements/types/_repeat.py`
-- [ ] 4.5 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+- [ ] 4.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 4.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
 
 ## 5. Update server-side rendering entry points
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -17,9 +17,10 @@
 
 - [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
 - [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
-- [ ] 3.3 Update `ElementBase._init_node()` in `_element.py` — remove `else: raise WebComPyException` branch; both browser and server now use `_create_node()` which delegates to `inject(DOM_PORT_KEY)`
-- [ ] 3.4 Update `TextElement._init_node()` in `_text.py` — same unification
-- [ ] 3.5 Update `_detach_node()` in `_abstract.py` — remove `else: raise WebComPyException` branch; the unified path calls `dom_port.create_text_node("")` and `parent_node.replaceChild(...)` which works on both BrowserDOMNode (real DOM) and VirtualDOMNode (children list)
+- [ ] 3.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
+- [ ] 3.4 Remove `if not browser:` server branches from element `_on_set_parent()` — `_switch.py:84`, `_repeat.py:95`, `_view.py:25`. After virtual DOM unification, `_render()` creates nodes in both environments, making these server-only code paths dead or causing double creation
+- [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
+- [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
 
 ## 4. Remove _render_html() from element subclasses
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -18,7 +18,7 @@
 - [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
 - [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
 - [ ] 3.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
-- [ ] 3.4 Remove `if not browser:` server branches from element `_on_set_parent()` — `_switch.py:84`, `_repeat.py:95`, `_view.py:25`. After virtual DOM unification, `_render()` creates nodes in both environments, making these server-only code paths dead or causing double creation
+- [ ] 3.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
 - [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
 - [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -22,6 +22,7 @@
 - [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
 - [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
 - [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
+- [ ] 3.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
 
 ## 4. Remove _render_html() from element subclasses
 


### PR DESCRIPTION
## Summary
Add OpenSpec change artifacts for two planned changes: `feat-port-abstraction` and `feat-virtual-dom`, which together decouple browser APIs from WebComPy's core logic via injectable port abstractions. This PR contains only planning artifacts (proposal, design, specs, tasks) — no implementation code.

## Changes

### `feat-port-abstraction` (42 tasks)
- `DOMPort` Protocol — DOM node creation/manipulation, event listeners, `setTimeout` abstraction via `schedule_macro_task`
- `FFIPort` Protocol — Python↔JS bridge backed by `pyscript.ffi` (create_proxy, destroy_proxy, is_none, to_js, assign)
- `FetchPort` Protocol — HTTP requests backed by `pyscript.fetch` (browser) and `httpx` (server)
- `HistoryPort` (router-internal) — browser history and location abstraction
- Replace `DOMNode` duck-typing Protocol with explicit method signatures, enabling dual-environment implementations (`BrowserDOMNode` / `VirtualDOMNode`)
- Migrate all 20 files from direct `browser` imports to `inject(PORT_KEY)` DI injection
- Deprecate the `browser` object with a `DeprecationWarning` shim

### `feat-virtual-dom` (32 tasks, depends on `feat-port-abstraction`)
- Implement `VirtualDOMNode` class satisfying the `DOMNode` Protocol
- Rewrite `ServerDOMPort` from exception-throwing stubs to virtual DOM tree factory
- `ServerDOMPort.render_html()` — serialize virtual trees to HTML for SSG
- Remove `_render_html()` from all element types, unifying into a single `render()` path

## Validation
- `openspec validate` — both changes valid ✅
- `npx @fission-ai/openspec@latest validate --changes` — 3/3 passed ✅
- `npx @fission-ai/openspec@latest validate --specs` — 29/29 passed ✅
- Change naming — all conform to `^(feat|fix|...)-\w+` convention ✅

## Notes
- `feat-virtual-dom` depends on `feat-port-abstraction` (must implement first)
- Implementation will proceed in separate PRs following the tasks in each change