### PR TITLE
fix: add retry mechanism when CI review agent fails to write output file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,7 +522,7 @@ jobs:
           _review_ok() {
             [ -s .tmp/review-output.md ] || return 1
             local last
-            last=$(tail -n 1 .tmp/review-output.md)
+            last=$(grep -v '^[[:space:]]*$' .tmp/review-output.md | tail -n 1)
             [ "$last" = "REVIEW_RESULT: approved" ] || [ "$last" = "REVIEW_RESULT: changes_requested" ]
           }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,12 +512,12 @@ jobs:
           If .tmp/review-output.md does not exist when you finish, your work
           will be discarded and the review step will fail.
 
-           STEP-BY-STEP:
-           1. Analyze the diff and write your review
-           2. Call Write tool: filePath=.tmp/review-output.md, content=<your review>
-           3. Call Read tool on .tmp/review-output.md to verify it was written correctly
-           4. Confirm the last line is exactly REVIEW_RESULT: approved or REVIEW_RESULT: changes_requested
-           5. Only then are you truly done — do not stop before step 4"
+          STEP-BY-STEP:
+          1. Analyze the diff and write your review
+          2. Call Write tool: filePath=.tmp/review-output.md, content=<your review>
+          3. Call Read tool on .tmp/review-output.md to verify it was written correctly
+          4. Confirm the last line is exactly REVIEW_RESULT: approved or REVIEW_RESULT: changes_requested
+          5. Only then are you truly done — do not stop before step 4"
 
           _review_ok() {
             [ -s .tmp/review-output.md ] || return 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,9 +460,16 @@ jobs:
           REVIEWED_AT_COMMENT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
             --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | test("REVIEWED_AT:"))] | last.body // empty')
           LAST_SHA=$(echo "$REVIEWED_AT_COMMENT" | sed -n 's/.*REVIEWED_AT: \([a-f0-9]\{40\}\).*/\1/p' | head -1)
+          MERGE_BASE=$(git merge-base HEAD origin/main)
           if [ -n "$LAST_SHA" ] && git cat-file -e "$LAST_SHA" 2>/dev/null; then
-            git diff "$LAST_SHA"..HEAD > .tmp/pr-diff-since-last.txt
-            echo "Incremental diff generated from $LAST_SHA"
+            if git merge-base --is-ancestor "$LAST_SHA" "$MERGE_BASE" 2>/dev/null; then
+              git diff "$LAST_SHA"..HEAD > .tmp/pr-diff-since-last.txt
+              echo "Incremental diff generated from $LAST_SHA"
+            else
+              echo "# Incremental diff unavailable: branch was rebased or merged with main since last review." > .tmp/pr-diff-since-last.txt
+              echo "# Full PR diff is attached separately as .tmp/pr-diff.txt." >> .tmp/pr-diff-since-last.txt
+              echo "Incremental diff skipped — $LAST_SHA is not an ancestor of $MERGE_BASE"
+            fi
           else
             echo "# No REVIEWED_AT marker found in previous bot comments." > .tmp/pr-diff-since-last.txt
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,6 @@ jobs:
 
           MAX_RETRIES=2
           attempt=0
-          FILES="--file .tmp/pr-diff.txt --file .tmp/pr-diff-since-last.txt"
           PROMPT="Review this pull request. Two diff files are attached:
           - .tmp/pr-diff.txt — full diff against the merge base
           - .tmp/pr-diff-since-last.txt — incremental diff since the last CI review (or a note if unavailable)
@@ -526,15 +525,16 @@ jobs:
           You MUST use the Write tool to write ONLY the final review to .tmp/review-output.md."
             fi
 
-            opencode run \
-              --model "openai-compat/$OPENAI_COMPAT_MODEL" \
+            script -q -c "opencode run \
+              --model \"openai-compat/$OPENAI_COMPAT_MODEL\" \
               --agent ci-review \
-              $FILES \
-              --title "PR #$PR_NUMBER Review" \
-              "$PROMPT$RETRY_MSG" \
-              2>&1 | tee .tmp/review-raw-output.txt
+              --file .tmp/pr-diff.txt \
+              --file .tmp/pr-diff-since-last.txt \
+              --title \"PR #$PR_NUMBER Review\" \
+              \"$PROMPT$RETRY_MSG\"" \
+              .tmp/review-raw-output.txt
 
-            if [ -s .tmp/review-output.md ] && grep -q "REVIEW_RESULT:" .tmp/review-output.md; then
+            if [ -s .tmp/review-output.md ] && grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
               echo "::notice::Review output written on attempt $attempt"
               break
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-      issues: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
       id-token: write
       contents: read
       pull-requests: write
