### PR TITLE
docs: expand dom-port specs — Virtual DOM, event system, and testing module

### DIFF
--- a/openspec/changes/feat-testing-module/design.md
+++ b/openspec/changes/feat-testing-module/design.md
@@ -138,6 +138,8 @@ def create_test_app(scope, root_component=None, **kwargs):
 
 **Rationale**: Many component tests need access to signals, DI values, or the app's `provide()` method. `TestRenderer.render()` handles the simple case; `create_test_app()` handles the advanced case where the test needs to manipulate signals or DI before rendering.
 
+**Implementation note on ContextVar**: Setting `_active_scope` directly bypasses the normal `DIScope.__enter__`/`__exit__` context manager that sets `_active_di_scope` (a `ContextVar`). The implementation MUST also set `_active_di_scope.set(scope)` and provide a cleanup callback (returned from `create_test_app()`) to reset it, OR use `app.di_scope` as a context manager internally. Otherwise, `inject()` calls from within component setup (which checks `_active_di_scope` before falling back to `_app_di_scope`) may fail to resolve dependencies.
+
 ### Decision 6: TestRenderer and TestRendererResult
 
 **Chosen**: `TestRenderer` renders a component to a `VirtualDOMNode` tree. `TestRendererResult` wraps the root node and provides query/assertion/event/re-render methods.

--- a/openspec/changes/feat-testing-module/design.md
+++ b/openspec/changes/feat-testing-module/design.md
@@ -39,11 +39,50 @@ This enables a testing module that renders components to `VirtualDOMNode` trees 
 
 **Rationale**: Same approach as `webcompy.cli` and `webcompy.ports._server` — these are server/dev-only code. The `_is_browser_excluded` function uses prefix matching, so `"webcompy.testing"` matches all submodules. This prevents test utilities from being bundled into browser-deployed wheels.
 
-### Decision 2: FakeDOMNode extracted with minimal changes
+### Decision 2: FakeDOMNode inherits from VirtualDOMNode
 
-**Chosen**: Move `FakeDOMNode` from `tests/conftest.py` to `webcompy/testing/_dom.py`. Keep its behavior identical — `__webcompy_node__`, `__webcompy_prerendered_node__`, tree ops, attribute storage, event listener recording, counter attributes (`textContent_write_count`, `setAttribute_count`).
+**Chosen**: `FakeDOMNode` extends `VirtualDOMNode` and overrides only test-specific behavior: `setAttribute`/`textContent` increment counters, `__setattr__` guard, `__webcompy_prerendered_node__ = False`. All tree operations, attribute storage, event listener management, and `dispatchEvent(VirtualDOMEvent)` are inherited from `VirtualDOMNode`.
 
-**Rationale**: `FakeDOMNode` is used by 8+ test files that import `from conftest import FakeDOMNode`. Changing behavior risks breaking existing tests. The only new capability is `dispatchEvent(VirtualDOMEvent)`, which is added to align with `VirtualDOMNode` in `feat-virtual-dom`. `FakeDOMNode` is the browser-test equivalent; `VirtualDOMNode` is the server-test equivalent.
+```python
+from webcompy.ports._server._virtual_dom import VirtualDOMNode
+
+class FakeDOMNode(VirtualDOMNode):
+    def __init__(self, tag: str = "div", text_content: str | None = None):
+        super().__init__(tag, text_content)
+        self.__webcompy_prerendered_node__ = False
+        self.textContent_write_count = 0
+        self.setAttribute_count = 0
+
+    @VirtualDOMNode.textContent.setter  # type: ignore[attr-defined]
+    def textContent(self, value):
+        self._text_content = value
+        self.textContent_write_count += 1
+
+    def setAttribute(self, name, value):
+        super().setAttribute(name, value)
+        self.setAttribute_count += 1
+
+    def __setattr__(self, name, value):
+        if name.startswith("_VirtualDOMNode__") or name in (
+            "__webcompy_node__",
+            "__webcompy_prerendered_node__",
+        ):
+            object.__setattr__(self, name, value)
+        else:
+            try:
+                object.__getattribute__(self, name)
+                object.__setattr__(self, name, value)
+            except AttributeError:
+                object.__setattr__(self, name, value)
+
+    def __getattr__(self, name):
+        if name.startswith("_VirtualDOMNode__"):
+            raise AttributeError(name)
+        return object.__getattribute__(self, name)
+```
+
+**Rationale**: `VirtualDOMNode` already implements the full `DOMNode` Protocol — all tree operations, attribute storage, event listener management, and `dispatchEvent(VirtualDOMEvent)` with bubbling propagation. Writing these again in `FakeDOMNode` would be ~80% code duplication. Inheritance eliminates duplication and ensures `dispatchEvent` semantics remain identical. The dependency direction is safe: `webcompy.testing` → `webcompy.ports._server` — both are excluded from browser wheels. The `__setattr__` guard references `_VirtualDOMNode__` (name-mangled superclass internal name) since Python name mangling is based on the class where the attribute is defined.
+
 
 ### Decision 3: FakeBrowserFFIPort Protocol compliance fix
 
@@ -184,5 +223,5 @@ result.assert_has_class("container")
 ## Risks / Trade-offs
 
 - **[TestRenderer environment setup]** Monkeypatching `ENVIRONMENT` on element modules must match the pattern used by `fake_browser_full` fixture. If the patching is skipped, `_init_node()` methods will still have `ENVIRONMENT == "pyscript"` branches that raise exceptions. → Mitigation: `TestRenderer.render()` includes the same monkeypatch logic.
-- **[FakeDOMNode vs VirtualDOMNode divergence]** `FakeDOMNode` and `VirtualDOMNode` are structurally similar but not unified. `FakeDOMNode` has extra test-oriented attributes (counters, `__setattr__` guard). → Trade-off accepted: `FakeDOMNode` is for browser-side mock tests; `VirtualDOMNode` is for server-side rendering tests. They serve different purposes.
+- **[FakeDOMNode inherits VirtualDOMNode]** `FakeDOMNode` extends `VirtualDOMNode`, adding only test-specific attributes (counters, `__setattr__` guard, `__webcompy_prerendered_node__`). Any `VirtualDOMNode` API change will automatically propagate to `FakeDOMNode`. → Trade-off accepted: `webcompy.testing` depends on `webcompy.ports._server` — both are excluded from browser wheels, so this is safe.
 - **[E2E coverage gap]** Migrating tests from browser to unit loses coverage of PyScript integration bugs. → Mitigation: remaining E2E tests cover the PyScript lifecycle indirectly. The migrated tests cover logic that was never PyScript-dependent.

--- a/openspec/changes/feat-testing-module/design.md
+++ b/openspec/changes/feat-testing-module/design.md
@@ -1,0 +1,188 @@
+# Design: Testing Module
+
+## Context
+
+After `feat-virtual-dom` completes:
+
+- `VirtualDOMNode` satisfies the `DOMNode` Protocol with tree ops, attribute storage, event listener recording, and `dispatchEvent(VirtualDOMEvent)`.
+- `ServerDOMPort` creates `VirtualDOMNode` trees and provides `render_html()` for serialization.
+- Element types use a single unified `render()` path across browser and server.
+- `RouterLink._on_click()` calls `self._router.__set_path__()` unconditionally (only `pushState` is guarded behind `ENVIRONMENT == "pyscript"`).
+
+This enables a testing module that renders components to `VirtualDOMNode` trees and exercises the full reactive + routing pipeline without a browser.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `webcompy.testing` package with `FakeDOMNode`, fake port implementations, and scope helpers
+- `TestRenderer` / `TestRendererResult` — render components, query trees, dispatch events, re-render
+- Fix `FakeBrowserFFIPort` Protocol compliance
+- Migrate ~55 E2E tests to unit tests using `TestRenderer`
+- Exclude `webcompy.testing` from browser wheels
+- Backwards-compatible re-exports from `tests/conftest.py`
+
+**Non-Goals:**
+- CSS cascade / layout computation
+- Real browser `<input>` widget state emulation
+- `window.history.pushState` / `popstate` emulation
+- Console error capture
+
+## Dependency
+
+**Requires `feat-virtual-dom`** for: `VirtualDOMNode`, `VirtualDOMEvent`, `ServerDOMPort`, unified `render()`, and RouterLink `_on_click` fix. This change cannot be implemented first — it depends on the virtual DOM infrastructure.
+
+## Decisions
+
+### Decision 1: webcompy.testing as a separate package, excluded from browser wheels
+
+**Chosen**: Create `webcompy/testing/` with `__init__.py`, `_dom.py` (FakeDOMNode), `_ports.py` (fake port implementations), and `_renderer.py` (TestRenderer / TestRendererResult). Add `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE`.
+
+**Rationale**: Same approach as `webcompy.cli` and `webcompy.ports._server` — these are server/dev-only code. The `_is_browser_excluded` function uses prefix matching, so `"webcompy.testing"` matches all submodules. This prevents test utilities from being bundled into browser-deployed wheels.
+
+### Decision 2: FakeDOMNode extracted with minimal changes
+
+**Chosen**: Move `FakeDOMNode` from `tests/conftest.py` to `webcompy/testing/_dom.py`. Keep its behavior identical — `__webcompy_node__`, `__webcompy_prerendered_node__`, tree ops, attribute storage, event listener recording, counter attributes (`textContent_write_count`, `setAttribute_count`).
+
+**Rationale**: `FakeDOMNode` is used by 8+ test files that import `from conftest import FakeDOMNode`. Changing behavior risks breaking existing tests. The only new capability is `dispatchEvent(VirtualDOMEvent)`, which is added to align with `VirtualDOMNode` in `feat-virtual-dom`. `FakeDOMNode` is the browser-test equivalent; `VirtualDOMNode` is the server-test equivalent.
+
+### Decision 3: FakeBrowserFFIPort Protocol compliance fix
+
+**Chosen**: Add `to_js` and `assign` methods to `FakeBrowserFFIPort` that match the `FFIPort` ABC.
+
+```python
+class FakeBrowserFFIPort:
+    def to_js(self, value: Any, **kwargs: Any) -> Any:
+        return value
+    def assign(self, target: Any, *sources: Any) -> Any:
+        for source in sources:
+            target.update(source)
+        return target
+```
+
+**Rationale**: The `FFIPort` ABC defines 5 abstract methods: `create_proxy`, `destroy_proxy`, `is_none`, `to_js`, `assign`. The current fake only implements 3 of them. This gap was harmless because no test calls `to_js`/`assign` directly, but as a proper testing module, Protocol compliance matters.
+
+### Decision 4: Scope helpers — create_browser_scope() and create_server_scope()
+
+**Chosen**: Two convenience functions that return pre-wired `DIScope` instances.
+
+```python
+def create_browser_scope() -> DIScope:
+    scope = DIScope()
+    scope.provide(DOM_PORT_KEY, FakeBrowserDOMPort())
+    scope.provide(HOST_PORT_KEY, FakeBrowserHostPort())
+    scope.provide(FFI_PORT_KEY, FakeBrowserFFIPort())
+    return scope
+
+def create_server_scope() -> DIScope:
+    scope = DIScope()
+    scope.provide(DOM_PORT_KEY, ServerDOMPort())
+    scope.provide(HOST_PORT_KEY, ServerHostPort())
+    scope.provide(FFI_PORT_KEY, ServerFFIPort())
+    return scope
+```
+
+**Rationale**: The `fake_browser_full` fixture in `tests/conftest.py` is 30 lines of setup — monkeypatching `ENVIRONMENT`, creating a `DIScope`, providing ports, setting the active scope. This boilerplate should be a one-liner for app developers writing tests.
+
+### Decision 5: create_test_app() — minimal WebComPyApp factory
+
+**Chosen**: `create_test_app(scope: DIScope, root_component=None, **config_overrides)` instantiates a minimal `WebComPyApp` with the given scope. Returns the app instance with the scope active.
+
+```python
+def create_test_app(scope, root_component=None, **kwargs):
+    config = AppConfig(**kwargs)
+    app = WebComPyApp(config=config)
+    if root_component is not None:
+        app.set_root(root_component)
+    app._active_scope = scope  # so app.di_scope uses this scope
+    return app
+```
+
+**Rationale**: Many component tests need access to signals, DI values, or the app's `provide()` method. `TestRenderer.render()` handles the simple case; `create_test_app()` handles the advanced case where the test needs to manipulate signals or DI before rendering.
+
+### Decision 6: TestRenderer and TestRendererResult
+
+**Chosen**: `TestRenderer` renders a component to a `VirtualDOMNode` tree. `TestRendererResult` wraps the root node and provides query/assertion/event/re-render methods.
+
+```python
+from webcompy.testing import TestRenderer
+
+# Basic rendering
+result = TestRenderer.render(MyComponent(props={"name": "World"}))
+
+# Query virtual DOM tree
+h1 = result.query_selector("h1")
+items = result.query_selector_all("li")
+node = result.find_by_text("Hello")
+node = result.find_by_attribute("id", "main")
+
+# Event dispatch + re-render
+button = result.query_selector("button")
+button.dispatchEvent(VirtualDOMEvent("click"))
+result.rerender()
+assert result.find_by_text("Clicked: 1")
+
+# HTML output
+html = result.to_html()
+
+# Assertion helpers
+result.assert_element_count("li", 3)
+result.assert_has_class("container")
+```
+
+`TestRenderer.render()`:
+1. Creates a `create_server_scope()`
+2. Creates a `WebComPyApp` with default config
+3. Monkeypatches `ENVIRONMENT` to non-pyscript on element modules
+4. Renders the component via `component.render()`
+5. Returns `TestRendererResult(app, root_node, scope)`
+
+`TestRendererResult`:
+- `query_selector(tag: str) -> VirtualDOMNode | None` — DFS for first element matching `tag`
+- `query_selector_all(tag: str) -> list[VirtualDOMNode]` — DFS for all elements matching `tag`
+- `find_by_text(text: str) -> VirtualDOMNode | None` — DFS for node with matching `textContent`
+- `find_by_attribute(name: str, value: str) -> VirtualDOMNode | None` — DFS for node with matching attribute
+- `to_html() -> str` — delegates to `ServerDOMPort.render_html(root)`
+- `rerender()` — re-executes `component.render()` on the virtual tree
+- `assert_element_count(tag: str, count: int)` — `assert len(query_selector_all(tag)) == count`
+- `assert_has_class(cls: str)` — `assert "class" in root.getAttributeNames()` and the class is present
+
+**Rationale**: This is the jsdom-like API for WebComPy. After `feat-virtual-dom`, any component can be rendered to a `VirtualDOMNode` tree. `TestRenderer` wraps the boilerplate and provides ergonomic query/assertion methods. The `rerender()` method is essential for testing reactive behavior after `dispatchEvent(VirtualDOMEvent)` — it re-drives component `render()` so the queryable tree reflects post-signal-update state.
+
+### Decision 7: E2E test migration strategy
+
+**Chosen**: Migrate tests in dependency order, using `TestRenderer` as the verification tool. Keep E2E tests for browser-only behavior.
+
+**Migratable (with TestRenderer)**:
+
+| E2E File | Tests | Mechanism |
+|----------|-------|-----------|
+| `test_component.py` | 2 | `TestRenderer` + `query_selector` + `textContent` |
+| `test_standalone.py` | 4 | Pure file/string checks (no Playwright) |
+| `test_bundled_deps.py` | 9 | Pure file/string checks (no Playwright) |
+| `test_static_site.py` | 7 | Pure file/string checks (no Playwright) |
+| `test_runtime_local.py` | 2 | HTML string verification |
+| `test_switch.py` | 3 | `TestRenderer` + `dispatchEvent(VirtualDOMEvent("click"))` |
+| `test_reactive.py` | 3 | `TestRenderer` + `dispatchEvent` + `rerender` |
+| `test_repeat.py` | 3 | `TestRenderer` + `dispatchEvent` + `rerender` |
+| `test_keyed_repeat.py` | 4 | `TestRenderer` + `dispatchEvent` + `rerender` |
+| `test_dict_repeat.py` | 4 | `TestRenderer` + `dispatchEvent` + `rerender` |
+| `test_nested_dynamic.py` | 6 | `TestRenderer` + `dispatchEvent` + `rerender` |
+| `test_scoped_style.py` | 2 | `TestRenderer` + style node `textContent` inspection |
+| `test_di.py` | 4 | `TestRenderer` with DI scope + `dispatchEvent` for RouterLink navigation |
+| `test_lifecycle.py` | 2 | `TestRenderer` + `dispatchEvent` |
+
+**Browser-required (remain in E2E)**:
+
+| Reason | Tests | Files |
+|--------|-------|-------|
+| `getComputedStyle()` | 5 | `test_scoped_style.py` |
+| Browser `<input>` widget state | 2 | `test_keyed_repeat.py`, `test_dict_repeat.py` |
+| RouterView lifecycle on navigation | 1 | `test_lifecycle.py` |
+| `assert_no_console_errors` | 3 | `test_di.py`, `test_bootstrap.py` |
+| All `tests/e2e_docs/` | ~27 | docs E2E (iframe + PyScript) |
+
+## Risks / Trade-offs
+
+- **[TestRenderer environment setup]** Monkeypatching `ENVIRONMENT` on element modules must match the pattern used by `fake_browser_full` fixture. If the patching is skipped, `_init_node()` methods will still have `ENVIRONMENT == "pyscript"` branches that raise exceptions. → Mitigation: `TestRenderer.render()` includes the same monkeypatch logic.
+- **[FakeDOMNode vs VirtualDOMNode divergence]** `FakeDOMNode` and `VirtualDOMNode` are structurally similar but not unified. `FakeDOMNode` has extra test-oriented attributes (counters, `__setattr__` guard). → Trade-off accepted: `FakeDOMNode` is for browser-side mock tests; `VirtualDOMNode` is for server-side rendering tests. They serve different purposes.
+- **[E2E coverage gap]** Migrating tests from browser to unit loses coverage of PyScript integration bugs. → Mitigation: remaining E2E tests cover the PyScript lifecycle indirectly. The migrated tests cover logic that was never PyScript-dependent.