-      issues: write
+      issues: write  # required for POST/PATCH to /issues/{number}/comments via gh api
     steps:
       - uses: actions/checkout@v4
         with:
@@ -460,15 +460,14 @@ jobs:
           REVIEWED_AT_COMMENT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
             --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | test("REVIEWED_AT:"))] | last.body // empty')
           LAST_SHA=$(echo "$REVIEWED_AT_COMMENT" | sed -n 's/.*REVIEWED_AT: \([a-f0-9]\{40\}\).*/\1/p' | head -1)
-          MERGE_BASE=$(git merge-base HEAD origin/main)
           if [ -n "$LAST_SHA" ] && git cat-file -e "$LAST_SHA" 2>/dev/null; then
-            if git merge-base --is-ancestor "$LAST_SHA" "$MERGE_BASE" 2>/dev/null; then
+            if git merge-base --is-ancestor "$LAST_SHA" HEAD 2>/dev/null; then
               git diff "$LAST_SHA"..HEAD > .tmp/pr-diff-since-last.txt
               echo "Incremental diff generated from $LAST_SHA"
             else
               echo "# Incremental diff unavailable: branch was rebased or merged with main since last review." > .tmp/pr-diff-since-last.txt
               echo "# Full PR diff is attached separately as .tmp/pr-diff.txt." >> .tmp/pr-diff-since-last.txt
-              echo "Incremental diff skipped — $LAST_SHA is not an ancestor of $MERGE_BASE"
+              echo "Incremental diff skipped — $LAST_SHA is not an ancestor of HEAD"
             fi
           else
             echo "# No REVIEWED_AT marker found in previous bot comments." > .tmp/pr-diff-since-last.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,33 +506,34 @@ jobs:
           If .tmp/review-output.md does not exist when you finish, your work
           will be discarded and the review step will fail.
 
-          STEP-BY-STEP:
-          1. Analyze the diff and write your review
-          2. Call Write tool: filePath=\".tmp/review-output.md\", content=\"<your review>\"
-          3. Call Read tool on .tmp/review-output.md to verify it was written correctly
-          4. Confirm the last line is exactly \"REVIEW_RESULT: approved\" or \"REVIEW_RESULT: changes_requested\"
-          5. Only then are you truly done — do not stop before step 4"
+           STEP-BY-STEP:
+           1. Analyze the diff and write your review
+           2. Call Write tool: filePath=.tmp/review-output.md, content=<your review>
+           3. Call Read tool on .tmp/review-output.md to verify it was written correctly
+           4. Confirm the last line is exactly REVIEW_RESULT: approved or REVIEW_RESULT: changes_requested
+           5. Only then are you truly done — do not stop before step 4"
 
           while [ $attempt -lt $MAX_RETRIES ]; do
             attempt=$((attempt + 1))
 
             RETRY_MSG=""
+            FILES="--file .tmp/pr-diff.txt --file .tmp/pr-diff-since-last.txt"
             if [ $attempt -gt 1 ]; then
+              FILES="$FILES --file .tmp/review-raw-output.log"
               RETRY_MSG="
 
           RETRY ATTEMPT: The previous run completed without writing .tmp/review-output.md.
-          Your analysis from the previous attempt is in .tmp/review-raw-output.txt — recover it.
+          Your analysis from the previous attempt is in .tmp/review-raw-output.log — recover it.
           You MUST use the Write tool to write ONLY the final review to .tmp/review-output.md."
             fi
 
-            script -q -c "opencode run \
-              --model \"openai-compat/$OPENAI_COMPAT_MODEL\" \
+            opencode run \
+              --model "openai-compat/$OPENAI_COMPAT_MODEL" \
               --agent ci-review \
-              --file .tmp/pr-diff.txt \
-              --file .tmp/pr-diff-since-last.txt \
-              --title \"PR #$PR_NUMBER Review\" \
-              \"$PROMPT$RETRY_MSG\"" \
-              .tmp/review-raw-output.txt
+              $FILES \
+              --title "PR #$PR_NUMBER Review" \
+              "$PROMPT$RETRY_MSG" \
+              2>&1 | tee .tmp/review-raw-output.log
 
             if [ -s .tmp/review-output.md ] && grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
               echo "::notice::Review output written on attempt $attempt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,7 @@ jobs:
         run: |
           set -eo pipefail
 
-          MAX_RETRIES=2
+          MAX_ATTEMPTS=2
           attempt=0
           PROMPT="Review this pull request. Two diff files are attached:
           - .tmp/pr-diff.txt — full diff against the merge base
@@ -520,7 +520,14 @@ jobs:
            4. Confirm the last line is exactly REVIEW_RESULT: approved or REVIEW_RESULT: changes_requested
            5. Only then are you truly done — do not stop before step 4"
 
-          while [ $attempt -lt $MAX_RETRIES ]; do
+          _review_ok() {
+            [ -s .tmp/review-output.md ] || return 1
+            local last
+            last=$(tail -n 1 .tmp/review-output.md)
+            [ "$last" = "REVIEW_RESULT: approved" ] || [ "$last" = "REVIEW_RESULT: changes_requested" ]
+          }
+
+          while [ $attempt -lt $MAX_ATTEMPTS ]; do
             attempt=$((attempt + 1))
 
             RETRY_MSG=""
@@ -542,7 +549,7 @@ jobs:
               "$PROMPT$RETRY_MSG" \
               2>&1 | tee .tmp/review-raw-output.log || true
 
-            if [ -s .tmp/review-output.md ] && grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
+            if _review_ok; then
               echo "::notice::Review output written on attempt $attempt"
               break
             fi
@@ -550,8 +557,8 @@ jobs:
             echo "::warning::Attempt $attempt: review-output.md missing or lacks REVIEW_RESULT marker"
           done
 
-          if [ ! -s .tmp/review-output.md ] || ! grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
-            echo "::error::All $MAX_RETRIES attempts failed to produce valid review output"
+          if ! _review_ok; then
+            echo "::error::All $MAX_ATTEMPTS attempts failed to produce valid review output"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,9 +530,9 @@ jobs:
             attempt=$((attempt + 1))
 
             RETRY_MSG=""
-            FILES="--file .tmp/pr-diff.txt --file .tmp/pr-diff-since-last.txt"
+            FILES=(--file .tmp/pr-diff.txt --file .tmp/pr-diff-since-last.txt)
             if [ $attempt -gt 1 ]; then
-              FILES="$FILES --file .tmp/review-raw-output.log"
+              FILES+=(--file .tmp/review-raw-output.log)
               RETRY_MSG="
 
           RETRY ATTEMPT: The previous run completed without writing .tmp/review-output.md.
@@ -543,7 +543,7 @@ jobs:
             opencode run \
               --model "openai-compat/$OPENAI_COMPAT_MODEL" \
               --agent ci-review \
-              $FILES \
+              "${FILES[@]}" \
               --title "PR #$PR_NUMBER Review" \
               "$PROMPT$RETRY_MSG" \
               2>&1 | tee .tmp/review-raw-output.log || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,7 +469,7 @@ jobs:
 
       - name: Run OpenCode Review
         id: opencode-review
-        timeout-minutes: 20
+        timeout-minutes: 30
         env:
           GITHUB_TOKEN: ${{ github.token }}
           OPENAI_COMPAT_API_KEY: ${{ secrets.OPENAI_COMPAT_API_KEY }}
@@ -478,16 +478,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -eo pipefail
-          opencode run \
-            --model "openai-compat/$OPENAI_COMPAT_MODEL" \
-            --agent ci-review \
-            --file .tmp/pr-diff.txt \
-            --file .tmp/pr-diff-since-last.txt \
-            --title "PR #$PR_NUMBER Review" \
-            "Review this pull request. Two diff files are attached:
-           - .tmp/pr-diff.txt — full diff against the merge base
-           - .tmp/pr-diff-since-last.txt — incremental diff since the last CI review (or a note if unavailable)
-           CI results have already been verified by the CI pipeline — read .tmp/ci-results.txt for the full results.
+
+          MAX_RETRIES=2
+          attempt=0
+          FILES="--file .tmp/pr-diff.txt --file .tmp/pr-diff-since-last.txt"
+          PROMPT="Review this pull request. Two diff files are attached:
+          - .tmp/pr-diff.txt — full diff against the merge base
+          - .tmp/pr-diff-since-last.txt — incremental diff since the last CI review (or a note if unavailable)
+          CI results have already been verified by the CI pipeline — read .tmp/ci-results.txt for the full results.
           Trust these CI results and only review for issues that CI cannot catch (logic bugs, design issues, missing edge cases).
 
           .tmp/ and .workspace/ are your scratch workspace — you may write files there for intermediate work.