--- a/openspec/changes/feat-testing-module/proposal.md
+++ b/openspec/changes/feat-testing-module/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: Testing Module
+
+## Why
+
+Currently, all test utilities (fake DOM nodes, fake port implementations, browser mock fixtures) live in `tests/conftest.py`. These utilities are imported directly by 8+ test files but are inaccessible to external projects testing their own WebComPy apps. After `feat-virtual-dom` completes, `VirtualDOMNode` + `VirtualDOMEvent` + unified render path enables rich server-side component testing. A proper testing module makes this accessible.
+
+## What Changes
+
+- **NEW** `webcompy/testing/` package — public API for testing WebComPy components
+- **MOVED** `FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `tests/conftest.py` into `webcompy/testing/`
+- **NEW** `create_browser_scope()` — pre-configured `DIScope` with browser-side fake ports
+- **NEW** `create_server_scope()` — pre-configured `DIScope` with `ServerDOMPort` for virtual DOM testing
+- **NEW** `create_test_app()` — minimal `WebComPyApp` factory for component rendering tests
+- **NEW** `TestRenderer` / `TestRendererResult` — jsdom-like high-level API: render components, query virtual DOM trees, dispatch events, re-render
+- **NEW** `"webcompy.testing"` added to `_BROWSER_ONLY_EXCLUDE` — excludes the module from browser wheels
+- **MIGRATED** `tests/e2e/test_component.py`, `test_standalone.py`, `test_bundled_deps.py`, `test_static_site.py`, `test_runtime_local.py` (24 tests) — purely rendering tests, no browser interaction
+- **MIGRATED** `tests/e2e/test_switch.py`, `test_reactive.py`, `test_repeat.py`, `test_keyed_repeat.py` (4/5), `test_dict_repeat.py` (4/5), `test_nested_dynamic.py`, `test_scoped_style.py` (2/7), `test_di.py` (4/5), `test_lifecycle.py` (2/3) — interactive tests now covered by `TestRenderer.render()` + `VirtualDOMEvent` dispatch + `rerender()` + virtual tree assertions
+
+## Capabilities
+
+### New Capabilities
+
+- `testing-module`: `webcompy.testing` package providing `FakeDOMNode`, fake port implementations, scope helpers, and `TestRenderer` for component rendering tests. External apps can import `from webcompy.testing import TestRenderer` and write tests that render components to `VirtualDOMNode` trees, query the structure, dispatch events, and assert on the resulting virtual DOM.
+
+## Known Issues Addressed
+
+- **`FakeBrowserFFIPort` Protocol non-compliance** — adds missing `to_js` and `assign` methods
+- **Test utilities inaccessible to external apps** — `FakeDOMNode` and fake ports become importable via `webcompy.testing`
+- **E2E tests for rendering-only behavior** — migrated to unit tests; E2E retains only browser-required tests (getComputedStyle, input widget state, RouterView lifecycle)
+
+## Non-goals
+
+- Full jsdom-level CSS cascade or layout computation (getComputedStyle remains browser-only)
+- Real browser `<input>` widget state emulation (verified in E2E with `input.fill()`)
+- Navigation via `window.history.pushState` / `popstate` (tested via `MockHistoryPort` / `HistoryPort`; RouterView mount/unmount lifecycle requires E2E)
+- Console error capture (`assert_no_console_errors` requires real PyScript runtime)
+
+## Dependency
+
+- **Requires** `feat-virtual-dom` — depends on `VirtualDOMNode`, `VirtualDOMEvent`, `ServerDOMPort.render_html()`, unified render path, and RouterLink `_on_click` fix
+
+## Impact
+
+- **Affected modules**: new `webcompy/testing/` package, `tests/conftest.py` (shrink), `tests/e2e/*` (shrink), `webcompy/cli/_wheel_builder.py` (1-line exclusion addition)
+- **Breaking**: None for framework users. `tests/conftest.py` re-exports from `webcompy.testing` for backwards compatibility; test code can migrate gradually.
+- **Testing**: ~55 E2E tests migrate to unit tests; ~11 E2E tests remain browser-required

--- a/openspec/changes/feat-testing-module/specs/testing-module/spec.md
+++ b/openspec/changes/feat-testing-module/specs/testing-module/spec.md
@@ -22,7 +22,7 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 
 #### Scenario: Dispatching a VirtualDOMEvent on FakeDOMNode
 - **WHEN** `handler = lambda ev: None` is registered via `node.addEventListener("click", handler)`
-- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called
+- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called (where `VirtualDOMEvent` is imported from `webcompy.ports._server._virtual_dom` — re-exported by `webcompy.testing`)
 - **THEN** the handler SHALL be invoked with the event
 
 ### Requirement: webcompy.testing package shall provide fake port implementations
@@ -41,7 +41,7 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 
 ### Requirement: webcompy.testing package shall provide scope helpers
 
-`create_browser_scope()` SHALL return a `DIScope` with `FakeBrowserDOMPort`, `FakeBrowserHostPort`, and `FakeBrowserFFIPort` wired to their standard injection keys. `create_server_scope()` SHALL return a `DIScope` with `ServerDOMPort`, `ServerHostPort`, and `ServerFFIPort` wired to their standard injection keys. `create_test_app(scope, **config_overrides)` SHALL return a minimal `WebComPyApp` instance with the given DI scope.
+`create_browser_scope()` SHALL return a `DIScope` with `FakeBrowserDOMPort`, `FakeBrowserHostPort`, and `FakeBrowserFFIPort` wired to their standard injection keys. `create_server_scope()` SHALL return a `DIScope` with `ServerDOMPort`, `ServerHostPort`, and `ServerFFIPort` wired to their standard injection keys. `create_test_app(scope, **config_overrides)` SHALL return a minimal `WebComPyApp` instance with the given DI scope set directly on `app._active_scope` — this is an intentional test-only escape hatch, not a public API contract, and SHALL NOT be used in production code.
 
 #### Scenario: create_browser_scope returns a ready-to-use DIScope
 - **WHEN** `scope = create_browser_scope()` is called
@@ -56,7 +56,7 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 
 ### Requirement: TestRenderer shall render components to VirtualDOMNode trees
 
-`TestRenderer.render(component)` SHALL create a server-side DI scope, instantiate a minimal `WebComPyApp`, render the component via `component.render()`, and return a `TestRendererResult` wrapping the root `VirtualDOMNode`. `TestRendererResult` SHALL provide query methods (`query_selector`, `query_selector_all`, `find_by_text`, `find_by_attribute`), `to_html()`, `rerender()`, and assertion helpers (`assert_element_count`, `assert_has_class`).
+`TestRenderer.render(component)` SHALL set the runtime environment to non-PyScript during rendering to ensure the element system uses server-side code paths (i.e., `_create_node()` calls `ServerDOMPort.create_element()` rather than `BrowserDOMPort.create_element()`). It SHALL create a server-side DI scope, instantiate a minimal `WebComPyApp`, render the component via `component.render()`, and return a `TestRendererResult` wrapping the root `VirtualDOMNode`. `TestRendererResult` SHALL provide query methods (`query_selector`, `query_selector_all`, `find_by_text`, `find_by_attribute`), `to_html()`, `rerender()`, and assertion helpers (`assert_element_count`, `assert_has_class`).
 
 #### Scenario: Rendering a simple component
 - **WHEN** `result = TestRenderer.render(component)` is called

--- a/openspec/changes/feat-testing-module/specs/testing-module/spec.md
+++ b/openspec/changes/feat-testing-module/specs/testing-module/spec.md
@@ -1,0 +1,105 @@
+# Testing Module
+
+## Purpose
+
+WebComPy provides a `webcompy.testing` package with reusable test utilities for component rendering tests. Developers can import `TestRenderer`, `FakeDOMNode`, fake port implementations, and scope helpers to write unit tests that render components to `VirtualDOMNode` trees, query the structure, dispatch events, and assert on the resulting virtual DOM — without a browser or PyScript runtime.
+
+## ADDED Requirements
+
+### Requirement: webcompy.testing package shall provide FakeDOMNode
+
+`FakeDOMNode` SHALL be a concrete class satisfying the `DOMNode` Protocol. It SHALL store tag name, attributes, children, event listeners, text content, `__webcompy_node__`, and `__webcompy_prerendered_node__`. It SHALL implement all tree operations (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute operations (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), and event operations (`addEventListener`, `removeEventListener`, `dispatchEvent(VirtualDOMEvent)`). It SHALL expose `childNodes` (returning a `DOMNodeList`-compatible wrapper), `parentNode`, `nodeName`, `nodeType`, and `textContent` properties.
+
+#### Scenario: Creating a FakeDOMNode for browser-side mock tests
+- **WHEN** `FakeDOMNode("div")` is instantiated
+- **THEN** a node with `nodeName == "DIV"` and `nodeType == 1` SHALL be returned
+- **AND** `__webcompy_node__ == True`
+
+#### Scenario: Building a tree with FakeDOMNode
+- **WHEN** `parent.appendChild(child)` is called
+- **THEN** `child.parentNode` SHALL reference `parent`
+- **AND** `parent.childNodes` SHALL contain `child`
+
+#### Scenario: Dispatching a VirtualDOMEvent on FakeDOMNode
+- **WHEN** `handler = lambda ev: None` is registered via `node.addEventListener("click", handler)`
+- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called
+- **THEN** the handler SHALL be invoked with the event
+
+### Requirement: webcompy.testing package shall provide fake port implementations
+
+`FakeBrowserDOMPort` SHALL implement `DOMPort` with `create_element()` returning a `FakeDOMNode` and `create_text_node()` returning a text `FakeDOMNode`. `FakeBrowserHostPort` SHALL implement `HostPort` with `schedule_macro_task()` as a no-op. `FakeBrowserFFIPort` SHALL implement all 5 abstract methods of `FFIPort`: `create_proxy`, `destroy_proxy`, `is_none`, `to_js`, `assign`.
+
+#### Scenario: FakeBrowserDOMPort creates FakeDOMNodes
+- **WHEN** `FakeBrowserDOMPort().create_element("span")` is called
+- **THEN** a `FakeDOMNode` with `nodeName == "SPAN"` SHALL be returned
+
+#### Scenario: FakeBrowserFFIPort satisfies the full FFIPort ABC
+- **WHEN** `FakeBrowserFFIPort.to_js({"key": "val"})` is called
+- **THEN** the original dict SHALL be returned
+- **WHEN** `FakeBrowserFFIPort.assign(target, source)` is called
+- **THEN** `target.update(source)` SHALL be executed and `target` returned
+
+### Requirement: webcompy.testing package shall provide scope helpers
+
+`create_browser_scope()` SHALL return a `DIScope` with `FakeBrowserDOMPort`, `FakeBrowserHostPort`, and `FakeBrowserFFIPort` wired to their standard injection keys. `create_server_scope()` SHALL return a `DIScope` with `ServerDOMPort`, `ServerHostPort`, and `ServerFFIPort` wired to their standard injection keys. `create_test_app(scope, **config_overrides)` SHALL return a minimal `WebComPyApp` instance with the given DI scope.
+
+#### Scenario: create_browser_scope returns a ready-to-use DIScope
+- **WHEN** `scope = create_browser_scope()` is called
+- **THEN** `scope.inject(DOM_PORT_KEY)` SHALL return a `FakeBrowserDOMPort`
+- **AND** `scope.inject(FFI_PORT_KEY)` SHALL return a `FakeBrowserFFIPort`
+- **AND** `scope.inject(HOST_PORT_KEY)` SHALL return a `FakeBrowserHostPort`
+
+#### Scenario: create_server_scope returns a ready-to-use DIScope
+- **WHEN** `scope = create_server_scope()` is called
+- **THEN** `scope.inject(DOM_PORT_KEY)` SHALL return a `ServerDOMPort`
+- **AND** `scope.inject(FFI_PORT_KEY)` SHALL return a `ServerFFIPort`
+
+### Requirement: TestRenderer shall render components to VirtualDOMNode trees
+
+`TestRenderer.render(component)` SHALL create a server-side DI scope, instantiate a minimal `WebComPyApp`, render the component via `component.render()`, and return a `TestRendererResult` wrapping the root `VirtualDOMNode`. `TestRendererResult` SHALL provide query methods (`query_selector`, `query_selector_all`, `find_by_text`, `find_by_attribute`), `to_html()`, `rerender()`, and assertion helpers (`assert_element_count`, `assert_has_class`).
+
+#### Scenario: Rendering a simple component
+- **WHEN** `result = TestRenderer.render(component)` is called
+- **THEN** `result.query_selector("h1")` SHALL return a `VirtualDOMNode`
+- **AND** the node's `textContent` SHALL match the component's rendered text
+
+#### Scenario: Querying elements by tag
+- **WHEN** a component renders three `<li>` elements
+- **AND** `items = result.query_selector_all("li")` is called
+- **THEN** `len(items)` SHALL be 3
+
+#### Scenario: Finding a node by text content
+- **WHEN** a component renders `<span>Hello World</span>`
+- **AND** `node = result.find_by_text("Hello World")` is called
+- **THEN** `node` SHALL be the `<span>` VirtualDOMNode
+
+#### Scenario: Finding a node by attribute
+- **WHEN** a component renders `<div id="main">`
+- **AND** `node = result.find_by_attribute("id", "main")` is called
+- **THEN** `node` SHALL be the `<div>` VirtualDOMNode
+
+#### Scenario: Dispatching an event and re-rendering
+- **WHEN** `button = result.query_selector("button")` returns a node
+- **AND** `button.dispatchEvent(VirtualDOMEvent("click"))` is called
+- **AND** `result.rerender()` is called
+- **THEN** `result.query_selector("span")` SHALL reflect the updated signal value
+
+#### Scenario: Generating HTML from the virtual tree
+- **WHEN** `html = result.to_html()` is called
+- **THEN** the string SHALL match `ServerDOMPort.render_html(root)`
+
+#### Scenario: Assertion helpers
+- **WHEN** `result.assert_element_count("li", 3)` is called
+- **AND** the tree contains exactly 3 `<li>` elements
+- **THEN** no AssertionError SHALL be raised
+- **WHEN** `result.assert_has_class("container")` is called
+- **AND** the root element has `class` containing `"container"`
+- **THEN** no AssertionError SHALL be raised
+
+### Requirement: webcompy.testing shall not be bundled into browser wheels
+
+The `"webcompy.testing"` pattern SHALL be added to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py`. All submodules under `webcompy.testing` SHALL be excluded from browser-targeted wheels.
+
+#### Scenario: Testing module excluded from browser wheel
+- **WHEN** a browser-targeted wheel is built
+- **THEN** no files under `webcompy/testing/` SHALL be present in the wheel archive

--- a/openspec/changes/feat-testing-module/specs/testing-module/spec.md
+++ b/openspec/changes/feat-testing-module/specs/testing-module/spec.md
@@ -85,6 +85,14 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 - **AND** `result.rerender()` is called
 - **THEN** `result.query_selector("span")` SHALL reflect the updated signal value
 
+#### Scenario: Server scope rerender handles synchronous signal updates only
+- **WHEN** `result = TestRenderer.render(component)` is called (using default server scope)
+- **AND** `dispatchEvent` triggers a signal update synchronously
+- **AND** `result.rerender()` is called
+- **THEN** synchronous signal effects SHALL be reflected in the re-rendered tree
+- **BUT** `on_after_rendering` lifecycle hooks that depend on `schedule_macro_task()` SHALL NOT fire (because `ServerHostPort.schedule_macro_task()` is a no-op)
+- **AND** tests requiring macro-task-dependent lifecycle hooks SHALL use `create_browser_scope()` instead of the default server scope
+
 #### Scenario: Generating HTML from the virtual tree
 - **WHEN** `html = result.to_html()` is called
 - **THEN** the string SHALL match `ServerDOMPort.render_html(root)`

--- a/openspec/changes/feat-testing-module/specs/testing-module/spec.md
+++ b/openspec/changes/feat-testing-module/specs/testing-module/spec.md
@@ -28,11 +28,19 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 
 ### Requirement: webcompy.testing package shall provide fake port implementations
 
-`FakeBrowserDOMPort` SHALL implement `DOMPort` with `create_element()` returning a `FakeDOMNode` and `create_text_node()` returning a text `FakeDOMNode`. `FakeBrowserHostPort` SHALL implement `HostPort` with `schedule_macro_task()` as a no-op. `FakeBrowserFFIPort` SHALL implement all 5 abstract methods of `FFIPort`: `create_proxy`, `destroy_proxy`, `is_none`, `to_js`, `assign`.
+`FakeBrowserDOMPort` SHALL implement `DOMPort` with `create_element()` returning a `FakeDOMNode`, `create_text_node()` returning a text `FakeDOMNode`, `create_event()` returning a `VirtualDOMEvent` with the given type and options, and `add_document_event_listener()` returning a no-op cleanup callback. `FakeBrowserHostPort` SHALL implement `HostPort` with `schedule_macro_task()` as a no-op and `create_js_global_getter()` returning a callable that returns `None`. `FakeBrowserFFIPort` SHALL implement `FFIPort` with all 5 abstract methods: `create_proxy` (returns `MagicMock` wrapping the original), `destroy_proxy`, `is_none`, `to_js`, `assign`.
 
 #### Scenario: FakeBrowserDOMPort creates FakeDOMNodes
 - **WHEN** `FakeBrowserDOMPort().create_element("span")` is called
 - **THEN** a `FakeDOMNode` with `nodeName == "SPAN"` SHALL be returned
+
+#### Scenario: FakeBrowserDOMPort.create_event returns a VirtualDOMEvent
+- **WHEN** `FakeBrowserDOMPort().create_event("click", bubbles=True, cancelable=False)` is called
+- **THEN** a `VirtualDOMEvent` with `type == "click"`, `bubbles == True`, `cancelable == False` SHALL be returned
+
+#### Scenario: FakeBrowserHostPort.create_js_global_getter returns a None-returning callable
+- **WHEN** `getter = FakeBrowserHostPort().create_js_global_getter("someName")` is called
+- **THEN** `getter()` SHALL return `None`
 
 #### Scenario: FakeBrowserFFIPort satisfies the full FFIPort ABC
 - **WHEN** `FakeBrowserFFIPort.to_js({"key": "val"})` is called

--- a/openspec/changes/feat-testing-module/specs/testing-module/spec.md
+++ b/openspec/changes/feat-testing-module/specs/testing-module/spec.md
@@ -8,22 +8,23 @@ WebComPy provides a `webcompy.testing` package with reusable test utilities for 
 
 ### Requirement: webcompy.testing package shall provide FakeDOMNode
 
-`FakeDOMNode` SHALL be a concrete class satisfying the `DOMNode` Protocol. It SHALL store tag name, attributes, children, event listeners, text content, `__webcompy_node__`, and `__webcompy_prerendered_node__`. It SHALL implement all tree operations (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute operations (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), and event operations (`addEventListener`, `removeEventListener`, `dispatchEvent(VirtualDOMEvent)`). It SHALL expose `childNodes` (returning a `DOMNodeList`-compatible wrapper), `parentNode`, `nodeName`, `nodeType`, and `textContent` properties.
+`FakeDOMNode` SHALL extend `VirtualDOMNode` (from `webcompy.ports._server._virtual_dom`). It SHALL inherit all `DOMNode` Protocol methods — tree operations (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute operations (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), event operations (`addEventListener`, `removeEventListener`, `dispatchEvent(VirtualDOMEvent)`), and properties (`childNodes`, `parentNode`, `nodeName`, `nodeType`, `textContent`, `__webcompy_node__`). It SHALL add: `textContent_write_count` and `setAttribute_count` counter increments on mutation, `__webcompy_prerendered_node__ = False`, and a `__setattr__` guard for attribute proxying.
 
 #### Scenario: Creating a FakeDOMNode for browser-side mock tests
-- **WHEN** `FakeDOMNode("div")` is instantiated
-- **THEN** a node with `nodeName == "DIV"` and `nodeType == 1` SHALL be returned
+- **WHEN** `FakeDOMNode("div")` is instantiated (inheriting `VirtualDOMNode.__init__`)
+- **THEN** a node with `nodeName == "DIV"` and `nodeType == 1` SHALL be returned (inherited from `VirtualDOMNode`)
 - **AND** `__webcompy_node__ == True`
+- **AND** `__webcompy_prerendered_node__ == False` (set by `FakeDOMNode.__init__`)
 
-#### Scenario: Building a tree with FakeDOMNode
-- **WHEN** `parent.appendChild(child)` is called
-- **THEN** `child.parentNode` SHALL reference `parent`
+#### Scenario: FakeDOMNode inherits tree operations from VirtualDOMNode
+- **WHEN** `parent.appendChild(child)` is called on a `FakeDOMNode`
+- **THEN** `child.parentNode` SHALL reference `parent` (inherited from `VirtualDOMNode.appendChild`)
 - **AND** `parent.childNodes` SHALL contain `child`
 
-#### Scenario: Dispatching a VirtualDOMEvent on FakeDOMNode
+#### Scenario: FakeDOMNode inherits dispatchEvent from VirtualDOMNode
 - **WHEN** `handler = lambda ev: None` is registered via `node.addEventListener("click", handler)`
-- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called (where `VirtualDOMEvent` is imported from `webcompy.ports._server._virtual_dom` — re-exported by `webcompy.testing`)
-- **THEN** the handler SHALL be invoked with the event
+- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called
+- **THEN** the handler SHALL be invoked with the event (propagation inherited from `VirtualDOMNode.dispatchEvent`)
 
 ### Requirement: webcompy.testing package shall provide fake port implementations
 

--- a/openspec/changes/feat-testing-module/tasks.md
+++ b/openspec/changes/feat-testing-module/tasks.md
@@ -1,0 +1,50 @@
+## 1. webcompy.testing package foundation
+
+- [ ] 1.1 Create `webcompy/testing/` package — `__init__.py` re-exporting key symbols (`FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort`, `TestRenderer`, `TestRendererResult`, `VirtualDOMEvent`, `create_browser_scope`, `create_server_scope`, `create_test_app`)
+- [ ] 1.2 Create `webcompy/testing/_dom.py` — move `FakeDOMNode` from `tests/conftest.py` with no behavior changes, add `dispatchEvent(VirtualDOMEvent)`
+- [ ] 1.3 Create `webcompy/testing/_ports.py` — move `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `tests/conftest.py`
+- [ ] 1.4 Fix `FakeBrowserFFIPort` Protocol compliance — add missing `to_js` and `assign` methods that match `FFIPort` ABC
+- [ ] 1.5 Create `create_browser_scope()` — returns a `DIScope` with `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` wired up, mirroring the `fake_browser_full` fixture
+- [ ] 1.6 Create `create_server_scope()` — returns a `DIScope` with `ServerDOMPort`, `ServerHostPort`, `ServerFFIPort` wired up; enables `component.render()` to build `VirtualDOMNode` trees in tests
+- [ ] 1.7 Create `create_test_app()` — instantiates a minimal `WebComPyApp` with the given scope, enabling component rendering tests without a full server
+- [ ] 1.8 Add `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` — prevents the testing module from being bundled into browser wheels
+- [ ] 1.9 Update `tests/conftest.py` — re-export `FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `webcompy.testing` for backwards compatibility
+- [ ] 1.10 Update all test files that import from `conftest` (`FakeDOMNode`, `FakeBrowserDOMPort` — `MockHistoryPort` is out of scope) to import from `webcompy.testing` instead
+
+## 2. TestRenderer and TestRendererResult
+
+- [ ] 2.1 Create `webcompy/testing/_renderer.py` with `TestRenderer` class — high-level API for rendering components to `VirtualDOMNode` trees and querying the result
+- [ ] 2.2 Implement `TestRenderer.render(component)` — monkeypatches `ENVIRONMENT` on element modules, creates server-side DI scope, instantiates minimal `WebComPyApp`, calls `component.render()`, returns `TestRendererResult(app, root_node, scope)`
+- [ ] 2.3 Implement `TestRendererResult` query methods — `query_selector(tag)` (DFS, first match), `query_selector_all(tag)` (DFS, all matches), `find_by_text(text)`, `find_by_attribute(name, value)` — traverse the virtual tree and return matching `VirtualDOMNode`(s)
+- [ ] 2.4 Implement `TestRendererResult.to_html()` — delegates to `ServerDOMPort.render_html(root)`
+- [ ] 2.5 Implement `TestRendererResult.rerender()` — re-executes component `render()` on the existing virtual root so that signal changes from `dispatchEvent(VirtualDOMEvent)` are reflected in the queryable tree
+- [ ] 2.6 Implement `TestRendererResult` tree assertion helpers — `assert_element_count(tag, count)`, `assert_has_class(cls)` — raise `AssertionError` on mismatch
+
+## 3. E2E test migration — purely rendering (24 tests)
+
+- [ ] 3.1 Migrate `tests/e2e/test_component.py` (2 tests) — replace `to_be_visible`/`to_have_text` with `TestRenderer.render()` + `query_selector` + `textContent`; component text content is fully verifiable via `VirtualDOMNode`
+- [ ] 3.2 Migrate `tests/e2e/test_standalone.py` (4 tests) — CDN URL absence, local asset paths, file existence checks; no Playwright usage, move to `tests/` with `pytest.mark.e2e` removed
+- [ ] 3.3 Migrate `tests/e2e/test_bundled_deps.py` (9 tests) — lockfile existence/schema, wheel content, HTML string verification; no Playwright usage, move to `tests/` as regular unit tests
+- [ ] 3.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
+- [ ] 3.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
+
+## 4. E2E test migration — interactive with TestRenderer (31 tests)
+
+- [ ] 4.1 Migrate `test_switch.py` (3 tests) — all tests use only click events; `dispatchEvent(VirtualDOMEvent("click"))` replaces Playwright `click()`. Default state, toggle on, toggle off all work via `TestRenderer` + `rerender` + virtual DOM assertions.
+- [ ] 4.2 Migrate `test_reactive.py` (3 tests) — text update, list operations, dict operations all triggered by button clicks ignoring event arg. dispatchEvent + rerender + virtual tree assertions fully cover.
+- [ ] 4.3 Migrate `test_repeat.py` (3 tests) — initial empty state (no interaction) plus add/remove via clicks. dispatchEvent covers all interactive assertions.
+- [ ] 4.4 Migrate `test_keyed_repeat.py` (4 of 5 tests) — initial empty, add items, remove first, insert at start all use click-only handlers. **Exclude**: `test_keyed_repeat_input_preserved_after_add` — verifies real browser `<input>` widget state survives keyed reconciliation; virtual DOM has no equivalent widget state.
+- [ ] 4.5 Migrate `test_dict_repeat.py` (4 of 5 tests) — same pattern as keyed repeat. **Exclude**: `test_dict_repeat_input_preserved_after_add` — same browser `<input>` widget state requirement.
+- [ ] 4.6 Migrate `test_nested_dynamic.py` (6 tests) — all tests (initial view, switch to grid, switch back, add item, add then switch, remove first) use click-only handlers. dispatchEvent + rerender covers all.
+- [ ] 4.7 Migrate `test_scoped_style.py` (2 of 7 tests) — `test_scoped_style_attribute_selector` and `test_scoped_style_top_level_media_query` only check `<style>` element `textContent` against virtual DOM. **Exclude**: 5 tests using `getComputedStyle()` which requires a real browser CSS engine.
+- [ ] 4.8 Migrate `test_di.py` (4 of 5 tests) — `test_provide_inject_from_parent` and `test_inject_from_app_level` can render DI components directly via TestRenderer with proper DI scope set up. `test_di_navigation_no_python_errors` and `test_di_home_then_navigate_then_back` use RouterLink navigation which is now testable via dispatchEvent (after `feat-virtual-dom` RouterLink fix); `assert_no_console_errors` replaced by exception assertion. **Exclude**: `test_di_provide_inject_no_python_errors` — requires `assert_no_console_errors`.
+- [ ] 4.9 Migrate `test_lifecycle.py` (2 of 3 tests) — `test_lifecycle_hooks_fire` and `test_on_after_rendering_on_interactions` use click-only handler or no interaction. **Exclude**: `test_on_before_rendering_on_navigation` — depends on RouterView destroy/recreate cycle during navigation (requires real PyScript lifecycle).
+
+## 5. Verification
+
+- [ ] 5.1 Run lint: `uv run ruff check .`
+- [ ] 5.2 Run type check: `uv run pyright`
+- [ ] 5.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 5.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 5.5 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope (browser-required tests stay in E2E)
+- [ ] 5.6 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -8,6 +8,9 @@ This change replaces the exception-throwing stubs in `ServerDOMPort` with a virt
 
 **Goals:**
 - Implement `VirtualDOMNode` satisfying the `DOMNode` Protocol with attribute storage, child management, and `__webcompy_node__` marker
+- Implement `VirtualDOMEvent` satisfying the `DOMEvent` Protocol with full event propagation (at-target + bubbling)
+- Add `dispatchEvent` to `DOMNode` Protocol and `create_event` to `DOMPort` ABC
+- Move `DOMEvent` Protocol from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py`
 - `ServerDOMPort` returns `VirtualDOMNode` instances from `create_element()` / `create_text_node()`
 - Remove all `_render_html()` methods from element type classes
 - `render()` becomes the single rendering entry point for both environments
@@ -19,6 +22,8 @@ This change replaces the exception-throwing stubs in `ServerDOMPort` with a virt
 - Performance optimization of virtual tree operations
 - Worker-thread rendering
 - Hydration of virtual trees (only real DOM nodes are hydrated)
+- Capturing phase (event handlers always use `useCapture=False`; at-target + bubbling only)
+- `document.createEvent("MouseEvent")`-style legacy API (constructor-style only)
 
 ## Decisions
 
@@ -63,31 +68,68 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 **Rationale**: `ServerFFIPort.create_proxy()` returns the handler as-is (identity). The handlers stored here are the exact functions produced by `_generate_event_handler()`, which wraps user handlers for async resolution. No FFI proxy wrapping is needed.
 
-### Decision 5b: VirtualDOMNode supports dispatchEvent() for component behavior testing
+### Decision 5b: VirtualDOMNode.dispatchEvent() implements standard event propagation
 
-**Chosen**: `VirtualDOMNode.dispatchEvent(event: VirtualDOMEvent)` fires all stored handlers matching `event.type` synchronously. `VirtualDOMEvent` is a companion class in the same module providing minimal fields (`type`, `target`, `currentTarget`, `preventDefault`). Combined with the unified render path and synchronous signal propagation, this enables end-to-end component behavior tests:
+**Chosen**: `VirtualDOMNode.dispatchEvent(event: DOMEvent) -> bool` executes the at-target phase followed by the bubbling phase (if `event.bubbles` is `True`). `VirtualDOMEvent` is a concrete class satisfying the `DOMEvent` Protocol with full event fields.
+
+Event propagation flow:
+```
+dispatchEvent(event) on a node:
+  1. Set event.target = node, event.eventPhase = AT_TARGET (2)
+  2. Set event.currentTarget = node
+  3. Fire all stored handlers matching event.type synchronously
+  4. If event.bubbles and not event._propagation_stopped:
+     a. Walk node.parentNode chain upward
+     b. For each ancestor:
+        - Set event.eventPhase = BUBBLING (3)
+        - Set event.currentTarget = ancestor
+        - Fire ancestor's handlers matching event.type
+        - Stop if event._propagation_stopped
+  5. Return not event.defaultPrevented
+```
+
+**Rationale**: Three facts make full event propagation viable without a browser:
+1. **Handler wrapping happens at `addEventListener` time** — `_generate_event_handler()` wraps the user handler and `ServerFFIPort.create_proxy()` returns it as-is. The stored handler is call-ready.
+2. **Signal propagation is synchronous** — `Signal.set_value()` triggers all `on_after_updating` callbacks within the same call stack.
+3. **The unified render path** renders to `VirtualDOMNode` — `render()` → `_mount_node()` operates on the virtual tree identically.
+
+The capturing phase is intentionally excluded because WebComPy always passes `useCapture=False` to `addEventListener` — all framework-registered handlers run during the bubbling phase. Bubbling through the ancestor chain is straightforward since `VirtualDOMNode` stores `_parent` references. `event.stopPropagation()` allows event handlers to prevent ancestor dispatch, matching browser behavior.
+
+`preventDefault` gates on `event.cancelable` per spec: `event.defaultPrevented` is set to `True` only when `cancelable` is `True`. The return value (`True` unless default prevented) enables guards like `if not node.dispatchEvent(...): return`.
 
 ```python
 result = TestRenderer.render(Counter)
 button = result.query_selector("button")
 assert result.find_by_text("Clicked: 0")
 
-button.dispatchEvent(VirtualDOMEvent("click"))
+event = VirtualDOMEvent("click", bubbles=True, cancelable=True)
+button.dispatchEvent(event)
 # → handler fires → signal.set(1) → computed recalc → _refresh()
-# → child._render() → VirtualDOMNode.appendChild()
+# → VirtualDOMNode.appendChild()
 
-result.rerender()  # re-execute component.render() on the virtual tree
+result.rerender()
 assert result.find_by_text("Clicked: 1")
+assert event.defaultPrevented == False
 ```
 
-**Rationale**: Three facts make this viable without a browser:
-1. **Handler wrapping happens at `addEventListener` time** — `_generate_event_handler()` wraps the user handler and `ServerFFIPort.create_proxy()` returns it as-is. The stored handler is call-ready.
-2. **Signal propagation is synchronous** — `Signal.set_value()` triggers all `on_after_updating` callbacks (`_refresh()`, `_generate_attr_updater()`) within the same call stack.
-3. **The unified render path** renders to `VirtualDOMNode` — `_render()` → `_mount_node()` → `appendChild()`/`insertBefore()` all operate on the virtual tree.
+**Alternative considered**: Skip bubbling, only fire on the target node. Rejected because bubbling is a core DOM event semantic. Without bubbling, event delegation patterns (where a parent listens for child events) would not be testable, and the behavior would diverge from browser DOM. Walking the ancestor chain is a trivial `while parent` loop.
 
-The `rerender()` method on `TestRendererResult` re-drives component `render()` so the queryable tree reflects post-event state.
+### Decision 9: DOMPort.create_event() — constructor-style event factory
 
-**Non-goal boundary**: `preventDefault`, `stopPropagation`, event bubbling, and `event.target`/`currentTarget` reference management are NOT emulated. `VirtualDOMEvent` provides only `type`, `target`, `currentTarget`, and `preventDefault` (no-op). Full JS event model simulation is intentionally out of scope.
+**Chosen**: `DOMPort.create_event(event_type: str, *, bubbles: bool = False, cancelable: bool = False) -> DOMEvent`. BrowserDOMPort creates a native JS `Event` (via `new Event(type, {bubbles, cancelable})`), ServerDOMPort returns a `VirtualDOMEvent`.
+
+```python
+def create_event(self, event_type: str, *, bubbles: bool = False, cancelable: bool = False) -> DOMEvent:
+    ...
+```
+
+**Rationale**: The `new Event(type, eventInitDict)` constructor pattern is the modern standard. `bubbles` and `cancelable` as keyword-only arguments mirror the `EventInit` dictionary. The legacy `document.createEvent("MouseEvent")` API is not supported because WebComPy has no use for MouseEvent-specific properties (clientX, screenY, etc.) — test events are dispatched programmatically, not derived from actual mouse positions.
+
+### Decision 10: DOMEvent Protocol moves to ports/_dom.py
+
+**Chosen**: Move the `DOMEvent` Protocol from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py`, alongside `DOMNode` and `DOMPort`. `webcompy/elements/_dom_objs.py` re-exports it for backwards compatibility.
+
+**Rationale**: `DOMEvent`, `DOMNode`, and `DOMPort` form a cohesive domain — they are the three pillars of the abstracted DOM layer. Grouping them in the same module makes the ports layer self-contained: all type contracts that port implementations must satisfy live in `webcompy/ports/_dom.py`. This also enables `VirtualDOMEvent` (in `ports/_server/`) to reference the Protocol without importing from `webcompy/elements/`, avoiding potential circular dependencies.
 
 ### Decision 6: VirtualDOMNode implements all DOMNode tree operations
 

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -53,9 +53,10 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 **Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted.
 
 **Correct migration ordering:**
-1. Implement `VirtualDOMNode` + `ServerDOMPort.render_html()` (tasks 1-2)
-2. Update `cli/_html.py` to use `ServerDOMPort.render_html()` (task 5)
-3. THEN remove `_render_html()` from element classes — subclasses first (`_text.py`, `_dynamic.py`), base classes last (`_base.py`, `_abstract.py`) (tasks 3-4)
+1. Implement `VirtualDOMNode` + `ServerDOMPort.render_html()` (groups 1-2)
+2. Create `webcompy.testing` module and extract test utilities from `conftest` (group 3)
+3. Update `cli/_html.py` to use `ServerDOMPort.render_html()` (group 6)
+4. THEN remove `_render_html()` from element classes — subclasses first (`_text.py`, `_dynamic.py`), base classes last (`_base.py`, `_abstract.py`) (groups 4-5)
 
 ### Decision 5: VirtualDOMNode.event_listeners is a list of (event_name, handler) tuples
 
@@ -89,9 +90,24 @@ with app.di_scope:
 ```
 
 **Migration ordering**: Remove `_render_html()` from element base classes LAST (after all callers are updated), not first. This is the opposite of Decision 4 in feat-port-abstraction's design — the correct order is:
-1. Implement VirtualDOMNode + ServerDOMPort.render_html() (task 1-2)
-2. Update cli/_html.py to use ServerDOMPort.render_html() (task 5)
-3. THEN remove _render_html() from element classes (tasks 3-4)
+1. Implement VirtualDOMNode + ServerDOMPort.render_html() (groups 1-2)
+2. Create webcompy.testing module (group 3)
+3. Update cli/_html.py to use ServerDOMPort.render_html() (group 6)
+4. THEN remove _render_html() from element classes (groups 4-5)
+
+### Decision 8: webcompy.testing module — extract test utilities from conftest
+
+**Chosen**: Create a `webcompy.testing` package that houses `FakeDOMNode` and fake port implementations (`FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort`), plus convenience helpers (`create_browser_scope()`, `create_server_scope()`, `create_test_app()`). The module SHALL be excluded from browser wheels via `_BROWSER_ONLY_EXCLUDE`.
+
+**Rationale**: `tests/conftest.py` currently contains ~200 lines of reusable fake/mock classes that are also imported directly by 8+ test files (`from conftest import FakeDOMNode`). These utilities are useful for third-party app testing as well. Extracting them to a proper package under `webcompy.testing`:
+- Makes them importable by external app test suites
+- Provides pre-configured DI scope helpers (`create_browser_scope()`, `create_server_scope()`)
+- Centralizes the fake implementations in one discoverable location
+- Fixes `FakeBrowserFFIPort` Protocol non-compliance (missing `to_js`/`assign`)
+
+**Exclusion from browser wheels**: Adding `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` ensures the testing module is never bundled into browser-deployed wheels. The `_is_browser_excluded` function uses prefix matching, so `"webcompy.testing"` matches all submodules.
+
+**Alternative considered**: Keep in `conftest.py`. Rejected because external projects cannot import from test conftest, and the fake classes have outgrown their single-file origin.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -62,7 +62,33 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 **Chosen**: Store event listeners as `list[tuple[str, Callable]]` on `VirtualDOMNode`. `addEventListener` appends, `removeEventListener` removes by identity.
 
-**Rationale**: On the server, event listeners are never actually invoked — they're recorded for structural testing. A simple list is sufficient. No FFI proxy wrapping is needed (handled by `ServerFFIPort` which returns functions as-is).
+**Rationale**: `ServerFFIPort.create_proxy()` returns the handler as-is (identity). The handlers stored here are the exact functions produced by `_generate_event_handler()`, which wraps user handlers for async resolution. No FFI proxy wrapping is needed.
+
+### Decision 5b: VirtualDOMNode supports dispatchEvent() for component behavior testing
+
+**Chosen**: `VirtualDOMNode.dispatchEvent(event: MockDOMEvent)` fires all stored handlers matching `event.type` synchronously. A `MockDOMEvent` class provides minimal fields (`type`, `target`, `currentTarget`, `preventDefault`). Combined with the unified render path and synchronous signal propagation, this enables end-to-end component behavior tests:
+
+```python
+result = TestRenderer.render(Counter)
+button = result.query_selector("button")
+assert result.find_by_text("Clicked: 0")
+
+button.dispatchEvent(MockDOMEvent("click"))
+# → handler fires → signal.set(1) → computed recalc → _refresh()
+# → child._render() → VirtualDOMNode.appendChild()
+
+result.rerender()  # re-execute component.render() on the virtual tree
+assert result.find_by_text("Clicked: 1")
+```
+
+**Rationale**: Three facts make this viable without a browser:
+1. **Handler wrapping happens at `addEventListener` time** — `_generate_event_handler()` wraps the user handler and `ServerFFIPort.create_proxy()` returns it as-is. The stored handler is call-ready.
+2. **Signal propagation is synchronous** — `Signal.set_value()` triggers all `on_after_updating` callbacks (`_refresh()`, `_generate_attr_updater()`) within the same call stack.
+3. **The unified render path** renders to `VirtualDOMNode` — `_render()` → `_mount_node()` → `appendChild()`/`insertBefore()` all operate on the virtual tree.
+
+The `rerender()` method on `TestRendererResult` re-drives component `render()` so the queryable tree reflects post-event state.
+
+**Non-goal boundary**: `preventDefault`, `stopPropagation`, event bubbling, and `event.target`/`currentTarget` reference management are NOT emulated. `MockDOMEvent` provides only `type`, `target`, `currentTarget`, and `preventDefault` (no-op). Full JS event model simulation is intentionally out of scope.
 
 ### Decision 6: VirtualDOMNode implements all DOMNode tree operations
 

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -109,6 +109,37 @@ with app.di_scope:
 
 **Alternative considered**: Keep in `conftest.py`. Rejected because external projects cannot import from test conftest, and the fake classes have outgrown their single-file origin.
 
+### Decision 9: TestRenderer — jsdom-like high-level testing API
+
+**Chosen**: Provide a `TestRenderer` class in `webcompy.testing` that renders components to `VirtualDOMNode` trees and offers query/assertion methods on the result. This is the WebComPy equivalent of jsdom or React Testing Library's `render()`.
+
+```python
+from webcompy.testing import TestRenderer
+
+result = TestRenderer.render(MyComponent(props={"name": "World"}))
+
+# Query the virtual DOM tree
+h1 = result.query_selector("h1")
+assert h1.textContent == "Hello World"
+items = result.query_selector_all("li")
+assert len(items) == 3
+
+# Convenience finders
+node = result.find_by_text("Hello")
+node = result.find_by_attribute("id", "main")
+
+# HTML output
+html = result.to_html()
+
+# Built-in assertion helpers
+result.assert_element_count("li", 3)
+result.assert_has_class("container")
+```
+
+**Rationale**: After virtual DOM unification, any component can be rendered server-side via `render()` → `VirtualDOMNode`. `TestRenderer` wraps the boilerplate of DI scope setup, renders the component, and provides query/assertion methods. This turns component rendering tests from fragile HTML string comparison into structural assertions on the virtual DOM tree. The `TestRendererResult` query methods (`query_selector`, `query_selector_all`, `find_by_text`, `find_by_attribute`) traverse the `VirtualDOMNode` tree and return matching nodes for further inspection.
+
+**Alternative considered**: Let users call `component.render()` directly via `create_server_scope()`. Rejected because the setup boilerplate (DI scope, ENVIRONMENT patching, app instantiation) is non-trivial and error-prone. A single `TestRenderer.render()` call is the ergonomic entry point.
+
 ## Risks / Trade-offs
 
 - **[HTML output divergence]** ServerDOMPort.render_html() might produce different HTML than the old _render_html() methods. → Mitigation: generate docs_app with both old and new paths, diff the output, fix discrepancies before deleting _render_html().

--- a/openspec/changes/feat-virtual-dom/design.md
+++ b/openspec/changes/feat-virtual-dom/design.md
@@ -53,10 +53,9 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 **Rationale**: The `_render_html()` methods encode element-specific HTML formatting rules (void tags, self-closing, text escaping, attribute ordering). These rules must be replicated in `ServerDOMPort.render_html()` before the old methods can be deleted.
 
 **Correct migration ordering:**
-1. Implement `VirtualDOMNode` + `ServerDOMPort.render_html()` (groups 1-2)
-2. Create `webcompy.testing` module and extract test utilities from `conftest` (group 3)
-3. Update `cli/_html.py` to use `ServerDOMPort.render_html()` (group 6)
-4. THEN remove `_render_html()` from element classes — subclasses first (`_text.py`, `_dynamic.py`), base classes last (`_base.py`, `_abstract.py`) (groups 4-5)
+1. Implement `VirtualDOMNode` + `VirtualDOMEvent` + `ServerDOMPort.render_html()` (groups 1-2)
+2. Update `cli/_html.py` to use `ServerDOMPort.render_html()` (group 6)
+3. THEN remove `_render_html()` from element classes — subclasses first (`_text.py`, `_dynamic.py`), base classes last (`_base.py`, `_abstract.py`) (groups 3, 5)
 
 ### Decision 5: VirtualDOMNode.event_listeners is a list of (event_name, handler) tuples
 
@@ -66,14 +65,14 @@ On the server, `_create_node()` calls `ServerDOMPort.create_element()` which ret
 
 ### Decision 5b: VirtualDOMNode supports dispatchEvent() for component behavior testing
 
-**Chosen**: `VirtualDOMNode.dispatchEvent(event: MockDOMEvent)` fires all stored handlers matching `event.type` synchronously. A `MockDOMEvent` class provides minimal fields (`type`, `target`, `currentTarget`, `preventDefault`). Combined with the unified render path and synchronous signal propagation, this enables end-to-end component behavior tests:
+**Chosen**: `VirtualDOMNode.dispatchEvent(event: VirtualDOMEvent)` fires all stored handlers matching `event.type` synchronously. `VirtualDOMEvent` is a companion class in the same module providing minimal fields (`type`, `target`, `currentTarget`, `preventDefault`). Combined with the unified render path and synchronous signal propagation, this enables end-to-end component behavior tests:
 
 ```python
 result = TestRenderer.render(Counter)
 button = result.query_selector("button")
 assert result.find_by_text("Clicked: 0")
 
-button.dispatchEvent(MockDOMEvent("click"))
+button.dispatchEvent(VirtualDOMEvent("click"))
 # → handler fires → signal.set(1) → computed recalc → _refresh()
 # → child._render() → VirtualDOMNode.appendChild()
 
@@ -88,7 +87,7 @@ assert result.find_by_text("Clicked: 1")
 
 The `rerender()` method on `TestRendererResult` re-drives component `render()` so the queryable tree reflects post-event state.
 
-**Non-goal boundary**: `preventDefault`, `stopPropagation`, event bubbling, and `event.target`/`currentTarget` reference management are NOT emulated. `MockDOMEvent` provides only `type`, `target`, `currentTarget`, and `preventDefault` (no-op). Full JS event model simulation is intentionally out of scope.
+**Non-goal boundary**: `preventDefault`, `stopPropagation`, event bubbling, and `event.target`/`currentTarget` reference management are NOT emulated. `VirtualDOMEvent` provides only `type`, `target`, `currentTarget`, and `preventDefault` (no-op). Full JS event model simulation is intentionally out of scope.
 
 ### Decision 6: VirtualDOMNode implements all DOMNode tree operations
 
@@ -116,55 +115,15 @@ with app.di_scope:
 ```
 
 **Migration ordering**: Remove `_render_html()` from element base classes LAST (after all callers are updated), not first. This is the opposite of Decision 4 in feat-port-abstraction's design — the correct order is:
-1. Implement VirtualDOMNode + ServerDOMPort.render_html() (groups 1-2)
-2. Create webcompy.testing module (group 3)
-3. Update cli/_html.py to use ServerDOMPort.render_html() (group 6)
-4. THEN remove _render_html() from element classes (groups 4-5)
+1. Implement VirtualDOMNode + VirtualDOMEvent + ServerDOMPort.render_html() (groups 1-2)
+2. Update cli/_html.py to use ServerDOMPort.render_html() (group 6)
+3. THEN remove _render_html() from element classes — subclasses first, base classes last (groups 3, 5)
 
-### Decision 8: webcompy.testing module — extract test utilities from conftest
+### Decision 8: RouterLink._on_click() accessible outside browser
 
-**Chosen**: Create a `webcompy.testing` package that houses `FakeDOMNode` and fake port implementations (`FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort`), plus convenience helpers (`create_browser_scope()`, `create_server_scope()`, `create_test_app()`). The module SHALL be excluded from browser wheels via `_BROWSER_ONLY_EXCLUDE`.
+**Chosen**: Modify `RouterLink._on_click()` to execute `self._router.__set_path__()` unconditionally. Only `pushState` and `window.location` access remain guarded behind `ENVIRONMENT == "pyscript"`.
 
-**Rationale**: `tests/conftest.py` currently contains ~200 lines of reusable fake/mock classes that are also imported directly by 8+ test files (`from conftest import FakeDOMNode`). These utilities are useful for third-party app testing as well. Extracting them to a proper package under `webcompy.testing`:
-- Makes them importable by external app test suites
-- Provides pre-configured DI scope helpers (`create_browser_scope()`, `create_server_scope()`)
-- Centralizes the fake implementations in one discoverable location
-- Fixes `FakeBrowserFFIPort` Protocol non-compliance (missing `to_js`/`assign`)
-
-**Exclusion from browser wheels**: Adding `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` ensures the testing module is never bundled into browser-deployed wheels. The `_is_browser_excluded` function uses prefix matching, so `"webcompy.testing"` matches all submodules.
-
-**Alternative considered**: Keep in `conftest.py`. Rejected because external projects cannot import from test conftest, and the fake classes have outgrown their single-file origin.
-
-### Decision 9: TestRenderer — jsdom-like high-level testing API
-
-**Chosen**: Provide a `TestRenderer` class in `webcompy.testing` that renders components to `VirtualDOMNode` trees and offers query/assertion methods on the result. This is the WebComPy equivalent of jsdom or React Testing Library's `render()`.
-
-```python
-from webcompy.testing import TestRenderer
-
-result = TestRenderer.render(MyComponent(props={"name": "World"}))
-
-# Query the virtual DOM tree
-h1 = result.query_selector("h1")
-assert h1.textContent == "Hello World"
-items = result.query_selector_all("li")
-assert len(items) == 3
-
-# Convenience finders
-node = result.find_by_text("Hello")
-node = result.find_by_attribute("id", "main")
-
-# HTML output
-html = result.to_html()
-
-# Built-in assertion helpers
-result.assert_element_count("li", 3)
-result.assert_has_class("container")
-```
-
-**Rationale**: After virtual DOM unification, any component can be rendered server-side via `render()` → `VirtualDOMNode`. `TestRenderer` wraps the boilerplate of DI scope setup, renders the component, and provides query/assertion methods. This turns component rendering tests from fragile HTML string comparison into structural assertions on the virtual DOM tree. The `TestRendererResult` query methods (`query_selector`, `query_selector_all`, `find_by_text`, `find_by_attribute`) traverse the `VirtualDOMNode` tree and return matching nodes for further inspection.
-
-**Alternative considered**: Let users call `component.render()` directly via `create_server_scope()`. Rejected because the setup boilerplate (DI scope, ENVIRONMENT patching, app instantiation) is non-trivial and error-prone. A single `TestRenderer.render()` call is the ergonomic entry point.
+**Rationale**: `Router._router.__set_path__()` is pure Python logic (guards → navigate → after_route_change hooks). It works with any `HistoryPort`, including `MockHistoryPort`. The `from pyscript import context` and `context.window.history.pushState()` are browser-only infrastructure. Moving `__set_path__` outside the guard enables `dispatchEvent(VirtualDOMEvent("click"))` on rendered RouterLinks to trigger full route transitions in test contexts. This is the smallest possible change — 1-2 lines — to unlock RouterLink navigation testing without a browser.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/feat-virtual-dom/proposal.md
+++ b/openspec/changes/feat-virtual-dom/proposal.md
@@ -33,7 +33,7 @@ Currently, server-side rendering uses a parallel code path (`_render_html()`) th
 - Browser-side virtual DOM diffing (remains direct DOM manipulation)
 - Incremental/patch-based SSR updates (full tree rebuild per render)
 - Worker thread rendering (virtual DOM builds in main server thread only)
-- Full JS event model emulation (no `preventDefault`, `stopPropagation`, `event.target`/`currentTarget` reference management — MockDOMEvent covers essential fields only)
+- Full JS event model emulation (no `preventDefault`, `stopPropagation`, `event.target`/`currentTarget` reference management — VirtualDOMEvent covers essential fields only)
 
 ## Impact
 

--- a/openspec/changes/feat-virtual-dom/proposal.md
+++ b/openspec/changes/feat-virtual-dom/proposal.md
@@ -4,40 +4,50 @@ Currently, server-side rendering uses a parallel code path (`_render_html()`) th
 
 ## What Changes
 
-- **NEW** `VirtualDOMNode` class satisfying the `DOMNode` Protocol — an in-memory DOM tree node with attribute storage, child management, and HTML serialization
-- **MODIFIED** `ServerDOMPort` — replaces exception-throwing stubs with `VirtualDOMNode` factory methods; `create_element()` returns a `VirtualDOMNode`, `create_text_node()` returns a virtual text node
+- **NEW** `VirtualDOMNode` class satisfying the `DOMNode` Protocol — an in-memory DOM tree node with attribute storage, child management, event dispatch with bubbling propagation, and `dispatchEvent()`
+- **NEW** `VirtualDOMEvent` class satisfying the `DOMEvent` Protocol — full event object with `bubbles`, `cancelable`, `preventDefault()`, `stopPropagation()`, and phase tracking
+- **MODIFIED** `DOMNode` Protocol — adds `dispatchEvent(event: DOMEvent) -> bool`
+- **MODIFIED** `DOMPort` ABC — adds `create_event(event_type, *, bubbles, cancelable) -> DOMEvent`
+- **MOVED** `DOMEvent` Protocol from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py` for co-location with `DOMNode` and `DOMPort`
+- **MODIFIED** `ServerDOMPort` — replaces exception-throwing stubs with `VirtualDOMNode` factory methods; `create_element()` returns a `VirtualDOMNode`, `create_text_node()` returns a virtual text node, `create_event()` returns a `VirtualDOMEvent`
 - **REMOVED** `_render_html()` methods from element types (`_abstract.py`, `_base.py`, `_text.py`, `_dynamic.py`) — replaced by `render()` + `ServerDOMPort`
 - **MODIFIED** `render()` path becomes the single unified rendering entry point in both environments
 - **MODIFIED** Server-side rendering tests can validate full DOM tree structure (attribute values, child ordering, text content) instead of just HTML string comparison
 - **NEW** `ServerDOMPort` provides `render_html(node)` method that serializes the virtual tree to an HTML string
+- **MODIFIED** `RouterLink._on_click()` — executes `__set_path__()` unconditionally; only browser-specific `pushState` remains guarded behind `ENVIRONMENT == "pyscript"`
 
 ## Capabilities
 
 ### New Capabilities
 
 - `virtual-dom`: Server-side virtual DOM tree constructed via `ServerDOMPort.create_element()` / `ServerDOMPort.create_text_node()`, satisfying the `DOMNode` Protocol identically to browser nodes. The tree can be serialized to HTML and inspected in tests for exact DOM structure.
+- `virtual-events`: `DOMPort.create_event()` creates environment-appropriate `DOMEvent` objects. `VirtualDOMNode.dispatchEvent()` implements at-target + bubbling phase propagation with `preventDefault()` and `stopPropagation()` support. Combined with the unified render path and synchronous signal propagation, this enables end-to-end component interaction tests (click → dispatch → signal update → re-render) without a browser.
 
 ### Modified Capabilities
 
 - `elements`: The dual rendering path (`_render()` for browser DOM, `_render_html()` for server HTML) SHALL be unified into a single `render()` entry point. All element types SHALL remove `_render_html()`. Server-side HTML generation SHALL be handled by `ServerDOMPort.render_html()`. Element system no longer has knowledge of HTML string formatting (indentation, newlines).
 
-- `port-abstraction` (from `feat-port-abstraction` change): `ServerDOMPort` SHALL change from exception-throwing phase-1 stubs to full virtual DOM tree construction. `ServerDOMPort.create_element()` SHALL return a `VirtualDOMNode`. `ServerDOMPort.render_html(node)` SHALL serialize a virtual tree to HTML.
+- `port-abstraction` (from `feat-port-abstraction` change): `ServerDOMPort` SHALL change from exception-throwing phase-1 stubs to full virtual DOM tree construction. `ServerDOMPort.create_element()` SHALL return a `VirtualDOMNode`. `ServerDOMPort.create_event()` SHALL return a `VirtualDOMEvent`. `ServerDOMPort.render_html(node)` SHALL serialize a virtual tree to HTML. `DOMNode` Protocol SHALL include `dispatchEvent()`. `DOMPort` ABC SHALL include `create_event()`.
+
+- `router`: `RouterLink._on_click()` SHALL call `Router.__set_path__()` in both environments, enabling RouterLink click → route transition testing via `dispatchEvent(VirtualDOMEvent("click"))`. Only `pushState` and `window.location` access remain browser-guarded.
 
 ## Known Issues Addressed
 
 - **No virtual DOM diffing** — this change introduces a virtual DOM tree for server-side *construction*, not diffing. Browser-side still uses direct DOM manipulation. The virtual DOM serves as a testable representation, not a diffing algorithm.
-- **Event dispatching on VirtualDOMNode** — `dispatchEvent()` fires stored event handlers synchronously. Combined with the unified render path, this enables end-to-end component behavior tests (click → signal update → re-render → query updated virtual tree) without a browser.
+- **Event dispatching on VirtualDOMNode** — `dispatchEvent()` implements standard DOM event propagation (at-target + bubbling). Combined with the unified render path, this enables end-to-end component interaction tests without a browser.
+- **DOMEvent Protocol isolation** — `DOMEvent` Protocol moves to `webcompy/ports/_dom.py`, co-located with `DOMNode` and `DOMPort`, making the ports layer self-contained.
 
 ## Non-goals
 
 - Browser-side virtual DOM diffing (remains direct DOM manipulation)
 - Incremental/patch-based SSR updates (full tree rebuild per render)
 - Worker thread rendering (virtual DOM builds in main server thread only)
-- Full JS event model emulation (no `preventDefault`, `stopPropagation`, `event.target`/`currentTarget` reference management — VirtualDOMEvent covers essential fields only)
+- Capturing phase in `dispatchEvent()` (WebComPy always uses `useCapture=False`)
+- Legacy `document.createEvent("MouseEvent")`-style event creation (constructor-style only)
 
 ## Impact
 
-- **Affected modules**: `webcompy/ports/_server/_dom.py` (major rewrite), element types with `_render_html()` (`_abstract.py`, `_base.py`, `_text.py`, `_dynamic.py`), `webcompy/cli/_html.py` (caller), existing SSG tests (migrate from string comparison to tree inspection)
-- **Breaking**: `_render_html()` is **REMOVED** — any code calling it externally must migrate to `ServerDOMPort.render_html(node)`
-- **Dependency**: Requires `feat-port-abstraction` to be completed first (depends on `DOMNode` Protocol and `DOMPort.do` interface)
-- **Testing**: Server-side rendering tests gain ability to assert exact DOM tree shape instead of fragile HTML string matching
+- **Affected modules**: `webcompy/ports/_dom.py` (DOMEvent move + Protocol additions), `webcompy/ports/_server/_dom.py` (major rewrite + create_event), `webcompy/ports/_server/_virtual_dom.py` (new: VirtualDOMNode + VirtualDOMEvent), `webcompy/ports/_browser/_dom.py` (add create_event), `webcompy/router/_link.py` (guard change), element types with `_render_html()` (`_abstract.py`, `_base.py`, `_text.py`, `_dynamic.py`), `webcompy/cli/_html.py` (caller), existing SSG tests (migrate from string comparison to tree inspection)
+- **Breaking**: `_render_html()` is **REMOVED** — any code calling it externally must migrate to `ServerDOMPort.render_html(node)`. `DOMEvent` Protocol moves from `webcompy.elements._dom_objs.DOMEvent` to `webcompy.ports._dom.DOMEvent` (backwards-compatible re-export maintained)
+- **Dependency**: Requires `feat-port-abstraction` to be completed first (depends on `DOMNode` Protocol and `DOMPort` ABC)
+- **Testing**: Server-side rendering tests gain ability to assert exact DOM tree shape and simulate user interactions via event dispatch — no browser required

--- a/openspec/changes/feat-virtual-dom/proposal.md
+++ b/openspec/changes/feat-virtual-dom/proposal.md
@@ -26,12 +26,14 @@ Currently, server-side rendering uses a parallel code path (`_render_html()`) th
 ## Known Issues Addressed
 
 - **No virtual DOM diffing** — this change introduces a virtual DOM tree for server-side *construction*, not diffing. Browser-side still uses direct DOM manipulation. The virtual DOM serves as a testable representation, not a diffing algorithm.
+- **Event dispatching on VirtualDOMNode** — `dispatchEvent()` fires stored event handlers synchronously. Combined with the unified render path, this enables end-to-end component behavior tests (click → signal update → re-render → query updated virtual tree) without a browser.
 
 ## Non-goals
 
 - Browser-side virtual DOM diffing (remains direct DOM manipulation)
 - Incremental/patch-based SSR updates (full tree rebuild per render)
 - Worker thread rendering (virtual DOM builds in main server thread only)
+- Full JS event model emulation (no `preventDefault`, `stopPropagation`, `event.target`/`currentTarget` reference management — MockDOMEvent covers essential fields only)
 
 ## Impact
 

--- a/openspec/changes/feat-virtual-dom/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/port-abstraction/spec.md
@@ -17,3 +17,39 @@ ServerDOMPort SHALL additionally provide `render_html(node: DOMNode) -> str` for
 - **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual tree
 - **THEN** a valid HTML string SHALL be returned
 - **AND** void elements SHALL be self-closing and text SHALL be escaped
+
+## ADDED Requirements
+
+### Requirement: DOMPort shall provide an event factory method
+
+`DOMPort.create_event(event_type: str, *, bubbles: bool = False, cancelable: bool = False) -> DOMEvent` SHALL create a DOM event object satisfying the `DOMEvent` Protocol. `BrowserDOMPort.create_event()` SHALL create a native JavaScript `Event` (via `new Event(type, {bubbles, cancelable})` or equivalent). `ServerDOMPort.create_event()` SHALL return a `VirtualDOMEvent` with the given type, bubbles, and cancelable settings.
+
+#### Scenario: BrowserDOMPort creates a native JS event
+- **WHEN** `BrowserDOMPort.create_event("click", bubbles=True, cancelable=True)` is called in the browser
+- **THEN** a native JS `Event` object SHALL be returned
+- **AND** `event.type` SHALL be `"click"`
+- **AND** `event.bubbles` SHALL be `True`
+- **AND** `event.cancelable` SHALL be `True`
+
+#### Scenario: ServerDOMPort creates a VirtualDOMEvent
+- **WHEN** `ServerDOMPort.create_event("change", bubbles=False, cancelable=False)` is called on the server
+- **THEN** a `VirtualDOMEvent` with `type == "change"` SHALL be returned
+- **AND** `event.bubbles` SHALL be `False`
+- **AND** `event.cancelable` SHALL be `False`
+
+### Requirement: DOMNode Protocol shall include dispatchEvent
+
+`DOMNode.dispatchEvent(event: DOMEvent) -> bool` SHALL be added to the `DOMNode` Protocol. In the browser, `BrowserDOMNode.dispatchEvent()` SHALL delegate to the native JS `node.dispatchEvent()`. On the server, `VirtualDOMNode.dispatchEvent()` SHALL execute at-target and bubbling phase handler invocation per standard DOM event semantics.
+
+#### Scenario: dispatchEvent is callable on any DOMNode via Protocol
+- **WHEN** code calls `node.dispatchEvent(event)` through the `DOMNode` Protocol
+- **THEN** the operation SHALL work on both `BrowserDOMNode` (delegates to native JS) and `VirtualDOMNode` (synchronous Python handler invocation)
+
+### Requirement: DOMEvent Protocol shall live in ports/_dom.py
+
+The `DOMEvent` Protocol SHALL be moved from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py`. `webcompy/elements/_dom_objs.py` SHALL re-export it for backwards compatibility. The Protocol SHALL define `type`, `bubbles`, `cancelable`, `target`, `currentTarget`, `defaultPrevented`, `eventPhase`, `timeStamp`, `preventDefault()`, and `stopPropagation()`.
+
+#### Scenario: DOMEvent is importable from ports._dom
+- **WHEN** `from webcompy.ports._dom import DOMEvent` is executed
+- **THEN** the `DOMEvent` Protocol SHALL be available
+- **AND** `webcompy.elements._dom_objs.DOMEvent` SHALL re-export the same Protocol

--- a/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
@@ -4,7 +4,7 @@
 
 WebComPy uses a `DOMNode` Protocol to abstract DOM operations. In the browser, `BrowserDOMNode` wraps a real JavaScript DOM node. On the server, `VirtualDOMNode` builds an in-memory DOM tree that satisfies the same Protocol. This enables a single rendering code path that works identically in both environments — the element system calls `dom_port.create_element()` and operates on the returned `DOMNode` without knowing whether it's real or virtual.
 
-The virtual tree can be serialized to HTML for static site generation and inspected in tests to verify exact DOM structure.
+The virtual tree can be serialized to HTML for static site generation and inspected in tests to verify exact DOM structure. Events can be created via `DOMPort.create_event()` and dispatched on `VirtualDOMNode` to simulate user interactions for component behavior testing.
 
 ## ADDED Requirements
 
@@ -54,7 +54,7 @@ The virtual tree can be serialized to HTML for static site generation and inspec
 
 `VirtualDOMNode.setAttribute(name, value)` SHALL store the attribute. `getAttribute(name)` SHALL return the stored value or `None`. `removeAttribute(name)` SHALL remove it. `hasAttribute(name)` SHALL return `True` if stored. `getAttributeNames()` SHALL return all stored attribute names.
 
-`VirtualDOMNode.addEventListener(event, handler)` SHALL record the event-handler pair. `removeEventListener(event, handler)` SHALL remove it by identity. `VirtualDOMNode.dispatchEvent(event: VirtualDOMEvent)` SHALL fire all stored handlers matching `event.type` synchronously.
+`VirtualDOMNode.addEventListener(event, handler)` SHALL record the event-handler pair. `removeEventListener(event, handler)` SHALL remove it by identity. `VirtualDOMNode.dispatchEvent(event: DOMEvent)` SHALL fire stored handlers and propagate through ancestors per standard DOM event phase semantics.
 
 #### Scenario: Setting and reading attributes on a virtual node
 - **WHEN** `node.setAttribute("id", "my-id")` is called
@@ -68,19 +68,73 @@ The virtual tree can be serialized to HTML for static site generation and inspec
 - **WHEN** `node.removeEventListener("click", handler)` is called
 - **THEN** the handler SHALL no longer be recorded
 
-#### Scenario: Dispatching an event on a virtual node
-- **WHEN** `node.addEventListener("click", handler)` is called
-- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called
-- **THEN** `handler` SHALL be invoked with the `VirtualDOMEvent` argument
+### Requirement: VirtualDOMEvent shall satisfy the DOMEvent Protocol
 
-### Requirement: VirtualDOMEvent shall provide minimal event fields
-
-`VirtualDOMEvent` SHALL be a simple class with `type` (event name string), `target` (the node), `currentTarget` (the node), and `preventDefault` (no-op). It SHALL live in `webcompy/ports/_server/_virtual_dom.py` alongside `VirtualDOMNode`.
+`VirtualDOMEvent` SHALL be a concrete class satisfying the `DOMEvent` Protocol defined in `webcompy/ports/_dom.py` (moved from `webcompy/elements/_dom_objs.py`). It SHALL provide `type`, `bubbles`, `cancelable`, `target`, `currentTarget`, `defaultPrevented`, `eventPhase`, `timeStamp`, `preventDefault()`, and `stopPropagation()`. It SHALL live in `webcompy/ports/_server/_virtual_dom.py` alongside `VirtualDOMNode`.
 
 #### Scenario: Constructing a VirtualDOMEvent
 - **WHEN** `VirtualDOMEvent("click")` is created
 - **THEN** `event.type` SHALL be `"click"`
-- **AND** `event.preventDefault()` SHALL be a no-op
+- **AND** `event.bubbles` SHALL be `False` (default)
+- **AND** `event.cancelable` SHALL be `False` (default)
+- **AND** `event.defaultPrevented` SHALL be `False`
+- **AND** `event.eventPhase` SHALL be `0` (NONE)
+- **AND** `event.target` SHALL be `None` (set by `dispatchEvent`)
+
+#### Scenario: Constructing a bubbling cancelable event
+- **WHEN** `VirtualDOMEvent("submit", bubbles=True, cancelable=True)` is created
+- **THEN** `event.bubbles` SHALL be `True`
+- **AND** `event.cancelable` SHALL be `True`
+
+#### Scenario: preventDefault on a cancelable event
+- **WHEN** `event = VirtualDOMEvent("click", cancelable=True)` and `event.preventDefault()` is called
+- **THEN** `event.defaultPrevented` SHALL be `True`
+
+#### Scenario: preventDefault on a non-cancelable event is ignored
+- **WHEN** `event = VirtualDOMEvent("click", cancelable=False)` and `event.preventDefault()` is called
+- **THEN** `event.defaultPrevented` SHALL remain `False`
+
+#### Scenario: stopPropagation
+- **WHEN** `event.stopPropagation()` is called during `dispatchEvent` handler execution
+- **THEN** further ancestor traversal SHALL be stopped
+
+### Requirement: VirtualDOMNode.dispatchEvent() shall implement standard event propagation
+
+`VirtualDOMNode.dispatchEvent(event: DOMEvent) -> bool` SHALL execute the at-target phase followed by the bubbling phase (if `event.bubbles` is `True`). During the at-target phase, `event.eventPhase` SHALL be `2` (AT_TARGET) and `event.target` and `event.currentTarget` SHALL both reference the dispatch target. Handlers registered via `addEventListener` with matching `event.type` SHALL be invoked synchronously. During the bubbling phase, `event.eventPhase` SHALL be `3` (BUBBLING) and `event.currentTarget` SHALL reference each ancestor. Propagation SHALL stop if `event.stopPropagation()` is called. The return value SHALL be `False` if `event.defaultPrevented` is `True` after all handlers have run, `True` otherwise. The capturing phase SHALL NOT be implemented (WebComPy event handlers always use `False` for `useCapture`).
+
+#### Scenario: Dispatching a non-bubbling event on the target
+- **WHEN** `node.addEventListener("click", handler)` is called
+- **AND** `event = VirtualDOMEvent("click", bubbles=False)` is created
+- **AND** `node.dispatchEvent(event)` is called
+- **THEN** `event.target` SHALL reference `node`
+- **AND** `event.currentTarget` SHALL reference `node`
+- **AND** `event.eventPhase` SHALL be `2` (AT_TARGET)
+- **AND** `handler` SHALL be invoked with `event`
+- **AND** no ancestor handlers SHALL be invoked
+
+#### Scenario: Dispatching a bubbling event through ancestors
+- **WHEN** `child.appendChild(grandchild)` builds a tree
+- **AND** `parent.addEventListener("click", parent_handler)` is registered
+- **AND** `child.addEventListener("click", child_handler)` is registered
+- **AND** `event = VirtualDOMEvent("click", bubbles=True)` is created
+- **AND** `grandchild.dispatchEvent(event)` is called
+- **THEN** `grandchild_handler` SHALL be invoked (at-target)
+- **AND** `child_handler` SHALL be invoked (bubbling, currentTarget = child)
+- **AND** `parent_handler` SHALL be invoked (bubbling, currentTarget = parent)
+- **AND** handlers SHALL be invoked in that order
+
+#### Scenario: stopPropagation during bubbling
+- **WHEN** `child.addEventListener("click", lambda e: e.stopPropagation())` is registered
+- **AND** `grandchild.dispatchEvent(VirtualDOMEvent("click", bubbles=True))` is called
+- **THEN** `parent_handler` SHALL NOT be invoked
+
+#### Scenario: dispatchEvent returns bool indicating default prevented
+- **WHEN** `event = VirtualDOMEvent("click", cancelable=True)` and a handler calls `event.preventDefault()`
+- **AND** `result = node.dispatchEvent(event)` is called
+- **THEN** `result` SHALL be `False`
+- **WHEN** no handler calls `preventDefault()`
+- **AND** `result = node.dispatchEvent(event)` is called
+- **THEN** `result` SHALL be `True`
 
 ### Requirement: ServerDOMPort.render_html() shall serialize VirtualDOMNode trees to HTML
 

--- a/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
+++ b/openspec/changes/feat-virtual-dom/specs/virtual-dom/spec.md
@@ -54,7 +54,7 @@ The virtual tree can be serialized to HTML for static site generation and inspec
 
 `VirtualDOMNode.setAttribute(name, value)` SHALL store the attribute. `getAttribute(name)` SHALL return the stored value or `None`. `removeAttribute(name)` SHALL remove it. `hasAttribute(name)` SHALL return `True` if stored. `getAttributeNames()` SHALL return all stored attribute names.
 
-`VirtualDOMNode.addEventListener(event, handler)` SHALL record the event-handler pair. `removeEventListener(event, handler)` SHALL remove it by identity.
+`VirtualDOMNode.addEventListener(event, handler)` SHALL record the event-handler pair. `removeEventListener(event, handler)` SHALL remove it by identity. `VirtualDOMNode.dispatchEvent(event: VirtualDOMEvent)` SHALL fire all stored handlers matching `event.type` synchronously.
 
 #### Scenario: Setting and reading attributes on a virtual node
 - **WHEN** `node.setAttribute("id", "my-id")` is called
@@ -67,6 +67,20 @@ The virtual tree can be serialized to HTML for static site generation and inspec
 - **THEN** the handler SHALL be recorded
 - **WHEN** `node.removeEventListener("click", handler)` is called
 - **THEN** the handler SHALL no longer be recorded
+
+#### Scenario: Dispatching an event on a virtual node
+- **WHEN** `node.addEventListener("click", handler)` is called
+- **AND** `node.dispatchEvent(VirtualDOMEvent("click"))` is called
+- **THEN** `handler` SHALL be invoked with the `VirtualDOMEvent` argument
+
+### Requirement: VirtualDOMEvent shall provide minimal event fields
+
+`VirtualDOMEvent` SHALL be a simple class with `type` (event name string), `target` (the node), `currentTarget` (the node), and `preventDefault` (no-op). It SHALL live in `webcompy/ports/_server/_virtual_dom.py` alongside `VirtualDOMNode`.
+
+#### Scenario: Constructing a VirtualDOMEvent
+- **WHEN** `VirtualDOMEvent("click")` is created
+- **THEN** `event.type` SHALL be `"click"`
+- **AND** `event.preventDefault()` SHALL be a no-op
 
 ### Requirement: ServerDOMPort.render_html() shall serialize VirtualDOMNode trees to HTML
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -4,7 +4,9 @@
 - [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove` — manage children list and parent references
 - [ ] 1.3 Implement attribute operations: `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`
 - [ ] 1.4 Implement event operations: `addEventListener`, `removeEventListener` — store as `(event_name, handler)` tuples
-- [ ] 1.5 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)
+- [ ] 1.5 Implement `dispatchEvent(event: MockDOMEvent) -> None` — fire stored handlers matching `event.type` synchronously so that signal updates and re-rendering propagate within the same call stack
+- [ ] 1.6 Create `MockDOMEvent` class in `webcompy/testing/_dom.py` — minimal `type`, `target`, `currentTarget`, `preventDefault` for use with `VirtualDOMNode.dispatchEvent()`
+- [ ] 1.7 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)
 
 ## 2. ServerDOMPort rewrite
 
@@ -28,6 +30,7 @@
 - [ ] 3.11 Implement `TestRenderer.render(component)` — creates a `DIScope` with `ServerDOMPort`, calls `component.render()`, returns a `TestRendererResult` wrapping the virtual root node
 - [ ] 3.12 Implement `TestRendererResult` query methods — `query_selector(tag)`, `query_selector_all(tag)`, `find_by_text(text)`, `find_by_attribute(name, value)`, `to_html()` — traverse the virtual tree and return matching `VirtualDOMNode`(s)
 - [ ] 3.13 Implement `TestRendererResult` tree assertion helpers — `assert_element(tag, text=None)`, `assert_element_count(tag, count)`, `assert_has_class(cls)` — raise `AssertionError` on mismatch
+- [ ] 3.14 Implement `TestRendererResult.rerender()` — re-executes component `render()` on the existing virtual root so that signal changes from `dispatchEvent()` are reflected in the queryable tree
 
 ## 4. Unify render path in element base classes
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -4,8 +4,8 @@
 - [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove` — manage children list and parent references
 - [ ] 1.3 Implement attribute operations: `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`
 - [ ] 1.4 Implement event operations: `addEventListener`, `removeEventListener` — store as `(event_name, handler)` tuples
-- [ ] 1.5 Implement `dispatchEvent(event: MockDOMEvent) -> None` — fire stored handlers matching `event.type` synchronously so that signal updates and re-rendering propagate within the same call stack
-- [ ] 1.6 Create `MockDOMEvent` class in `webcompy/testing/_dom.py` — minimal `type`, `target`, `currentTarget`, `preventDefault` for use with `VirtualDOMNode.dispatchEvent()`
+- [ ] 1.5 Create `VirtualDOMEvent` class in `webcompy/ports/_server/_virtual_dom.py` — minimal `type`, `target`, `currentTarget`, `preventDefault` (no-op) for use with `VirtualDOMNode.dispatchEvent()`
+- [ ] 1.6 Implement `dispatchEvent(event: VirtualDOMEvent) -> None` on `VirtualDOMNode` — fire stored handlers matching `event.type` synchronously so that signal updates and re-rendering propagate within the same call stack
 - [ ] 1.7 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)
 
 ## 2. ServerDOMPort rewrite
@@ -15,106 +15,58 @@
 - [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, output void elements without closing tags (e.g., `<br>`, `<img>`) per HTML5 convention, omit `None`-valued attributes
 - [ ] 2.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
 
-## 3. webcompy.testing module
+## 3. Unify render path in element base classes
 
-- [ ] 3.1 Create `webcompy/testing/` package — `__init__.py` re-exporting key symbols, `_dom.py` for `FakeDOMNode`, `_ports.py` for port fakes, helper for pre-wired `DIScope`
-- [ ] 3.2 Move `FakeDOMNode` from `tests/conftest.py` to `webcompy/testing/_dom.py` — no behavior changes, just relocation
-- [ ] 3.3 Fix `FakeBrowserFFIPort` Protocol compliance — add missing `to_js` and `assign` methods that match `FFIPort` ABC
-- [ ] 3.4 Create `create_browser_scope()` helper — returns a `DIScope` with all browser-side fake ports (FakeBrowserDOMPort, FakeBrowserHostPort, FakeBrowserFFIPort) wired up, mirroring the `fake_browser_full` fixture
-- [ ] 3.5 Create `create_server_scope()` helper — returns a `DIScope` with `ServerDOMPort` wired up; enables `component.render()` to build `VirtualDOMNode` trees in tests
-- [ ] 3.6 Create `create_test_app()` helper — instantiates a minimal `WebComPyApp` with the given scope, enabling component rendering tests without a full server
-- [ ] 3.7 Add `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` — prevents the testing module from being bundled into browser wheels
-- [ ] 3.8 Update all test files that import from `conftest` (`FakeDOMNode`, `FakeBrowserDOMPort`, `MockHistoryPort` is out of scope) to import from `webcompy.testing` instead
-- [ ] 3.9 Remove `FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `tests/conftest.py` — replaced by imports from `webcompy.testing`
-- [ ] 3.10 Create `webcompy/testing/_renderer.py` with `TestRenderer` class — high-level API for rendering components to `VirtualDOMNode` trees and querying the result (jsdom-like for WebComPy)
-- [ ] 3.11 Implement `TestRenderer.render(component)` — creates a `DIScope` with `ServerDOMPort`, calls `component.render()`, returns a `TestRendererResult` wrapping the virtual root node
-- [ ] 3.12 Implement `TestRendererResult` query methods — `query_selector(tag)`, `query_selector_all(tag)`, `find_by_text(text)`, `find_by_attribute(name, value)`, `to_html()` — traverse the virtual tree and return matching `VirtualDOMNode`(s)
-- [ ] 3.13 Implement `TestRendererResult` tree assertion helpers — `assert_element(tag, text=None)`, `assert_element_count(tag, count)`, `assert_has_class(cls)` — raise `AssertionError` on mismatch
-- [ ] 3.14 Implement `TestRendererResult.rerender()` — re-executes component `render()` on the existing virtual root so that signal changes from `dispatchEvent()` are reflected in the queryable tree
+- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
+- [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
+- [ ] 3.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
+- [ ] 3.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
+- [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
+- [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
+- [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
+- [ ] 3.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
+- [ ] 3.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
 
-## 4. Unify render path in element base classes
+## 4. Router accessibility for testing
 
-- [ ] 4.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 6)
-- [ ] 4.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
-- [ ] 4.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
-- [ ] 4.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
-- [ ] 4.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
-- [ ] 4.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
-- [ ] 4.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
-- [ ] 4.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
-- [ ] 4.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
+- [ ] 4.1 Modify `RouterLink._on_click()` in `webcompy/router/_link.py` — remove `ENVIRONMENT != "pyscript"` early return; instead, guard only the `pyscript` import, `pushState`, and `window.location` access inside a `if ENVIRONMENT == "pyscript"` block. `self._router.__set_path__(href, params)` executes unconditionally so that `dispatchEvent(VirtualDOMEvent("click"))` on a rendered RouterLink triggers full route transition (guards → navigate → after_route_change → SwitchElement route selection)
 
-## 5. Router accessibility for testing
+## 5. Remove _render_html() from element subclasses
 
-- [ ] 5.1 Modify `RouterLink._on_click()` in `webcompy/router/_link.py` — remove `ENVIRONMENT != "pyscript"` early return; instead, guard only the `pyscript` import, `pushState`, and `window.location` access inside a `if ENVIRONMENT == "pyscript"` block. `self._router.__set_path__(href, params)` executes unconditionally so that `dispatchEvent(MockDOMEvent("click"))` on a rendered RouterLink triggers full route transition (guards → navigate → after_route_change → SwitchElement route selection)
-- [ ] 5.2 Add unit test for RouterLink click → route navigation — render a component tree containing RouterLink via TestRenderer, dispatch click event, verify that `MockHistoryPort.value` shows the new path and that `SwitchElement` (via `RouterView`) correctly renders the target route component in the virtual DOM tree
-- [ ] 5.3 Add unit test for `before_route_change` guard cancellation via RouterLink click — set up a guard returning `False`, dispatch click on RouterLink, verify path remains unchanged and wrong route is NOT rendered
-- [ ] 5.4 Add unit test for `after_route_change` callback via RouterLink click — dispatch click, verify callback was invoked with the new path
+- [ ] 5.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 5.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
 
-## 6. Remove _render_html() from element subclasses
+## 6. Update server-side rendering entry points
 
-- [ ] 6.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
-- [ ] 6.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+- [ ] 6.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
+- [ ] 6.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
+- [ ] 6.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
 
-## 7. Update server-side rendering entry points
+## 7. Element system adapter for server DOMPort
 
-- [ ] 7.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
-- [ ] 7.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
-- [ ] 7.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
+- [ ] 7.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
+- [ ] 7.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
 
-## 8. Element system adapter for server DOMPort
+## 8. Tests
 
-- [ ] 8.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
-- [ ] 8.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
+- [ ] 8.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording, dispatchEvent
+- [ ] 8.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
+- [ ] 8.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
+- [ ] 8.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
+- [ ] 8.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
+- [ ] 8.6 Run existing test suite and fix regressions
 
-## 9. Tests
+## 9. Cleanup
 
-- [ ] 9.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
-- [ ] 9.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
-- [ ] 9.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
-- [ ] 9.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
-- [ ] 9.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
-- [ ] 9.6 Run existing test suite and fix regressions
+- [ ] 9.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 9.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 9.3 Update type stubs if `_render_html` appears in any `.pyi` files
 
-## 10. E2E test migration to unit tests
+## 10. Verification
 
-### Purely rendering — fully migratable (24 tests)
-
-- [ ] 10.1 Migrate `tests/e2e/test_component.py` (2 tests) — replace `to_be_visible`/`to_have_text` with `TestRenderer.render()` + virtual tree assertions; component text content is fully verifiable via `VirtualDOMNode`
-- [ ] 10.2 Migrate `tests/e2e/test_standalone.py` (4 tests) — CDN URL absence, local asset paths, file existence checks; no Playwright usage, move these to `tests/` under `pytest.mark.e2e` removed
-- [ ] 10.3 Migrate `tests/e2e/test_bundled_deps.py` (9 tests) — lockfile existence/schema, wheel content, HTML string verification; no Playwright usage, move to `tests/` as regular unit tests
-- [ ] 10.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
-- [ ] 10.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
-
-### Mixed — fully migratable with dispatchEvent (29 tests)
-
-- [ ] 10.6 Migrate `test_switch.py` (3 tests) — all tests use only click events; `dispatchEvent(MockDOMEvent("click"))` replaces Playwright `click()`. Default state, toggle on, toggle off all work via virtual DOM assertions.
-- [ ] 10.7 Migrate `test_reactive.py` (3 tests) — text update, list operations, dict operations all triggered by button clicks ignoring event arg. dispatchEvent + rerender + virtual tree assertions fully cover.
-- [ ] 10.8 Migrate `test_repeat.py` (3 tests) — initial empty state (no interaction) plus add/remove via clicks. dispatchEvent covers all interactive assertions.
-- [ ] 10.9 Migrate `test_keyed_repeat.py` (4 of 5 tests) — initial empty, add items, remove first, insert at start all use click-only handlers. **Exclude**: `test_keyed_repeat_input_preserved_after_add` — verifies real browser `<input>` widget state survives keyed reconciliation; virtual DOM has no equivalent widget state.
-- [ ] 10.10 Migrate `test_dict_repeat.py` (4 of 5 tests) — same pattern as keyed repeat. **Exclude**: `test_dict_repeat_input_preserved_after_add` — same browser `<input>` widget state requirement.
-- [ ] 10.11 Migrate `test_nested_dynamic.py` (6 tests) — all tests (initial view, switch to grid, switch back, add item, add then switch, remove first) use click-only handlers. dispatchEvent + rerender covers all.
-- [ ] 10.12 Migrate `test_scoped_style.py` (2 of 7 tests) — `test_scoped_style_attribute_selector` and `test_scoped_style_top_level_media_query` only check `<style>` element `textContent` against virtual DOM. **Exclude**: 5 tests using `getComputedStyle()` which requires a real browser CSS engine.
-- [ ] 10.13 Migrate `test_di.py` (2 of 5 tests) — `test_provide_inject_from_parent` and `test_inject_from_app_level` can render DI components directly via TestRenderer with proper DI scope set up. **Exclude**: 3 tests using RouterLink navigation (now handled by group 5) and `assert_no_console_errors`.
-- [ ] 10.14 Migrate `test_lifecycle.py` (2 of 3 tests) — `test_lifecycle_hooks_fire` and `test_on_after_rendering_on_interactions` use click-only handler or no interaction. **Exclude**: `test_on_before_rendering_on_navigation` — depends on RouterView destroy/recreate cycle during navigation (partially covered by group 5).
-- [ ] 10.15 Migrate `test_di.py` navigation tests (2 of 5 in test_di.py) — `test_di_navigation_no_python_errors` and `test_di_home_then_navigate_then_back` — after group 5 RouterLink fix, navigation via RouterLink is testable with dispatchEvent; `assert_no_console_errors` replaced by exception assertion.
-
-### Verification
-
-- [ ] 10.16 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope (browser-required tests stay in E2E)
-- [ ] 10.17 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
-
-## 11. Cleanup
-
-- [ ] 11.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
-- [ ] 11.2 Remove any `_render_html`-specific test utilities or helpers
-- [ ] 11.3 Update type stubs if `_render_html` appears in any `.pyi` files
-
-## 12. Verification
-
-- [ ] 12.1 Run lint: `uv run ruff check .`
-- [ ] 12.2 Run type check: `uv run pyright`
-- [ ] 12.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
-- [ ] 12.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
-- [ ] 12.5 Diff generated docs against baseline to confirm no output regressions
-- [ ] 12.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`
+- [ ] 10.1 Run lint: `uv run ruff check .`
+- [ ] 10.2 Run type check: `uv run pyright`
+- [ ] 10.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 10.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 10.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 10.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -44,69 +44,77 @@
 - [ ] 4.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
 - [ ] 4.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
 
-## 5. Remove _render_html() from element subclasses
+## 5. Router accessibility for testing
 
-- [ ] 5.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
-- [ ] 5.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+- [ ] 5.1 Modify `RouterLink._on_click()` in `webcompy/router/_link.py` — remove `ENVIRONMENT != "pyscript"` early return; instead, guard only the `pyscript` import, `pushState`, and `window.location` access inside a `if ENVIRONMENT == "pyscript"` block. `self._router.__set_path__(href, params)` executes unconditionally so that `dispatchEvent(MockDOMEvent("click"))` on a rendered RouterLink triggers full route transition (guards → navigate → after_route_change → SwitchElement route selection)
+- [ ] 5.2 Add unit test for RouterLink click → route navigation — render a component tree containing RouterLink via TestRenderer, dispatch click event, verify that `MockHistoryPort.value` shows the new path and that `SwitchElement` (via `RouterView`) correctly renders the target route component in the virtual DOM tree
+- [ ] 5.3 Add unit test for `before_route_change` guard cancellation via RouterLink click — set up a guard returning `False`, dispatch click on RouterLink, verify path remains unchanged and wrong route is NOT rendered
+- [ ] 5.4 Add unit test for `after_route_change` callback via RouterLink click — dispatch click, verify callback was invoked with the new path
 
-## 6. Update server-side rendering entry points
+## 6. Remove _render_html() from element subclasses
 
-- [ ] 6.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
-- [ ] 6.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
-- [ ] 6.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
+- [ ] 6.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 6.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
 
-## 7. Element system adapter for server DOMPort
+## 7. Update server-side rendering entry points
 
-- [ ] 7.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
-- [ ] 7.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
+- [ ] 7.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
+- [ ] 7.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
+- [ ] 7.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
 
-## 8. Tests
+## 8. Element system adapter for server DOMPort
 
-- [ ] 8.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
-- [ ] 8.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
-- [ ] 8.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
-- [ ] 8.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
-- [ ] 8.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
-- [ ] 8.6 Run existing test suite and fix regressions
+- [ ] 8.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
+- [ ] 8.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
 
-## 9. E2E test migration to unit tests
+## 9. Tests
+
+- [ ] 9.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
+- [ ] 9.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
+- [ ] 9.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
+- [ ] 9.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
+- [ ] 9.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
+- [ ] 9.6 Run existing test suite and fix regressions
+
+## 10. E2E test migration to unit tests
 
 ### Purely rendering — fully migratable (24 tests)
 
-- [ ] 9.1 Migrate `tests/e2e/test_component.py` (2 tests) — replace `to_be_visible`/`to_have_text` with `TestRenderer.render()` + virtual tree assertions; component text content is fully verifiable via `VirtualDOMNode`
-- [ ] 9.2 Migrate `tests/e2e/test_standalone.py` (4 tests) — CDN URL absence, local asset paths, file existence checks; no Playwright usage, move these to `tests/` under `pytest.mark.e2e` removed
-- [ ] 9.3 Migrate `tests/e2e/test_bundled_deps.py` (9 tests) — lockfile existence/schema, wheel content, HTML string verification; no Playwright usage, move to `tests/` as regular unit tests
-- [ ] 9.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
-- [ ] 9.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
+- [ ] 10.1 Migrate `tests/e2e/test_component.py` (2 tests) — replace `to_be_visible`/`to_have_text` with `TestRenderer.render()` + virtual tree assertions; component text content is fully verifiable via `VirtualDOMNode`
+- [ ] 10.2 Migrate `tests/e2e/test_standalone.py` (4 tests) — CDN URL absence, local asset paths, file existence checks; no Playwright usage, move these to `tests/` under `pytest.mark.e2e` removed
+- [ ] 10.3 Migrate `tests/e2e/test_bundled_deps.py` (9 tests) — lockfile existence/schema, wheel content, HTML string verification; no Playwright usage, move to `tests/` as regular unit tests
+- [ ] 10.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
+- [ ] 10.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
 
 ### Mixed — fully migratable with dispatchEvent (29 tests)
 
-- [ ] 9.6 Migrate `test_switch.py` (3 tests) — all tests use only click events; `dispatchEvent(MockDOMEvent("click"))` replaces Playwright `click()`. Default state, toggle on, toggle off all work via virtual DOM assertions.
-- [ ] 9.7 Migrate `test_reactive.py` (3 tests) — text update, list operations, dict operations all triggered by button clicks ignoring event arg. dispatchEvent + rerender + virtual tree assertions fully cover.
-- [ ] 9.8 Migrate `test_repeat.py` (3 tests) — initial empty state (no interaction) plus add/remove via clicks. dispatchEvent covers all interactive assertions.
-- [ ] 9.9 Migrate `test_keyed_repeat.py` (4 of 5 tests) — initial empty, add items, remove first, insert at start all use click-only handlers. **Exclude**: `test_keyed_repeat_input_preserved_after_add` — verifies real browser `<input>` widget state survives keyed reconciliation; virtual DOM has no equivalent widget state.
-- [ ] 9.10 Migrate `test_dict_repeat.py` (4 of 5 tests) — same pattern as keyed repeat. **Exclude**: `test_dict_repeat_input_preserved_after_add` — same browser `<input>` widget state requirement.
-- [ ] 9.11 Migrate `test_nested_dynamic.py` (6 tests) — all tests (initial view, switch to grid, switch back, add item, add then switch, remove first) use click-only handlers. dispatchEvent + rerender covers all.
-- [ ] 9.12 Migrate `test_scoped_style.py` (2 of 7 tests) — `test_scoped_style_attribute_selector` and `test_scoped_style_top_level_media_query` only check `<style>` element `textContent` against virtual DOM. **Exclude**: 5 tests using `getComputedStyle()` which requires a real browser CSS engine.
-- [ ] 9.13 Migrate `test_di.py` (2 of 5 tests) — `test_provide_inject_from_parent` and `test_inject_from_app_level` can render DI components directly via TestRenderer with proper DI scope set up. **Exclude**: 3 tests using RouterLink navigation (inert outside PyScript) and `assert_no_console_errors`.
-- [ ] 9.14 Migrate `test_lifecycle.py` (2 of 3 tests) — `test_lifecycle_hooks_fire` and `test_on_after_rendering_on_interactions` use click-only handler or no interaction. **Exclude**: `test_on_before_rendering_on_navigation` — depends on RouterLink navigation and RouterView destroy/recreate cycle.
+- [ ] 10.6 Migrate `test_switch.py` (3 tests) — all tests use only click events; `dispatchEvent(MockDOMEvent("click"))` replaces Playwright `click()`. Default state, toggle on, toggle off all work via virtual DOM assertions.
+- [ ] 10.7 Migrate `test_reactive.py` (3 tests) — text update, list operations, dict operations all triggered by button clicks ignoring event arg. dispatchEvent + rerender + virtual tree assertions fully cover.
+- [ ] 10.8 Migrate `test_repeat.py` (3 tests) — initial empty state (no interaction) plus add/remove via clicks. dispatchEvent covers all interactive assertions.
+- [ ] 10.9 Migrate `test_keyed_repeat.py` (4 of 5 tests) — initial empty, add items, remove first, insert at start all use click-only handlers. **Exclude**: `test_keyed_repeat_input_preserved_after_add` — verifies real browser `<input>` widget state survives keyed reconciliation; virtual DOM has no equivalent widget state.
+- [ ] 10.10 Migrate `test_dict_repeat.py` (4 of 5 tests) — same pattern as keyed repeat. **Exclude**: `test_dict_repeat_input_preserved_after_add` — same browser `<input>` widget state requirement.
+- [ ] 10.11 Migrate `test_nested_dynamic.py` (6 tests) — all tests (initial view, switch to grid, switch back, add item, add then switch, remove first) use click-only handlers. dispatchEvent + rerender covers all.
+- [ ] 10.12 Migrate `test_scoped_style.py` (2 of 7 tests) — `test_scoped_style_attribute_selector` and `test_scoped_style_top_level_media_query` only check `<style>` element `textContent` against virtual DOM. **Exclude**: 5 tests using `getComputedStyle()` which requires a real browser CSS engine.
+- [ ] 10.13 Migrate `test_di.py` (2 of 5 tests) — `test_provide_inject_from_parent` and `test_inject_from_app_level` can render DI components directly via TestRenderer with proper DI scope set up. **Exclude**: 3 tests using RouterLink navigation (now handled by group 5) and `assert_no_console_errors`.
+- [ ] 10.14 Migrate `test_lifecycle.py` (2 of 3 tests) — `test_lifecycle_hooks_fire` and `test_on_after_rendering_on_interactions` use click-only handler or no interaction. **Exclude**: `test_on_before_rendering_on_navigation` — depends on RouterView destroy/recreate cycle during navigation (partially covered by group 5).
+- [ ] 10.15 Migrate `test_di.py` navigation tests (2 of 5 in test_di.py) — `test_di_navigation_no_python_errors` and `test_di_home_then_navigate_then_back` — after group 5 RouterLink fix, navigation via RouterLink is testable with dispatchEvent; `assert_no_console_errors` replaced by exception assertion.
 
 ### Verification
 
-- [ ] 9.15 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope (11 browser-required tests stay in E2E)
-- [ ] 9.16 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
+- [ ] 10.16 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope (browser-required tests stay in E2E)
+- [ ] 10.17 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
 
-## 10. Cleanup
+## 11. Cleanup
 
-- [ ] 10.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
-- [ ] 10.2 Remove any `_render_html`-specific test utilities or helpers
-- [ ] 10.3 Update type stubs if `_render_html` appears in any `.pyi` files
+- [ ] 11.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 11.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 11.3 Update type stubs if `_render_html` appears in any `.pyi` files
 
-## 11. Verification
+## 12. Verification
 
-- [ ] 11.1 Run lint: `uv run ruff check .`
-- [ ] 11.2 Run type check: `uv run pyright`
-- [ ] 11.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
-- [ ] 11.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
-- [ ] 11.5 Diff generated docs against baseline to confirm no output regressions
-- [ ] 11.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`
+- [ ] 12.1 Run lint: `uv run ruff check .`
+- [ ] 12.2 Run type check: `uv run pyright`
+- [ ] 12.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 12.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 12.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 12.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -79,23 +79,22 @@
 - [ ] 9.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
 - [ ] 9.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
 
-### Mixed — extract rendering-only assertions into new unit tests (~15 tests)
+### Mixed — fully migratable with dispatchEvent (29 tests)
 
-- [ ] 9.6 Add `test_switch_initial_state` to `tests/test_switch.py` using `TestRenderer` — verify `switch()` renders the correct branch on initial render without browser interaction
-- [ ] 9.7 Add initial reactive text value tests to `tests/test_reactive.py` using `TestRenderer` — verify computed signals render correct initial text in the virtual tree
-- [ ] 9.8 Add initial nested dynamic state test to `tests/test_nested_dynamic.py` using `TestRenderer` — verify `repeat` inside `switch` renders correct initial children
-- [ ] 9.9 Add DI inject rendering test to `tests/test_di.py` using `TestRenderer` — verify `provide`/`inject` values are correctly rendered in component output
-- [ ] 9.10 Add lifecycle render-count test to `tests/test_lifecycle.py` using `TestRenderer` — verify initial `render-count` is 1 in the virtual tree
-
-### Remove redundant E2E assertions (already covered by existing unit tests)
-
-- [ ] 9.11 Remove style textContent assertions from `tests/e2e/test_scoped_style.py` — CSS content (selector names, pseudo-classes, `webcompy-cid-`) is already fully covered by `tests/test_scoped_style_generation.py`; keep only `getComputedStyle` color assertions
-- [ ] 9.12 Remove initial empty-list `to_have_count(0)` assertions from `tests/e2e/test_repeat.py`, `test_keyed_repeat.py`, `test_dict_repeat.py` — already covered by `tests/test_repeat.py` etc.
+- [ ] 9.6 Migrate `test_switch.py` (3 tests) — all tests use only click events; `dispatchEvent(MockDOMEvent("click"))` replaces Playwright `click()`. Default state, toggle on, toggle off all work via virtual DOM assertions.
+- [ ] 9.7 Migrate `test_reactive.py` (3 tests) — text update, list operations, dict operations all triggered by button clicks ignoring event arg. dispatchEvent + rerender + virtual tree assertions fully cover.
+- [ ] 9.8 Migrate `test_repeat.py` (3 tests) — initial empty state (no interaction) plus add/remove via clicks. dispatchEvent covers all interactive assertions.
+- [ ] 9.9 Migrate `test_keyed_repeat.py` (4 of 5 tests) — initial empty, add items, remove first, insert at start all use click-only handlers. **Exclude**: `test_keyed_repeat_input_preserved_after_add` — verifies real browser `<input>` widget state survives keyed reconciliation; virtual DOM has no equivalent widget state.
+- [ ] 9.10 Migrate `test_dict_repeat.py` (4 of 5 tests) — same pattern as keyed repeat. **Exclude**: `test_dict_repeat_input_preserved_after_add` — same browser `<input>` widget state requirement.
+- [ ] 9.11 Migrate `test_nested_dynamic.py` (6 tests) — all tests (initial view, switch to grid, switch back, add item, add then switch, remove first) use click-only handlers. dispatchEvent + rerender covers all.
+- [ ] 9.12 Migrate `test_scoped_style.py` (2 of 7 tests) — `test_scoped_style_attribute_selector` and `test_scoped_style_top_level_media_query` only check `<style>` element `textContent` against virtual DOM. **Exclude**: 5 tests using `getComputedStyle()` which requires a real browser CSS engine.
+- [ ] 9.13 Migrate `test_di.py` (2 of 5 tests) — `test_provide_inject_from_parent` and `test_inject_from_app_level` can render DI components directly via TestRenderer with proper DI scope set up. **Exclude**: 3 tests using RouterLink navigation (inert outside PyScript) and `assert_no_console_errors`.
+- [ ] 9.14 Migrate `test_lifecycle.py` (2 of 3 tests) — `test_lifecycle_hooks_fire` and `test_on_after_rendering_on_interactions` use click-only handler or no interaction. **Exclude**: `test_on_before_rendering_on_navigation` — depends on RouterLink navigation and RouterView destroy/recreate cycle.
 
 ### Verification
 
-- [ ] 9.13 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope
-- [ ] 9.14 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
+- [ ] 9.15 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope (11 browser-required tests stay in E2E)
+- [ ] 9.16 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
 
 ## 10. Cleanup
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -66,17 +66,45 @@
 - [ ] 8.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
 - [ ] 8.6 Run existing test suite and fix regressions
 
-## 9. Cleanup
+## 9. E2E test migration to unit tests
 
-- [ ] 9.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
-- [ ] 9.2 Remove any `_render_html`-specific test utilities or helpers
-- [ ] 9.3 Update type stubs if `_render_html` appears in any `.pyi` files
+### Purely rendering — fully migratable (24 tests)
 
-## 10. Verification
+- [ ] 9.1 Migrate `tests/e2e/test_component.py` (2 tests) — replace `to_be_visible`/`to_have_text` with `TestRenderer.render()` + virtual tree assertions; component text content is fully verifiable via `VirtualDOMNode`
+- [ ] 9.2 Migrate `tests/e2e/test_standalone.py` (4 tests) — CDN URL absence, local asset paths, file existence checks; no Playwright usage, move these to `tests/` under `pytest.mark.e2e` removed
+- [ ] 9.3 Migrate `tests/e2e/test_bundled_deps.py` (9 tests) — lockfile existence/schema, wheel content, HTML string verification; no Playwright usage, move to `tests/` as regular unit tests
+- [ ] 9.4 Migrate `tests/e2e/test_static_site.py` (7 tests) — wheel filename content-hash pattern, zip validity, HTML wheel URL; no Playwright usage, move to `tests/`
+- [ ] 9.5 Migrate `test_runtime_local_no_cdn_urls` and `test_runtime_local_static_assets_exist` from `tests/e2e/test_runtime_local.py` (2 tests) — HTML string verification without Playwright
 
-- [ ] 10.1 Run lint: `uv run ruff check .`
-- [ ] 10.2 Run type check: `uv run pyright`
-- [ ] 10.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
-- [ ] 10.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
-- [ ] 10.5 Diff generated docs against baseline to confirm no output regressions
-- [ ] 10.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`
+### Mixed — extract rendering-only assertions into new unit tests (~15 tests)
+
+- [ ] 9.6 Add `test_switch_initial_state` to `tests/test_switch.py` using `TestRenderer` — verify `switch()` renders the correct branch on initial render without browser interaction
+- [ ] 9.7 Add initial reactive text value tests to `tests/test_reactive.py` using `TestRenderer` — verify computed signals render correct initial text in the virtual tree
+- [ ] 9.8 Add initial nested dynamic state test to `tests/test_nested_dynamic.py` using `TestRenderer` — verify `repeat` inside `switch` renders correct initial children
+- [ ] 9.9 Add DI inject rendering test to `tests/test_di.py` using `TestRenderer` — verify `provide`/`inject` values are correctly rendered in component output
+- [ ] 9.10 Add lifecycle render-count test to `tests/test_lifecycle.py` using `TestRenderer` — verify initial `render-count` is 1 in the virtual tree
+
+### Remove redundant E2E assertions (already covered by existing unit tests)
+
+- [ ] 9.11 Remove style textContent assertions from `tests/e2e/test_scoped_style.py` — CSS content (selector names, pseudo-classes, `webcompy-cid-`) is already fully covered by `tests/test_scoped_style_generation.py`; keep only `getComputedStyle` color assertions
+- [ ] 9.12 Remove initial empty-list `to_have_count(0)` assertions from `tests/e2e/test_repeat.py`, `test_keyed_repeat.py`, `test_dict_repeat.py` — already covered by `tests/test_repeat.py` etc.
+
+### Verification
+
+- [ ] 9.13 Verify all E2E tests pass after migration — remaining E2E tests must still pass with reduced scope
+- [ ] 9.14 Update CI e2e-matrix in `.github/workflows/ci.yml` if any E2E test files are removed or renamed
+
+## 10. Cleanup
+
+- [ ] 10.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 10.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 10.3 Update type stubs if `_render_html` appears in any `.pyi` files
+
+## 11. Verification
+
+- [ ] 11.1 Run lint: `uv run ruff check .`
+- [ ] 11.2 Run type check: `uv run pyright`
+- [ ] 11.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 11.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 11.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 11.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -4,69 +4,77 @@
 - [ ] 1.2 Implement tree operations: `appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove` — manage children list and parent references
 - [ ] 1.3 Implement attribute operations: `setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`
 - [ ] 1.4 Implement event operations: `addEventListener`, `removeEventListener` — store as `(event_name, handler)` tuples
-- [ ] 1.5 Create `VirtualDOMEvent` class in `webcompy/ports/_server/_virtual_dom.py` — minimal `type`, `target`, `currentTarget`, `preventDefault` (no-op) for use with `VirtualDOMNode.dispatchEvent()`
-- [ ] 1.6 Implement `dispatchEvent(event: VirtualDOMEvent) -> None` on `VirtualDOMNode` — fire stored handlers matching `event.type` synchronously so that signal updates and re-rendering propagate within the same call stack
+- [ ] 1.5 Create `VirtualDOMEvent` class in `webcompy/ports/_server/_virtual_dom.py` satisfying the `DOMEvent` Protocol — full fields: `type`, `bubbles`, `cancelable`, `target`, `currentTarget`, `defaultPrevented`, `eventPhase`, `timeStamp`, `preventDefault()` (gates on `cancelable`), `stopPropagation()`
+- [ ] 1.6 Implement `dispatchEvent(event: DOMEvent) -> bool` on `VirtualDOMNode` — at-target phase (eventPhase=2, target=currentTarget=this), then bubbling phase (eventPhase=3, walk _parent chain) if `event.bubbles`. Stop if `event._propagation_stopped`. Return `not event.defaultPrevented`. The capturing phase SHALL NOT be implemented (WebComPy always uses `useCapture=False`).
 - [ ] 1.7 Implement properties: `childNodes` (returns list), `textContent` (get/set), `nodeName` (returns tag_name), `nodeType` (1=element, 3=text)
 
-## 2. ServerDOMPort rewrite
+## 2. Protocol layer — DOMEvent, DOMNode, DOMPort
 
-- [ ] 2.1 Rewrite `webcompy/ports/_server/_dom.py` — replace exception-throwing stubs with virtual DOM factory: `create_element()` returns `VirtualDOMNode`, `create_text_node()` returns virtual text node
-- [ ] 2.2 Implement `ServerDOMPort.render_html(node: DOMNode) -> str` — traverse virtual tree, serialize to HTML string
-- [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, output void elements without closing tags (e.g., `<br>`, `<img>`) per HTML5 convention, omit `None`-valued attributes
-- [ ] 2.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
+- [ ] 2.1 Move `DOMEvent` Protocol from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py` — alongside `DOMNode` and `DOMPort`. Keep re-export in `_dom_objs.py` for backwards compatibility.
+- [ ] 2.2 Add `dispatchEvent(event: DOMEvent) -> bool` to `DOMNode` Protocol in `webcompy/ports/_dom.py`
+- [ ] 2.3 Add `create_event(event_type: str, *, bubbles: bool = False, cancelable: bool = False) -> DOMEvent` abstract method to `DOMPort` ABC in `webcompy/ports/_dom.py`
+- [ ] 2.4 Implement `BrowserDOMPort.create_event()` — create a native JS `Event` via `new Event(type, {bubbles, cancelable})` or equivalent browser API
+- [ ] 2.5 Implement `ServerDOMPort.create_event()` — return a `VirtualDOMEvent(type, bubbles=bubbles, cancelable=cancelable)`
 
-## 3. Unify render path in element base classes
+## 3. ServerDOMPort rewrite
 
-- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
-- [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
-- [ ] 3.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
-- [ ] 3.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
-- [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
-- [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
-- [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
-- [ ] 3.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
-- [ ] 3.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
+- [ ] 3.1 Rewrite `webcompy/ports/_server/_dom.py` — replace exception-throwing stubs with virtual DOM factory: `create_element()` returns `VirtualDOMNode`, `create_text_node()` returns virtual text node
+- [ ] 3.2 Implement `ServerDOMPort.render_html(node: DOMNode) -> str` — traverse virtual tree, serialize to HTML string
+- [ ] 3.3 Implement HTML serialization rules: HTML-escape text content and attribute values, output void elements without closing tags (e.g., `<br>`, `<img>`) per HTML5 convention, omit `None`-valued attributes
+- [ ] 3.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
 
-## 4. Router accessibility for testing
+## 4. Unify render path in element base classes
 
-- [ ] 4.1 Modify `RouterLink._on_click()` in `webcompy/router/_link.py` — remove `ENVIRONMENT != "pyscript"` early return; instead, guard only the `pyscript` import, `pushState`, and `window.location` access inside a `if ENVIRONMENT == "pyscript"` block. `self._router.__set_path__(href, params)` executes unconditionally so that `dispatchEvent(VirtualDOMEvent("click"))` on a rendered RouterLink triggers full route transition (guards → navigate → after_route_change → SwitchElement route selection)
+- [ ] 4.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 7)
+- [ ] 4.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
+- [ ] 4.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
+- [ ] 4.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
+- [ ] 4.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
+- [ ] 4.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
+- [ ] 4.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
+- [ ] 4.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
+- [ ] 4.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
 
-## 5. Remove _render_html() from element subclasses
+## 5. Router accessibility for testing
 
-- [ ] 5.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
-- [ ] 5.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+- [ ] 5.1 Modify `RouterLink._on_click()` in `webcompy/router/_link.py` — remove `ENVIRONMENT != "pyscript"` early return; instead, guard only the `pyscript` import, `pushState`, and `window.location` access inside a `if ENVIRONMENT == "pyscript"` block. `self._router.__set_path__(href, params)` executes unconditionally so that `dispatchEvent(VirtualDOMEvent("click"))` on a rendered RouterLink triggers full route transition (guards → navigate → after_route_change → SwitchElement route selection)
 
-## 6. Update server-side rendering entry points
+## 6. Remove _render_html() from element subclasses
 
-- [ ] 6.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
-- [ ] 6.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
-- [ ] 6.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
+- [ ] 6.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 6.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
 
-## 7. Element system adapter for server DOMPort
+## 7. Update server-side rendering entry points
 
-- [ ] 7.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
-- [ ] 7.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
+- [ ] 7.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
+- [ ] 7.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
+- [ ] 7.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
 
-## 8. Tests
+## 8. Element system adapter for server DOMPort
 
-- [ ] 8.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording, dispatchEvent
-- [ ] 8.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
-- [ ] 8.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
-- [ ] 8.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
-- [ ] 8.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
-- [ ] 8.6 Run existing test suite and fix regressions
+- [ ] 8.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
+- [ ] 8.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
 
-## 9. Cleanup
+## 9. Tests
 
-- [ ] 9.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
-- [ ] 9.2 Remove any `_render_html`-specific test utilities or helpers
-- [ ] 9.3 Update type stubs if `_render_html` appears in any `.pyi` files
+- [ ] 9.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording, dispatchEvent (including bubbling, stopPropagation, preventDefault)
+- [ ] 9.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
+- [ ] 9.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
+- [ ] 9.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
+- [ ] 9.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
+- [ ] 9.6 Run existing test suite and fix regressions
 
-## 10. Verification
+## 10. Cleanup
 
-- [ ] 10.1 Run lint: `uv run ruff check .`
-- [ ] 10.2 Run type check: `uv run pyright`
-- [ ] 10.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
-- [ ] 10.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
-- [ ] 10.5 Diff generated docs against baseline to confirm no output regressions
-- [ ] 10.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`
+- [ ] 10.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 10.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 10.3 Update type stubs if `_render_html` appears in any `.pyi` files
+
+## 11. Verification
+
+- [ ] 11.1 Run lint: `uv run ruff check .`
+- [ ] 11.2 Run type check: `uv run pyright`
+- [ ] 11.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 11.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 11.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 11.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -24,6 +24,10 @@
 - [ ] 3.7 Add `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` — prevents the testing module from being bundled into browser wheels
 - [ ] 3.8 Update all test files that import from `conftest` (`FakeDOMNode`, `FakeBrowserDOMPort`, `MockHistoryPort` is out of scope) to import from `webcompy.testing` instead
 - [ ] 3.9 Remove `FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `tests/conftest.py` — replaced by imports from `webcompy.testing`
+- [ ] 3.10 Create `webcompy/testing/_renderer.py` with `TestRenderer` class — high-level API for rendering components to `VirtualDOMNode` trees and querying the result (jsdom-like for WebComPy)
+- [ ] 3.11 Implement `TestRenderer.render(component)` — creates a `DIScope` with `ServerDOMPort`, calls `component.render()`, returns a `TestRendererResult` wrapping the virtual root node
+- [ ] 3.12 Implement `TestRendererResult` query methods — `query_selector(tag)`, `query_selector_all(tag)`, `find_by_text(text)`, `find_by_attribute(name, value)`, `to_html()` — traverse the virtual tree and return matching `VirtualDOMNode`(s)
+- [ ] 3.13 Implement `TestRendererResult` tree assertion helpers — `assert_element(tag, text=None)`, `assert_element_count(tag, count)`, `assert_has_class(cls)` — raise `AssertionError` on mismatch
 
 ## 4. Unify render path in element base classes
 

--- a/openspec/changes/feat-virtual-dom/tasks.md
+++ b/openspec/changes/feat-virtual-dom/tasks.md
@@ -13,54 +13,66 @@
 - [ ] 2.3 Implement HTML serialization rules: HTML-escape text content and attribute values, output void elements without closing tags (e.g., `<br>`, `<img>`) per HTML5 convention, omit `None`-valued attributes
 - [ ] 2.4 Verify `render_html()` produces identical output to current `_render_html()` methods — generate docs_app with both paths and diff results
 
-## 3. Unify render path in element base classes
+## 3. webcompy.testing module
 
-- [ ] 3.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 5)
-- [ ] 3.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
-- [ ] 3.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
-- [ ] 3.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
-- [ ] 3.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
-- [ ] 3.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
-- [ ] 3.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
-- [ ] 3.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
-- [ ] 3.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
+- [ ] 3.1 Create `webcompy/testing/` package — `__init__.py` re-exporting key symbols, `_dom.py` for `FakeDOMNode`, `_ports.py` for port fakes, helper for pre-wired `DIScope`
+- [ ] 3.2 Move `FakeDOMNode` from `tests/conftest.py` to `webcompy/testing/_dom.py` — no behavior changes, just relocation
+- [ ] 3.3 Fix `FakeBrowserFFIPort` Protocol compliance — add missing `to_js` and `assign` methods that match `FFIPort` ABC
+- [ ] 3.4 Create `create_browser_scope()` helper — returns a `DIScope` with all browser-side fake ports (FakeBrowserDOMPort, FakeBrowserHostPort, FakeBrowserFFIPort) wired up, mirroring the `fake_browser_full` fixture
+- [ ] 3.5 Create `create_server_scope()` helper — returns a `DIScope` with `ServerDOMPort` wired up; enables `component.render()` to build `VirtualDOMNode` trees in tests
+- [ ] 3.6 Create `create_test_app()` helper — instantiates a minimal `WebComPyApp` with the given scope, enabling component rendering tests without a full server
+- [ ] 3.7 Add `"webcompy.testing"` to `_BROWSER_ONLY_EXCLUDE` in `webcompy/cli/_wheel_builder.py` — prevents the testing module from being bundled into browser wheels
+- [ ] 3.8 Update all test files that import from `conftest` (`FakeDOMNode`, `FakeBrowserDOMPort`, `MockHistoryPort` is out of scope) to import from `webcompy.testing` instead
+- [ ] 3.9 Remove `FakeDOMNode`, `FakeBrowserDOMPort`, `FakeBrowserHostPort`, `FakeBrowserFFIPort` from `tests/conftest.py` — replaced by imports from `webcompy.testing`
 
-## 4. Remove _render_html() from element subclasses
+## 4. Unify render path in element base classes
 
-- [ ] 4.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
-- [ ] 4.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
+- [ ] 4.1 Remove `_render_html()` abstract method from `ElementAbstract` in `webcompy/elements/types/_abstract.py` — after cli/_html.py is migrated (task 6)
+- [ ] 4.2 Remove `_render_html()` from `ElementWithChildren` in `webcompy/elements/types/_base.py`
+- [ ] 4.3 Update `TextElement._update_text()` in `webcompy/elements/types/_text.py` — remove `if browser:` branch; both environments call `node.textContent = new_text` since `VirtualDOMNode` supports it
+- [ ] 4.4 Remove `if not browser:` server branches from `_on_set_parent()` in element and router types — `_switch.py:84`, `_repeat.py:95`, `_view.py:25` (router). After virtual DOM unification, `render()` creates VirtualDOMNodes on the server via `ServerDOMPort`, so the server-only pre-creation logic inside these branches is no longer needed and would cause double creation
+- [ ] 4.5 Verify that `_init_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — both `ElementBase._init_node()` and `TextElement._init_node()` / `NewLine._init_node()` call `_create_node()` which delegates to `inject(DOM_PORT_KEY)` returning a `VirtualDOMNode`
+- [ ] 4.6 Verify that `_detach_node()` (already unbranchified by `feat-port-abstraction`) works correctly with `VirtualDOMNode` on the server — `dom_port.create_text_node("")` returns a virtual text node and `parent_node.replaceChild(...)` operates on the virtual children list
+- [ ] 4.7 Remove `if browser:` branch from `DynamicElement._render()` in `webcompy/elements/types/_dynamic.py` — after virtual DOM unification, `_position_element_nodes()` works on `VirtualDOMNode` (uses `appendChild`/`insertBefore` which `VirtualDOMNode` implements), so both environments use the same positioning logic
+- [ ] 4.8 Remove environment guard from `RepeatElement._refresh()` in `webcompy/elements/types/_repeat.py:148` — change `if self._has_key and browser and self._children_keys:` to `if self._has_key and self._children_keys:`. After virtual DOM unification, `VirtualDOMNode` implements all DOM operations used by `_reconcile_children()` (`appendChild`, `insertBefore`, `remove`), so key-based reconciliation works identically on the server
+- [ ] 4.9 Remove environment guard from `_component.py:172` — change `app._defer_depth > 0 and ENVIRONMENT == "pyscript"` to `app._defer_depth > 0`. After virtual DOM unification, both environments run `render()`, and the defer mechanism works correctly on the server via synchronous `schedule_macro_task()`. The guard is an unnecessary optimization that diverges from Decision 3's single-code-path goal
 
-## 5. Update server-side rendering entry points
+## 5. Remove _render_html() from element subclasses
 
-- [ ] 5.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
-- [ ] 5.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
-- [ ] 5.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
+- [ ] 5.1 Remove `_render_html()` from `TextElement` and `NewLine` in `webcompy/elements/types/_text.py`
+- [ ] 5.2 Remove `_render_html()` from `DynamicElement` in `webcompy/elements/types/_dynamic.py`
 
-## 6. Element system adapter for server DOMPort
+## 6. Update server-side rendering entry points
 
-- [ ] 6.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
-- [ ] 6.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
+- [ ] 6.1 Update SSG generation code to use `ServerDOMPort.render_html(root_node)` instead of calling element `_render_html()` directly
+- [ ] 6.2 Update `webcompy/cli/_generate.py` if it references `_render_html()`
+- [ ] 6.3 Update `webcompy/cli/_html.py` if it references `_render_html()`
 
-## 7. Tests
+## 7. Element system adapter for server DOMPort
 
-- [ ] 7.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
-- [ ] 7.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
-- [ ] 7.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
-- [ ] 7.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
-- [ ] 7.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
-- [ ] 7.6 Run existing test suite and fix regressions
+- [ ] 7.1 Verify `DomNodeRef` is compatible with `VirtualDOMNode` — `DomNodeRef.__init_node__(node)` sets `self._node = node` and `node` must satisfy `DOMNode` Protocol; `VirtualDOMNode` already does
+- [ ] 7.2 Verify `ElementBase._init_new_node()` works on `VirtualDOMNode` — `setAttribute` and `addEventListener` use `DOMNode` Protocol which `VirtualDOMNode` implements
 
-## 8. Cleanup
+## 8. Tests
 
-- [ ] 8.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
-- [ ] 8.2 Remove any `_render_html`-specific test utilities or helpers
-- [ ] 8.3 Update type stubs if `_render_html` appears in any `.pyi` files
+- [ ] 8.1 Write tests for `VirtualDOMNode` — tree construction, attribute operations, event listener recording
+- [ ] 8.2 Write tests for `ServerDOMPort.render_html()` — element serialization, void tags, attribute escaping, text escaping, nested trees
+- [ ] 8.3 Write tests for unified render path — render the same component tree in both browser mock and server DOMPort, verify identical structure
+- [ ] 8.4 Update existing SSG tests — migrate from HTML string comparison to virtual tree structure inspection where beneficial; keep string comparison as integration tests
+- [ ] 8.5 Write tests for server-side rendering of components with attributes, event handlers, conditional branches, and list rendering
+- [ ] 8.6 Run existing test suite and fix regressions
 
-## 9. Verification
+## 9. Cleanup
 
-- [ ] 9.1 Run lint: `uv run ruff check .`
-- [ ] 9.2 Run type check: `uv run pyright`
-- [ ] 9.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
-- [ ] 9.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
-- [ ] 9.5 Diff generated docs against baseline to confirm no output regressions
-- [ ] 9.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`
+- [ ] 9.1 Search codebase for any remaining `_render_html` references — ensure all are removed or migrated
+- [ ] 9.2 Remove any `_render_html`-specific test utilities or helpers
+- [ ] 9.3 Update type stubs if `_render_html` appears in any `.pyi` files
+
+## 10. Verification
+
+- [ ] 10.1 Run lint: `uv run ruff check .`
+- [ ] 10.2 Run type check: `uv run pyright`
+- [ ] 10.3 Run unit tests: `uv run python -m pytest tests/ --tb=short`
+- [ ] 10.4 Run SSG and verify output: `uv run python -m webcompy generate --app docs_app.bootstrap:app`
+- [ ] 10.5 Diff generated docs against baseline to confirm no output regressions
+- [ ] 10.6 Verify dev server starts: `uv run python -m webcompy start --dev --app docs_app.bootstrap:app`

--- a/openspec/specs/port-definitions/spec.md
+++ b/openspec/specs/port-definitions/spec.md
@@ -61,7 +61,7 @@ The system SHALL define DI injection keys in `webcompy.ports._keys` for all 6 po
 - **THEN** each key is a distinct `InjectKey` instance usable with `inject()` and `provide()`
 
 ### Requirement: DOMNode Protocol methods are available
-The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute methods (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), event methods (`addEventListener`, `removeEventListener`), content properties (`textContent`, `childNodes` (returns `DOMNodeList`), `parentNode`, `nodeName`, `nodeType`), and WebComPy markers (`__webcompy_node__`, `__webcompy_prerendered_node__`). Any object — raw JS node or `VirtualDOMNode` — that structurally satisfies these members SHALL be accepted as a `DOMNode`.
+The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute methods (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), event methods (`addEventListener`, `removeEventListener`, `dispatchEvent(event: DOMEvent) -> bool`), content properties (`textContent`, `childNodes` (returns `DOMNodeList`), `parentNode`, `nodeName`, `nodeType`), and WebComPy markers (`__webcompy_node__`, `__webcompy_prerendered_node__`). Any object — raw JS node or `VirtualDOMNode` — that structurally satisfies these members SHALL be accepted as a `DOMNode`.
 
 #### Scenario: Raw JS nodes satisfy DOMNode Protocol
 - **WHEN** a raw `document.createElement("div")` value is returned from `BrowserDOMPort.create_element()`
@@ -72,6 +72,28 @@ The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChi
 - **WHEN** code accesses `node.childNodes` on a DOMNode
 - **THEN** it SHALL return a `DOMNodeList` instance
 - **AND** `DOMNodeList` SHALL support `.length` (int) and `[index]` access returning `DOMNode`
+
+#### Scenario: dispatchEvent is callable on any DOMNode
+- **WHEN** code calls `node.dispatchEvent(event)` through the `DOMNode` Protocol
+- **THEN** the operation SHALL work on both `BrowserDOMNode` (delegates to native JS) and `VirtualDOMNode` (synchronous handler invocation with at-target + bubbling propagation)
+
+### Requirement: DOMEvent Protocol is defined in the ports layer
+
+The `DOMEvent` Protocol SHALL be defined in `webcompy/ports/_dom.py` alongside `DOMNode` and `DOMPort`. It SHALL define the interface for DOM event objects: `type` (str), `bubbles` (bool), `cancelable` (bool), `target` (DOMNode | None), `currentTarget` (DOMNode | None), `defaultPrevented` (bool), `eventPhase` (int), `timeStamp` (int), `preventDefault()`, and `stopPropagation()`.
+
+#### Scenario: DOMEvent is co-located with DOMNode and DOMPort
+- **WHEN** a developer imports `webcompy.ports._dom`
+- **THEN** `DOMEvent`, `DOMNode`, and `DOMPort` SHALL all be available from the same module
+
+#### Scenario: DOMEvent fields match the browser Event interface subset
+- **WHEN** a `DOMEvent` is accessed through the Protocol
+- **THEN** `type` SHALL return the event name string
+- **AND** `bubbles` SHALL indicate whether the event bubbles
+- **AND** `cancelable` SHALL indicate whether `preventDefault()` is effective
+- **AND** `defaultPrevented` SHALL return `True` only after `preventDefault()` is called on a cancelable event
+- **AND** `eventPhase` SHALL return 0 (NONE), 2 (AT_TARGET), or 3 (BUBBLING)
+- **AND** `stopPropagation()` SHALL halt further ancestor dispatch
+- **AND** `preventDefault()` SHALL set `defaultPrevented` to `True` only when `cancelable` is `True`
 
 ### Requirement: Port responsibilities are scoped by browser API surface
 Ports SHALL be organized around distinct browser API surfaces rather than arbitrary groupings. `DOMPort` SHALL handle document-level operations (`document.createElement`, `document.querySelector`, `document.title`, `document.addEventListener`). `HostPort` SHALL handle general window-level operations (JS global object access via `getattr(window, name, None)`, `window.setTimeout` for macro-task scheduling). Additional port ABCs SHALL be introduced when a new category of browser API surface is identified, following MDN's classification of browser features. This ensures each port has a clear, narrow responsibility and prevents ports from becoming monolithic catch-all abstractions.

--- a/openspec/specs/port-definitions/spec.md
+++ b/openspec/specs/port-definitions/spec.md
@@ -61,7 +61,7 @@ The system SHALL define DI injection keys in `webcompy.ports._keys` for all 6 po
 - **THEN** each key is a distinct `InjectKey` instance usable with `inject()` and `provide()`
 
 ### Requirement: DOMNode Protocol methods are available
-The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute methods (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), event methods (`addEventListener`, `removeEventListener`, `dispatchEvent(event: DOMEvent) -> bool`), content properties (`textContent`, `childNodes` (returns `DOMNodeList`), `parentNode`, `nodeName`, `nodeType`), and WebComPy markers (`__webcompy_node__`, `__webcompy_prerendered_node__`). Any object — raw JS node or `VirtualDOMNode` — that structurally satisfies these members SHALL be accepted as a `DOMNode`.
+The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChild`, `insertBefore`, `replaceChild`, `remove`), attribute methods (`setAttribute`, `getAttribute`, `removeAttribute`, `hasAttribute`, `getAttributeNames`), event methods (`addEventListener`, `removeEventListener`), content properties (`textContent`, `childNodes` (returns `DOMNodeList`), `parentNode`, `nodeName`, `nodeType`), and WebComPy markers (`__webcompy_node__`, `__webcompy_prerendered_node__`). Any object — raw JS node or `VirtualDOMNode` — that structurally satisfies these members SHALL be accepted as a `DOMNode`.
 
 #### Scenario: Raw JS nodes satisfy DOMNode Protocol
 - **WHEN** a raw `document.createElement("div")` value is returned from `BrowserDOMPort.create_element()`
@@ -72,28 +72,6 @@ The `DOMNode` Protocol SHALL expose tree manipulation (`appendChild`, `removeChi
 - **WHEN** code accesses `node.childNodes` on a DOMNode
 - **THEN** it SHALL return a `DOMNodeList` instance
 - **AND** `DOMNodeList` SHALL support `.length` (int) and `[index]` access returning `DOMNode`
-
-#### Scenario: dispatchEvent is callable on any DOMNode
-- **WHEN** code calls `node.dispatchEvent(event)` through the `DOMNode` Protocol
-- **THEN** the operation SHALL work on both `BrowserDOMNode` (delegates to native JS) and `VirtualDOMNode` (synchronous handler invocation with at-target + bubbling propagation)
-
-### Requirement: DOMEvent Protocol is defined in the ports layer
-
-The `DOMEvent` Protocol SHALL be defined in `webcompy/ports/_dom.py` alongside `DOMNode` and `DOMPort`. It SHALL define the interface for DOM event objects: `type` (str), `bubbles` (bool), `cancelable` (bool), `target` (DOMNode | None), `currentTarget` (DOMNode | None), `defaultPrevented` (bool), `eventPhase` (int), `timeStamp` (int), `preventDefault()`, and `stopPropagation()`.
-
-#### Scenario: DOMEvent is co-located with DOMNode and DOMPort
-- **WHEN** a developer imports `webcompy.ports._dom`
-- **THEN** `DOMEvent`, `DOMNode`, and `DOMPort` SHALL all be available from the same module
-
-#### Scenario: DOMEvent fields match the browser Event interface subset
-- **WHEN** a `DOMEvent` is accessed through the Protocol
-- **THEN** `type` SHALL return the event name string
-- **AND** `bubbles` SHALL indicate whether the event bubbles
-- **AND** `cancelable` SHALL indicate whether `preventDefault()` is effective
-- **AND** `defaultPrevented` SHALL return `True` only after `preventDefault()` is called on a cancelable event
-- **AND** `eventPhase` SHALL return 0 (NONE), 2 (AT_TARGET), or 3 (BUBBLING)
-- **AND** `stopPropagation()` SHALL halt further ancestor dispatch
-- **AND** `preventDefault()` SHALL set `defaultPrevented` to `True` only when `cancelable` is `True`
 
 ### Requirement: Port responsibilities are scoped by browser API surface
 Ports SHALL be organized around distinct browser API surfaces rather than arbitrary groupings. `DOMPort` SHALL handle document-level operations (`document.createElement`, `document.querySelector`, `document.title`, `document.addEventListener`). `HostPort` SHALL handle general window-level operations (JS global object access via `getattr(window, name, None)`, `window.setTimeout` for macro-task scheduling). Additional port ABCs SHALL be introduced when a new category of browser API surface is identified, following MDN's classification of browser features. This ensures each port has a clear, narrow responsibility and prevents ports from becoming monolithic catch-all abstractions.


### PR DESCRIPTION
## Summary

This branch contains **OpenSpec artifacts only** — no code changes. It documents the planning and specification work for two upcoming changes to the DOMPort abstraction layer.

### feat-virtual-dom

Specifies the completion of `ServerDOMPort` from exception-throwing stubs to a full virtual DOM implementation:

- **VirtualDOMNode** — in-memory DOM tree satisfying the `DOMNode` Protocol (tree ops, attributes, events)
- **VirtualDOMEvent** — satisfies the `DOMEvent` Protocol (`bubbles`, `cancelable`, `preventDefault()`, `stopPropagation()`, phase tracking)
- **dispatchEvent()** — at-target + bubbling phase propagation with `stopPropagation` support
- **DOMPort.create_event()** — constructor-style event factory (`type`, `bubbles`, `cancelable`)
- **DOMNode.dispatchEvent()** — added to the `DOMNode` Protocol; `BrowserDOMPort.create_event()` creates native JS Events
- **DOMEvent Protocol relocation** — moved from `webcompy/elements/_dom_objs.py` to `webcompy/ports/_dom.py`, co-located with `DOMNode` and `DOMPort`
- **ServerDOMPort.render_html()** — traverses virtual trees and serializes to HTML strings
- **Render path unification** — removes all `_render_html()` methods and `ENVIRONMENT` branches from element types; `render()` becomes the single entry point
- **RouterLink._on_click() fix** — executes `__set_path__()` unconditionally so RouterLink click → route transition is testable via `dispatchEvent(VirtualDOMEvent("click"))`

### feat-testing-module (depends on feat-virtual-dom)

Specifies a `webcompy.testing` package and E2E test migration:

- **webcompy.testing** — `FakeDOMNode`, fake port implementations, `TestRenderer` / `TestRendererResult`, scope helpers, excluded from browser wheels
- **TestRenderer** — jsdom-like API for rendering components to `VirtualDOMNode` trees, querying the structure, dispatching events, re-rendering, and asserting on results
- **E2E migration** — ~55 E2E tests migrate to unit tests using `TestRenderer` + `dispatchEvent(VirtualDOMEvent)`. Browser-required tests (~11) remain in E2E

### Groups

| Change | Groups | Tasks |
|--------|--------|-------|
| feat-virtual-dom | 11 | ~55 |
| feat-testing-module | 5 | ~33 |

### Commits

```
8f1fe2e docs: add full event system spec to feat-virtual-dom
804c28b refactor: split feat-virtual-dom into core + feat-testing-module
e6d35bf docs: add RouterLink accessibility group for unit-testable navigation
91ef3da docs: expand E2E migration to 53 tests (29 Mixed via dispatchEvent)
ff26383 docs: add dispatchEvent to VirtualDOMNode for component behavior testing
6c26d6e docs: add E2E test migration to unit tests group
3382168 docs: add TestRenderer (jsdom-like API) to webcompy.testing module
d4b2586 docs: add webcompy.testing module group to feat-virtual-dom plan
```

No implementation — just planning. Code changes will come in subsequent PRs after this is reviewed and approved.