@@ -500,7 +498,49 @@ jobs:
           - Verify all claims are backed by the actual diff
           - Check for formatting issues, typos, or unclear language
           - Confirm the REVIEW_RESULT marker is present and correct
-          - If you find any issues, rewrite the file with corrections"
+          - If you find any issues, rewrite the file with corrections
+
+          CRITICAL — OUTPUT INSTRUCTIONS (read twice):
+          Your review is NOT complete until you have called the Write tool
+          to save your final review to .tmp/review-output.md.
+          Writing to stdout is NOT sufficient — the file MUST exist on disk.
+          If .tmp/review-output.md does not exist when you finish, your work
+          will be discarded and the review step will fail.
+
+          STEP-BY-STEP:
+          1. Analyze the diff and write your review
+          2. Call Write tool: filePath=\".tmp/review-output.md\", content=\"<your review>\"
+          3. Call Read tool on .tmp/review-output.md to verify it was written correctly
+          4. Confirm the last line is exactly \"REVIEW_RESULT: approved\" or \"REVIEW_RESULT: changes_requested\"
+          5. Only then are you truly done — do not stop before step 4"
+
+          while [ $attempt -lt $MAX_RETRIES ]; do
+            attempt=$((attempt + 1))
+
+            RETRY_MSG=""
+            if [ $attempt -gt 1 ]; then
+              RETRY_MSG="
+
+          RETRY ATTEMPT: The previous run completed without writing .tmp/review-output.md.
+          Your analysis from the previous attempt is in .tmp/review-raw-output.txt — recover it.
+          You MUST use the Write tool to write ONLY the final review to .tmp/review-output.md."
+            fi
+
+            opencode run \
+              --model "openai-compat/$OPENAI_COMPAT_MODEL" \
+              --agent ci-review \
+              $FILES \
+              --title "PR #$PR_NUMBER Review" \
+              "$PROMPT$RETRY_MSG" \
+              2>&1 | tee .tmp/review-raw-output.txt
+
+            if [ -s .tmp/review-output.md ] && grep -q "REVIEW_RESULT:" .tmp/review-output.md; then
+              echo "::notice::Review output written on attempt $attempt"
+              break
+            fi
+
+            echo "::warning::Attempt $attempt: review-output.md missing or lacks REVIEW_RESULT marker"
+          done
 
       - name: Post review output as comment
         if: always() && steps.opencode-review.outcome != 'cancelled'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,7 +533,7 @@ jobs:
               $FILES \
               --title "PR #$PR_NUMBER Review" \
               "$PROMPT$RETRY_MSG" \
-              2>&1 | tee .tmp/review-raw-output.log
+              2>&1 | tee .tmp/review-raw-output.log || true
 
             if [ -s .tmp/review-output.md ] && grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
               echo "::notice::Review output written on attempt $attempt"
@@ -542,6 +542,11 @@ jobs:
 
             echo "::warning::Attempt $attempt: review-output.md missing or lacks REVIEW_RESULT marker"
           done
+
+          if [ ! -s .tmp/review-output.md ] || ! grep -Eq "^REVIEW_RESULT: (approved|changes_requested)$" .tmp/review-output.md; then
+            echo "::error::All $MAX_RETRIES attempts failed to produce valid review output"
+            exit 1
+          fi
 
       - name: Post review output as comment
         if: always() && steps.opencode-review.outcome != 'cancelled'


### PR DESCRIPTION
## Problem

The CI review step (`opencode run --agent ci-review`) sometimes completes
successfully but does not actually write `.tmp/review-output.md` to disk.
When this happens:

1. "Post review output as comment" skips (file is empty)
2. "Submit PR review based on result" finds no `REVIEW_RESULT` marker
3. Safety default triggers `--request-changes`, blocking merge with a false negative

This occurred on PR #159 — the agent produced a quality review in its stdout
but never called the Write tool to persist it.

## Solution

Two changes to the "Run OpenCode Review" step in `.github/workflows/ci.yml`:

1. **Retry loop** (max 2 attempts): stdout+stderr is tee'd to
   `.tmp/review-raw-output.txt`. If `.tmp/review-output.md` is empty or
   lacks `REVIEW_RESULT:`, the loop retries with the raw output attached
   as an additional `--file` input so the agent can recover its previous
   analysis.

2. **CRITICAL output instructions** in the prompt: a visually distinct
   block at the end of the prompt with step-by-step Write/Read/verify
   instructions emphasizing that stdout is insufficient and the file
   MUST exist on disk.

   Step timeout increased from 20m → 30m to accommodate the retry.