### PR TITLE
chore: add shared E2E test runner, console capture, and parallel execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,11 @@ jobs:
           name: docs-dist
           path: docs_app/dist/
       - name: Run E2E tests
-        run: |
-          uv run python -m pytest ${{ matrix.group.files }} --tb=short --serving-mode=${{ matrix.serving_mode }} 2>&1 | tee ci-e2e-results.log
-          exit "${PIPESTATUS[0]}"
         env:
           DOCS_DIST_DIR: ${{ github.workspace }}/docs_app/dist
+        run: |
+          scripts/run-e2e-tests.sh ${{ matrix.group.name }} --serving-mode=${{ matrix.serving_mode }} 2>&1 | tee ci-e2e-results.log
+          exit "${PIPESTATUS[0]}"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
           path: |
             tests/e2e/.e2e-server.log
             tests/e2e_docs/.e2e-docs-server.log
+            .tmp/e2e-test-corpus/
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,9 @@ Code in `webcompy/cli/` and `webcompy/_browser/` is context-sensitive.
 - Type check: `uv run pyright`
 - Test: `uv run python -m pytest tests/ --tb=short`
 - Test with coverage: `uv run python -m pytest tests/ --tb=short --cov=webcompy --cov-report=term-missing`
+- E2E tests: `scripts/run-e2e-tests.sh` — runs all groups in both prod/static modes. For a single group: `scripts/run-e2e-tests.sh bootstrap-static`. For a single mode: `scripts/run-e2e-tests.sh --serving-mode=static`. CI reuses the same script with per-group invocations for parallel matrix execution.
+- Before running E2E tests, ensure Playwright is installed: `uv run playwright install chromium`. Docs E2E tests require `uv sync --all-groups` (for matplotlib/numpy).
+- When adding or renaming E2E test files, update both `scripts/run-e2e-tests.sh` group definitions AND the CI matrix in `.github/workflows/ci.yml`.
 - Pre-commit hooks run ruff (lint + format) and pyright automatically on commit
 
 ## CI
@@ -55,7 +58,6 @@ Code in `webcompy/cli/` and `webcompy/_browser/` is context-sensitive.
 - **Lint + Typecheck + Test + Generate**: runs on push to `main` and PRs (`.github/workflows/ci.yml`)
 - **Automated PR review**: runs on PRs via OpenCode with an OpenAI-compatible provider (`.github/workflows/opencode-review.yml`)
 - Coverage report is uploaded as a CI artifact
-- **When adding or renaming E2E test files**, you MUST update the `e2e-matrix` job in `.github/workflows/ci.yml` to include the new file in the appropriate `group.files` matrix entry. This is critical because the CI uses an explicit file list per group rather than auto-discovering all files in `tests/e2e/`.
 
 ## Code Conventions
 

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -7,6 +7,8 @@
 #   scripts/run-e2e-tests.sh components interaction   # multiple groups
 #   scripts/run-e2e-tests.sh --serving-mode=static    # all groups, static mode only
 #   scripts/run-e2e-tests.sh docs-home --serving-mode=static
+#   scripts/run-e2e-tests.sh --console-level=error   # only show console errors in output
+#   scripts/run-e2e-tests.sh --console-file-level=info # save error+warning+info to file
 #
 # Prerequisites:
 #   uv sync --all-groups
@@ -27,6 +29,7 @@ mkdir -p "$CORPUS_DIR"
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 CYAN='\033[0;36m'
+YELLOW='\033[0;33m'
 NC='\033[0m'
 
 # Group definitions — must match .github/workflows/ci.yml e2e-matrix
@@ -54,12 +57,25 @@ declare -A DOCS_GROUPS=(
 SERVING_MODES=("prod" "static")
 SELECTED_GROUPS=()
 SERVING_MODE_FILTER=""
+CONSOLE_LEVEL=""
+CONSOLE_FILE_LEVEL=""
 
 for arg in "$@"; do
   if [[ "$arg" == --serving-mode=* ]]; then
     SERVING_MODE_FILTER="${arg#--serving-mode=}"
+  elif [[ "$arg" == --console-level=* ]]; then
+    CONSOLE_LEVEL="${arg#--console-level=}"
+  elif [[ "$arg" == --console-file-level=* ]]; then
+    CONSOLE_FILE_LEVEL="${arg#--console-file-level=}"
   elif [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
-    echo "Usage: scripts/run-e2e-tests.sh [group...] [--serving-mode=prod|static]"
+    echo "Usage: scripts/run-e2e-tests.sh [group...] [options]"
+    echo ""
+    echo "Options:"
+    echo "  --serving-mode=prod|static    Run only the specified serving mode"
+    echo "  --console-level=off|error|warning|info|log|debug"
+    echo "      Minimum console level to display in output (default: warning)"
+    echo "  --console-file-level=off|error|warning|info|log|debug"
+    echo "      Minimum console level to save to log files (default: debug)"
     echo ""
     echo "Core E2E groups:"
     for name in "${!E2E_GROUPS[@]}"; do
@@ -86,6 +102,60 @@ PASSED=0
 FAILED=0
 declare -a FAILED_NAMES=()
 
+_print_console_logs() {
+  local console_dir="$1"
+  local level_name="${2:-warning}"
+  local level_num=2
+  case "$level_name" in
+    off)    level_num=0 ;;
+    error)  level_num=1 ;;
+    warning) level_num=2 ;;
+    info)   level_num=3 ;;
+    log)    level_num=4 ;;
+    debug)  level_num=5 ;;
+  esac
+
+  if [ "$level_num" -eq 0 ] || [ ! -d "$console_dir" ]; then
+    return
+  fi
+
+  local found=0
+  for logfile in "$console_dir"/console-*.log; do
+    [ -f "$logfile" ] || continue
+    while IFS= read -r line; do
+      local msg_level_num=4
+      if [[ "$line" == \[error\]* ]]; then
+        msg_level_num=1
+      elif [[ "$line" == \[warning\]* ]]; then
+        msg_level_num=2
+      elif [[ "$line" == \[info\]* ]]; then
+        msg_level_num=3
+      elif [[ "$line" == \[log\]* ]]; then
+        msg_level_num=4
+      elif [[ "$line" == \[debug\]* ]]; then
+        msg_level_num=5
+      fi
+      if [ "$msg_level_num" -le "$level_num" ]; then
+        if [ "$found" -eq 0 ]; then
+          echo "       Console messages:"
+          echo "       ---"
+          found=1
+        fi
+        if [ "$msg_level_num" -le 1 ]; then
+          echo -e "       ${RED}${line}${NC}"
+        elif [ "$msg_level_num" -le 2 ]; then
+          echo -e "       ${YELLOW}${line}${NC}"
+        else
+          echo "       $line"
+        fi
+      fi
+    done < "$logfile"
+  done
+  if [ "$found" -eq 1 ]; then
+    echo "       ---"
+  fi
+}
+
 run_group() {
   local group_name="$1"
   local files="$2"
@@ -105,10 +175,20 @@ run_group() {
   for mode in "${modes[@]}"; do
     echo -e "${CYAN}━━━ $group_name ($mode) ━━━${NC}"
     local log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
+    local console_dir="$CORPUS_DIR/console-$group_name-$mode"
+    mkdir -p "$console_dir"
     local start_time=$(date +%s)
-    if uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then
+
+    local env_console_file_level="${CONSOLE_FILE_LEVEL:-debug}"
+    local env_console_stdout_level="${CONSOLE_LEVEL:-warning}"
+
+    if CONSOLE_LOG_DIR="$console_dir" \
+       CONSOLE_FILE_LEVEL="$env_console_file_level" \
+       CONSOLE_STDOUT_LEVEL="$env_console_stdout_level" \
+       uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then
       local elapsed=$(($(date +%s) - start_time))
       echo -e "${GREEN}OK${NC}  $group_name ($mode)  ${elapsed}s"
+      _print_console_logs "$console_dir" "$env_console_stdout_level"
       ((PASSED++)) || true
     else
       local elapsed=$(($(date +%s) - start_time))
@@ -119,7 +199,9 @@ run_group() {
         echo "       $line"
       done
       echo "       ---"
-      echo "       Full log: $log_file"
+      _print_console_logs "$console_dir" "$env_console_stdout_level"
+      echo "       Full test log: $log_file"
+      echo "       Console logs: $console_dir/"
       ((FAILED++)) || true
       FAILED_NAMES+=("$group_name ($mode)")
     fi

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# Run WebComPy E2E tests locally using the same groups and commands as CI.
+#
+# Usage:
+#   scripts/run-e2e-tests.sh                          # all groups (core + docs), both prod & static
+#   scripts/run-e2e-tests.sh bootstrap-static         # single group, both modes
+#   scripts/run-e2e-tests.sh components interaction   # multiple groups
+#   scripts/run-e2e-tests.sh --serving-mode=static    # all groups, static mode only
+#   scripts/run-e2e-tests.sh docs-home --serving-mode=static
+#
+# Prerequisites:
+#   uv sync --all-groups
+#   uv run playwright install chromium
+#
+# The script mirrors the CI matrix defined in .github/workflows/ci.yml.
+# When you add, rename, or remove E2E test files, update the group definitions
+# below AND the CI matrix in .github/workflows/ci.yml.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CORPUS_DIR="$ROOT_DIR/.tmp/e2e-test-corpus"
+mkdir -p "$CORPUS_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Group definitions — must match .github/workflows/ci.yml e2e-matrix
+declare -A E2E_GROUPS=(
+  ["bootstrap-static"]="tests/e2e/test_bootstrap.py tests/e2e/test_static_site.py"
+  ["components"]="tests/e2e/test_component.py tests/e2e/test_lifecycle.py tests/e2e/test_scoped_style.py"
+  ["reactive-lists"]="tests/e2e/test_reactive.py tests/e2e/test_repeat.py tests/e2e/test_keyed_repeat.py tests/e2e/test_dict_repeat.py"
+  ["dynamic-control"]="tests/e2e/test_nested_dynamic.py tests/e2e/test_switch.py"
+  ["router"]="tests/e2e/test_router.py tests/e2e/test_async_nav.py"
+  ["interaction"]="tests/e2e/test_event.py tests/e2e/test_di.py"
+  ["bundled-deps"]="tests/e2e/test_bundled_deps.py tests/e2e/test_bundled_deps_browser.py"
+  ["runtime-local"]="tests/e2e/test_runtime_local.py"
+  ["standalone"]="tests/e2e/test_standalone.py"
+  ["plugin-script"]="tests/e2e/test_eruda.py"
+)
+
+# Docs groups are static-only in CI
+declare -A DOCS_GROUPS=(
+  ["docs-home"]="tests/e2e_docs/test_home.py tests/e2e_docs/test_documents.py tests/e2e_docs/test_helloworld.py"
+  ["docs-demos"]="tests/e2e_docs/test_fizzbuzz.py tests/e2e_docs/test_todo.py"
+  ["docs-matplotlib"]="tests/e2e_docs/test_matplotlib.py"
+  ["docs-fetch"]="tests/e2e_docs/test_fetch.py"
+)
+
+SERVING_MODES=("prod" "static")
+SELECTED_GROUPS=()
+SERVING_MODE_FILTER=""
+
+for arg in "$@"; do
+  if [[ "$arg" == --serving-mode=* ]]; then
+    SERVING_MODE_FILTER="${arg#--serving-mode=}"
+  elif [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
+    echo "Usage: scripts/run-e2e-tests.sh [group...] [--serving-mode=prod|static]"
+    echo ""
+    echo "Core E2E groups:"
+    for name in "${!E2E_GROUPS[@]}"; do
+      echo "  $name"
+    done
+    echo ""
+    echo "Docs E2E groups (static mode only):"
+    for name in "${!DOCS_GROUPS[@]}"; do
+      echo "  $name"
+    done
+    echo ""
+    echo "Without arguments, all groups run in both prod and static modes."
+    exit 0
+  else
+    SELECTED_GROUPS+=("$arg")
+  fi
+done
+
+if [ ${#SELECTED_GROUPS[@]} -eq 0 ]; then
+  SELECTED_GROUPS=("${!E2E_GROUPS[@]}" "${!DOCS_GROUPS[@]}")
+fi
+
+PASSED=0
+FAILED=0
+declare -a FAILED_NAMES=()
+
+run_group() {
+  local group_name="$1"
+  local files="$2"
+  local modes=("${SERVING_MODES[@]}")
+
+  if [[ "$group_name" == docs-* ]]; then
+    modes=("static")
+  fi
+
+  if [ -n "$SERVING_MODE_FILTER" ]; then
+    if [[ ! " ${modes[*]} " =~ " ${SERVING_MODE_FILTER} " ]]; then
+      return
+    fi
+    modes=("$SERVING_MODE_FILTER")
+  fi
+
+  for mode in "${modes[@]}"; do
+    echo -e "${CYAN}━━━ $group_name ($mode) ━━━${NC}"
+    local log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
+    local start_time=$(date +%s)
+    if uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then
+      local elapsed=$(($(date +%s) - start_time))
+      echo -e "${GREEN}OK${NC}  $group_name ($mode)  ${elapsed}s"
+      ((PASSED++)) || true
+    else
+      local elapsed=$(($(date +%s) - start_time))
+      echo -e "${RED}FAIL${NC}  $group_name ($mode)  ${elapsed}s"
+      echo "       Last 20 lines of log:"
+      echo "       ---"
+      tail -20 "$log_file" | while IFS= read -r line; do
+        echo "       $line"
+      done
+      echo "       ---"
+      echo "       Full log: $log_file"
+      ((FAILED++)) || true
+      FAILED_NAMES+=("$group_name ($mode)")
+    fi
+  done
+}
+
+for group_name in "${SELECTED_GROUPS[@]}"; do
+  files=""
+  if [[ "$group_name" == docs-* ]]; then
+    files="${DOCS_GROUPS[$group_name]:-}"
+    if [ -z "$files" ]; then
+      echo -e "${RED}Unknown group: $group_name${NC}"
+      echo "Available docs groups: ${!DOCS_GROUPS[*]}"
+      exit 1
+    fi
+  else
+    files="${E2E_GROUPS[$group_name]:-}"
+    if [ -z "$files" ]; then
+      echo -e "${RED}Unknown group: $group_name${NC}"
+      echo "Available core groups: ${!E2E_GROUPS[*]}"
+      exit 1
+    fi
+  fi
+  run_group "$group_name" "$files"
+done
+
+echo ""
+echo "──────────────────────────────────────────────"
+echo -e "Total: ${GREEN}$PASSED passed${NC}, ${RED}$FAILED failed${NC}"
+if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+  echo "Failures:"
+  for name in "${FAILED_NAMES[@]}"; do
+    echo "  - $name"
+  done
+fi
+echo "Logs saved to: $CORPUS_DIR"
+echo "──────────────────────────────────────────────"
+
+[ $FAILED -eq 0 ]

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -241,12 +241,12 @@ _run_single() {
 
   local start_time=$(date +%s)
 
-  local env_cmd=""
-  if [ ${#env_extra[@]} -gt 0 ]; then
-    env_cmd="${env_extra[*]} "
-  fi
+  local env_cmd=(env)
+  for e in "${env_extra[@]}"; do
+    env_cmd+=("$e")
+  done
 
-  if ${env_cmd}CONSOLE_LOG_DIR="$console_dir" \
+  if "${env_cmd[@]}" CONSOLE_LOG_DIR="$console_dir" \
      CONSOLE_FILE_LEVEL="$env_console_file_level" \
      CONSOLE_STDOUT_LEVEL="$env_console_stdout_level" \
      uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -9,6 +9,7 @@
 #   scripts/run-e2e-tests.sh docs-home --serving-mode=static
 #   scripts/run-e2e-tests.sh --console-level=error   # only show console errors in output
 #   scripts/run-e2e-tests.sh --console-file-level=info # save error+warning+info to file
+#   scripts/run-e2e-tests.sh --parallel               # run groups in parallel
 #
 # Prerequisites:
 #   uv sync --all-groups
@@ -59,6 +60,7 @@ SELECTED_GROUPS=()
 SERVING_MODE_FILTER=""
 CONSOLE_LEVEL=""
 CONSOLE_FILE_LEVEL=""
+PARALLEL=0
 
 for arg in "$@"; do
   if [[ "$arg" == --serving-mode=* ]]; then
@@ -67,6 +69,8 @@ for arg in "$@"; do
     CONSOLE_LEVEL="${arg#--console-level=}"
   elif [[ "$arg" == --console-file-level=* ]]; then
     CONSOLE_FILE_LEVEL="${arg#--console-file-level=}"
+  elif [[ "$arg" == "--parallel" ]]; then
+    PARALLEL=1
   elif [[ "$arg" == "--help" ]] || [[ "$arg" == "-h" ]]; then
     echo "Usage: scripts/run-e2e-tests.sh [group...] [options]"
     echo ""
@@ -76,6 +80,7 @@ for arg in "$@"; do
     echo "      Minimum console level to display in output (default: warning)"
     echo "  --console-file-level=off|error|warning|info|log|debug"
     echo "      Minimum console level to save to log files (default: debug)"
+    echo "  --parallel                     Run groups in parallel"
     echo ""
     echo "Core E2E groups:"
     for name in "${!E2E_GROUPS[@]}"; do
@@ -98,9 +103,48 @@ if [ ${#SELECTED_GROUPS[@]} -eq 0 ]; then
   SELECTED_GROUPS=("${!E2E_GROUPS[@]}" "${!DOCS_GROUPS[@]}")
 fi
 
-PASSED=0
-FAILED=0
-declare -a FAILED_NAMES=()
+_find_free_port() {
+  python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"
+}
+
+_build_run_tasks() {
+  local tasks=()
+  for group_name in "${SELECTED_GROUPS[@]}"; do
+    local files=""
+    if [[ "$group_name" == docs-* ]]; then
+      files="${DOCS_GROUPS[$group_name]:-}"
+      if [ -z "$files" ]; then
+        echo -e "${RED}Unknown group: $group_name${NC}"
+        echo "Available docs groups: ${!DOCS_GROUPS[*]}"
+        exit 1
+      fi
+    else
+      files="${E2E_GROUPS[$group_name]:-}"
+      if [ -z "$files" ]; then
+        echo -e "${RED}Unknown group: $group_name${NC}"
+        echo "Available core groups: ${!E2E_GROUPS[*]}"
+        exit 1
+      fi
+    fi
+
+    local modes=("${SERVING_MODES[@]}")
+    if [[ "$group_name" == docs-* ]]; then
+      modes=("static")
+    fi
+    if [ -n "$SERVING_MODE_FILTER" ]; then
+      if [[ ! " ${modes[*]} " =~ " ${SERVING_MODE_FILTER} " ]]; then
+        continue
+      fi
+      modes=("$SERVING_MODE_FILTER")
+    fi
+
+    for mode in "${modes[@]}"; do
+      tasks+=("$group_name|$mode|$files")
+    done
+  done
+
+  printf '%s\n' "${tasks[@]}"
+}
 
 _print_console_logs() {
   local console_dir="$1"
@@ -156,43 +200,238 @@ _print_console_logs() {
   fi
 }
 
-run_group() {
+_run_single() {
   local group_name="$1"
-  local files="$2"
-  local modes=("${SERVING_MODES[@]}")
+  local mode="$2"
+  local files="$3"
+
+  local log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
+  local console_dir="$CORPUS_DIR/console-$group_name-$mode"
+  local task_tmp_dir="$CORPUS_DIR/tmp-$group_name-$mode"
+  mkdir -p "$console_dir" "$task_tmp_dir"
+
+  local env_console_file_level="${CONSOLE_FILE_LEVEL:-debug}"
+  local env_console_stdout_level="${CONSOLE_LEVEL:-warning}"
+
+  local port=""
+  local env_extra=()
+
+  if [[ "$mode" == "prod" ]]; then
+    port=$(_find_free_port)
+    if [[ "$group_name" == docs-* ]]; then
+      env_extra+=("DOCS_E2E_PORT=$port")
+    elif [[ "$group_name" == runtime-local ]]; then
+      env_extra+=("RUNTIME_LOCAL_PORT=$port")
+    else
+      env_extra+=("E2E_PORT=$port")
+    fi
+  fi
 
   if [[ "$group_name" == docs-* ]]; then
-    modes=("static")
+    env_extra+=("DOCS_E2E_TMP_DIR=$task_tmp_dir")
+    env_extra+=("DOCS_E2E_SERVER_LOG=$task_tmp_dir/server.log")
+  elif [[ "$group_name" == runtime-local ]]; then
+    env_extra+=("RUNTIME_LOCAL_TMP_DIR=$task_tmp_dir")
+  elif [[ "$group_name" == standalone ]]; then
+    env_extra+=("STANDALONE_TMP_DIR=$task_tmp_dir")
+  else
+    env_extra+=("E2E_TMP_DIR=$task_tmp_dir")
+    env_extra+=("E2E_SERVER_LOG=$task_tmp_dir/server.log")
   fi
 
-  if [ -n "$SERVING_MODE_FILTER" ]; then
-    if [[ ! " ${modes[*]} " =~ " ${SERVING_MODE_FILTER} " ]]; then
-      return
+  local start_time=$(date +%s)
+
+  local env_cmd=""
+  if [ ${#env_extra[@]} -gt 0 ]; then
+    env_cmd="${env_extra[*]} "
+  fi
+
+  if ${env_cmd}CONSOLE_LOG_DIR="$console_dir" \
+     CONSOLE_FILE_LEVEL="$env_console_file_level" \
+     CONSOLE_STDOUT_LEVEL="$env_console_stdout_level" \
+     uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then
+    local elapsed=$(($(date +%s) - start_time))
+    echo -e "${GREEN}OK${NC}  $group_name ($mode)  ${elapsed}s${port:+  port=$port}"
+    _print_console_logs "$console_dir" "$env_console_stdout_level"
+    echo "0" > "$task_tmp_dir/.result"
+  else
+    local elapsed=$(($(date +%s) - start_time))
+    echo -e "${RED}FAIL${NC}  $group_name ($mode)  ${elapsed}s${port:+  port=$port}"
+    echo "       Last 20 lines of log:"
+    echo "       ---"
+    tail -20 "$log_file" | while IFS= read -r line; do
+      echo "       $line"
+    done
+    echo "       ---"
+    _print_console_logs "$console_dir" "$env_console_stdout_level"
+    echo "       Full test log: $log_file"
+    echo "       Console logs: $console_dir/"
+    echo "1" > "$task_tmp_dir/.result"
+  fi
+}
+
+_run_single_bg() {
+  local group_name="$1"
+  local mode="$2"
+  local files="$3"
+  local log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
+  local task_tmp_dir="$CORPUS_DIR/tmp-$group_name-$mode"
+  mkdir -p "$task_tmp_dir"
+
+  local port=""
+  local env_args=()
+
+  if [[ "$mode" == "prod" ]]; then
+    port=$(_find_free_port)
+    if [[ "$group_name" == docs-* ]]; then
+      env_args+=("DOCS_E2E_PORT=$port")
+    elif [[ "$group_name" == runtime-local ]]; then
+      env_args+=("RUNTIME_LOCAL_PORT=$port")
+    else
+      env_args+=("E2E_PORT=$port")
     fi
-    modes=("$SERVING_MODE_FILTER")
   fi
 
-  for mode in "${modes[@]}"; do
+  if [[ "$group_name" == docs-* ]]; then
+    env_args+=("DOCS_E2E_TMP_DIR=$task_tmp_dir")
+    env_args+=("DOCS_E2E_SERVER_LOG=$task_tmp_dir/server.log")
+  elif [[ "$group_name" == runtime-local ]]; then
+    env_args+=("RUNTIME_LOCAL_TMP_DIR=$task_tmp_dir")
+  elif [[ "$group_name" == standalone ]]; then
+    env_args+=("STANDALONE_TMP_DIR=$task_tmp_dir")
+  else
+    env_args+=("E2E_TMP_DIR=$task_tmp_dir")
+    env_args+=("E2E_SERVER_LOG=$task_tmp_dir/server.log")
+  fi
+
+  local console_dir="$CORPUS_DIR/console-$group_name-$mode"
+  mkdir -p "$console_dir"
+  local env_console_file_level="${CONSOLE_FILE_LEVEL:-debug}"
+  local env_console_stdout_level="${CONSOLE_LEVEL:-warning}"
+
+  local env_cmd=(env)
+  for e in "${env_args[@]}"; do
+    env_cmd+=("$e")
+  done
+
+  echo -e "${CYAN}━━━ $group_name ($mode) ━━━${NC}${port:+  port=$port} [background]"
+
+  "${env_cmd[@]}" CONSOLE_LOG_DIR="$console_dir" \
+    CONSOLE_FILE_LEVEL="$env_console_file_level" \
+    CONSOLE_STDOUT_LEVEL="$env_console_stdout_level" \
+    uv run python -m pytest $files --tb=short --serving-mode="$mode" \
+    > "$log_file" 2>&1
+}
+
+if [ "$PARALLEL" -eq 1 ]; then
+  declare -a PIDS=()
+  declare -A PID_TASK=()
+
+  while IFS='|' read -r group_name mode files; do
+    _run_single_bg "$group_name" "$mode" "$files" &
+    pid=$!
+    PIDS+=("$pid")
+    PID_TASK["$pid"]="$group_name ($mode)"
+  done < <(_build_run_tasks)
+
+  PASSED=0
+  FAILED=0
+  declare -a FAILED_NAMES=()
+
+  for pid in "${PIDS[@]}"; do
+    if wait "$pid"; then
+      ((PASSED++)) || true
+    else
+      ((FAILED++)) || true
+      FAILED_NAMES+=("${PID_TASK[$pid]}")
+    fi
+  done
+
+  echo ""
+  echo "──────────────────────────────────────────────"
+  echo -e "Total: ${GREEN}$PASSED passed${NC}, ${RED}$FAILED failed${NC}"
+  if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+    echo "Failures:"
+    for name in "${FAILED_NAMES[@]}"; do
+      echo "  - $name"
+      log_name="${name% (*}"
+      log_mode="${name#* (}"
+      log_mode="${log_mode%)}"
+      log_file="$CORPUS_DIR/e2e-$log_name-$log_mode.log"
+      if [ -f "$log_file" ]; then
+        echo "    Last 10 lines:"
+        tail -10 "$log_file" | while IFS= read -r line; do
+          echo "      $line"
+        done
+      fi
+    done
+  fi
+  echo "Logs saved to: $CORPUS_DIR"
+  echo "──────────────────────────────────────────────"
+
+  [ $FAILED -eq 0 ]
+else
+  PASSED=0
+  FAILED=0
+  declare -a FAILED_NAMES=()
+
+  while IFS='|' read -r group_name mode files; do
     echo -e "${CYAN}━━━ $group_name ($mode) ━━━${NC}"
-    local log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
-    local console_dir="$CORPUS_DIR/console-$group_name-$mode"
-    mkdir -p "$console_dir"
-    local start_time=$(date +%s)
+    start_time=$(date +%s)
 
-    local env_console_file_level="${CONSOLE_FILE_LEVEL:-debug}"
-    local env_console_stdout_level="${CONSOLE_LEVEL:-warning}"
+    log_file="$CORPUS_DIR/e2e-$group_name-$mode.log"
+    console_dir="$CORPUS_DIR/console-$group_name-$mode"
+    task_tmp_dir="$CORPUS_DIR/tmp-$group_name-$mode"
+    mkdir -p "$console_dir" "$task_tmp_dir"
 
-    if CONSOLE_LOG_DIR="$console_dir" \
+    env_console_file_level="${CONSOLE_FILE_LEVEL:-debug}"
+    env_console_stdout_level="${CONSOLE_LEVEL:-warning}"
+
+    port=""
+
+    if [[ "$mode" == "prod" ]]; then
+      port=$(_find_free_port)
+    fi
+
+    env_args=()
+    if [ -n "$port" ]; then
+      if [[ "$group_name" == docs-* ]]; then
+        env_args+=("DOCS_E2E_PORT=$port")
+      elif [[ "$group_name" == runtime-local ]]; then
+        env_args+=("RUNTIME_LOCAL_PORT=$port")
+      else
+        env_args+=("E2E_PORT=$port")
+      fi
+    fi
+
+    if [[ "$group_name" == docs-* ]]; then
+      env_args+=("DOCS_E2E_TMP_DIR=$task_tmp_dir")
+      env_args+=("DOCS_E2E_SERVER_LOG=$task_tmp_dir/server.log")
+    elif [[ "$group_name" == runtime-local ]]; then
+      env_args+=("RUNTIME_LOCAL_TMP_DIR=$task_tmp_dir")
+    elif [[ "$group_name" == standalone ]]; then
+      env_args+=("STANDALONE_TMP_DIR=$task_tmp_dir")
+    else
+      env_args+=("E2E_TMP_DIR=$task_tmp_dir")
+      env_args+=("E2E_SERVER_LOG=$task_tmp_dir/server.log")
+    fi
+
+    env_cmd=(env)
+    for e in "${env_args[@]}"; do
+      env_cmd+=("$e")
+    done
+
+    if "${env_cmd[@]}" CONSOLE_LOG_DIR="$console_dir" \
        CONSOLE_FILE_LEVEL="$env_console_file_level" \
        CONSOLE_STDOUT_LEVEL="$env_console_stdout_level" \
        uv run python -m pytest $files --tb=short --serving-mode="$mode" > "$log_file" 2>&1; then
-      local elapsed=$(($(date +%s) - start_time))
-      echo -e "${GREEN}OK${NC}  $group_name ($mode)  ${elapsed}s"
+      elapsed=$(($(date +%s) - start_time))
+      echo -e "${GREEN}OK${NC}  $group_name ($mode)  ${elapsed}s${port:+  port=$port}"
       _print_console_logs "$console_dir" "$env_console_stdout_level"
       ((PASSED++)) || true
     else
-      local elapsed=$(($(date +%s) - start_time))
-      echo -e "${RED}FAIL${NC}  $group_name ($mode)  ${elapsed}s"
+      elapsed=$(($(date +%s) - start_time))
+      echo -e "${RED}FAIL${NC}  $group_name ($mode)  ${elapsed}s${port:+  port=$port}"
       echo "       Last 20 lines of log:"
       echo "       ---"
       tail -20 "$log_file" | while IFS= read -r line; do
@@ -205,39 +444,19 @@ run_group() {
       ((FAILED++)) || true
       FAILED_NAMES+=("$group_name ($mode)")
     fi
-  done
-}
+  done < <(_build_run_tasks)
 
-for group_name in "${SELECTED_GROUPS[@]}"; do
-  files=""
-  if [[ "$group_name" == docs-* ]]; then
-    files="${DOCS_GROUPS[$group_name]:-}"
-    if [ -z "$files" ]; then
-      echo -e "${RED}Unknown group: $group_name${NC}"
-      echo "Available docs groups: ${!DOCS_GROUPS[*]}"
-      exit 1
-    fi
-  else
-    files="${E2E_GROUPS[$group_name]:-}"
-    if [ -z "$files" ]; then
-      echo -e "${RED}Unknown group: $group_name${NC}"
-      echo "Available core groups: ${!E2E_GROUPS[*]}"
-      exit 1
-    fi
+  echo ""
+  echo "──────────────────────────────────────────────"
+  echo -e "Total: ${GREEN}$PASSED passed${NC}, ${RED}$FAILED failed${NC}"
+  if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
+    echo "Failures:"
+    for name in "${FAILED_NAMES[@]}"; do
+      echo "  - $name"
+    done
   fi
-  run_group "$group_name" "$files"
-done
+  echo "Logs saved to: $CORPUS_DIR"
+  echo "──────────────────────────────────────────────"
 
-echo ""
-echo "──────────────────────────────────────────────"
-echo -e "Total: ${GREEN}$PASSED passed${NC}, ${RED}$FAILED failed${NC}"
-if [ ${#FAILED_NAMES[@]} -gt 0 ]; then
-  echo "Failures:"
-  for name in "${FAILED_NAMES[@]}"; do
-    echo "  - $name"
-  done
+  [ $FAILED -eq 0 ]
 fi
-echo "Logs saved to: $CORPUS_DIR"
-echo "──────────────────────────────────────────────"
-
-[ $FAILED -eq 0 ]

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -20,12 +20,14 @@ if TYPE_CHECKING:
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 E2E_DIR = pathlib.Path(__file__).parent
-BASE_URL = "http://localhost:8088/"
-PORT = 8088
+PORT = int(os.environ.get("E2E_PORT", "8088"))
+BASE_URL = f"http://localhost:{PORT}/"
 PYSCRIPT_INIT_TIMEOUT = 120_000
 PYSCRIPT_POLL_INTERVAL = 500
-SERVER_LOG = pathlib.Path(__file__).parent / ".e2e-server.log"
-TMP_DIR = pathlib.Path(__file__).parent.parent.parent / ".tmp" / "e2e-static"
+SERVER_LOG = pathlib.Path(os.environ.get("E2E_SERVER_LOG", str(pathlib.Path(__file__).parent / ".e2e-server.log")))
+TMP_DIR = pathlib.Path(
+    os.environ.get("E2E_TMP_DIR", str(pathlib.Path(__file__).parent.parent.parent / ".tmp" / "e2e-static"))
+)
 
 _PYTHON_TRACEBACK_PATTERNS = (
     "Traceback (most recent call last):",

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,7 @@ import threading
 import time
 import urllib.request
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from typing import TYPE_CHECKING
@@ -39,6 +40,46 @@ _ASSET_ERROR_PATTERNS = (
     "Failed to fetch",
     "ModuleNotFoundError",
 )
+
+_CONSOLE_LEVEL_ORDER = {"off": 0, "error": 1, "warning": 2, "info": 3, "log": 4, "debug": 5}
+_CONSOLE_LEVEL_KEYS = ("error", "warning", "info", "log")
+
+
+def _parse_console_level(value: str | None, default: str) -> str:
+    if value is None:
+        return default
+    if value not in _CONSOLE_LEVEL_ORDER:
+        raise ValueError(f"Invalid console level: {value!r}. Expected one of: {', '.join(_CONSOLE_LEVEL_ORDER)}")
+    return value
+
+
+CONSOLE_FILE_LEVEL = _parse_console_level(os.environ.get("CONSOLE_FILE_LEVEL"), "debug")
+CONSOLE_STDOUT_LEVEL = _parse_console_level(os.environ.get("CONSOLE_STDOUT_LEVEL"), "warning")
+CONSOLE_LOG_DIR = os.environ.get("CONSOLE_LOG_DIR")
+
+
+@dataclass
+class ConsoleMessage:
+    type: str
+    text: str
+    location: str
+
+    def format(self) -> str:
+        return f"[{self.type}] {self.text} ({self.location})"
+
+
+def _collect_console_messages(page: Page, messages: list[ConsoleMessage]):
+    def on_console_msg(msg):
+        loc = msg.location if isinstance(msg.location, dict) else {}
+        messages.append(
+            ConsoleMessage(
+                type=msg.type,
+                text=msg.text,
+                location=f"{loc.get('url', '')}:{loc.get('lineNumber', '')}:{loc.get('columnNumber', '')}",
+            )
+        )
+
+    page.on("console", on_console_msg)
 
 
 class _QuietHandler(SimpleHTTPRequestHandler):
@@ -95,29 +136,29 @@ def _collect_console_errors(page: Page, errors: list[str]):
     page.on("console", on_console_msg)
 
 
-def _check_asset_errors(errors: list[str]):
-    asset_errors = [e for e in errors if any(p in e for p in _ASSET_ERROR_PATTERNS)]
+def _check_asset_errors(messages: list[ConsoleMessage]):
+    asset_errors = [m for m in messages if m.type == "error" and any(p in m.text for p in _ASSET_ERROR_PATTERNS)]
     if asset_errors:
         pytest.exit(
             f"Asset loading errors detected ({len(asset_errors)}) — aborting all tests:\n"
-            + "\n---\n".join(asset_errors)
+            + "\n---\n".join(m.format() for m in asset_errors)
         )
 
 
-def _check_python_errors(errors: list[str]):
-    python_errors = [e for e in errors if any(p in e for p in _PYTHON_TRACEBACK_PATTERNS)]
+def _check_python_errors(messages: list[ConsoleMessage]):
+    python_errors = [m for m in messages if m.type == "error" and any(p in m.text for p in _PYTHON_TRACEBACK_PATTERNS)]
     if python_errors:
         pytest.fail(
             f"Python errors detected during initialization ({len(python_errors)}):\n"
-            + "\n---\n".join(python_errors[:5])
+            + "\n---\n".join(m.format() for m in python_errors[:5])
         )
 
 
-def _wait_for_pyscript_init(page: Page, console_errors_list: list[str]):
+def _wait_for_pyscript_init(page: Page, console_messages_list: list[ConsoleMessage]):
     start_time = time.monotonic()
     while True:
-        _check_asset_errors(console_errors_list)
-        _check_python_errors(console_errors_list)
+        _check_asset_errors(console_messages_list)
+        _check_python_errors(console_messages_list)
         try:
             page.wait_for_selector("#webcompy-loading", state="hidden", timeout=PYSCRIPT_POLL_INTERVAL)
         except Exception:
@@ -126,10 +167,10 @@ def _wait_for_pyscript_init(page: Page, console_errors_list: list[str]):
             page.wait_for_selector("#webcompy-app:not([hidden])", timeout=PYSCRIPT_POLL_INTERVAL)
             return
         if time.monotonic() - start_time > PYSCRIPT_INIT_TIMEOUT / 1000:
-            remaining_errors = console_errors_list[-5:] if console_errors_list else []
+            remaining = console_messages_list[-5:] if console_messages_list else []
             pytest.fail(
                 f"PyScript did not initialize within {PYSCRIPT_INIT_TIMEOUT / 1000:.0f}s\n"
-                + f"Last console errors: {remaining_errors}"
+                + f"Last console messages: {[m.format() for m in remaining]}"
             )
 
 
@@ -331,48 +372,75 @@ def server_url(serving_mode, prod_server, static_server):
 
 
 @pytest.fixture
-def console_errors(page: Page):
-    errors: list[str] = []
-    _collect_console_errors(page, errors)
-    yield errors
+def console_messages(page: Page):
+    messages: list[ConsoleMessage] = []
+    _collect_console_messages(page, messages)
+    yield messages
 
 
 @pytest.fixture
-def app_page(page: Page, server_url, console_errors):
+def console_errors(console_messages: list[ConsoleMessage]):
+    yield [m.text for m in console_messages if m.type == "error"]
+
+
+@pytest.fixture
+def app_page(page: Page, server_url, console_messages):
     page.goto(server_url)
-    _wait_for_pyscript_init(page, console_errors)
+    _wait_for_pyscript_init(page, console_messages)
     return page
 
 
 @pytest.fixture
-def page_on(page: Page, server_url, console_errors) -> Callable[[str], Page]:
+def page_on(page: Page, server_url, console_messages) -> Callable[[str], Page]:
     def _navigate(path: str) -> Page:
         page.goto(f"{server_url}{path.lstrip('/')}")
-        _wait_for_pyscript_init(page, console_errors)
+        _wait_for_pyscript_init(page, console_messages)
         return page
 
     return _navigate
 
 
+def _write_console_log(request, console_messages_list: list[ConsoleMessage]):
+    if not CONSOLE_LOG_DIR:
+        return
+    level = _CONSOLE_LEVEL_ORDER[CONSOLE_FILE_LEVEL]
+    filtered = [m for m in console_messages_list if _CONSOLE_LEVEL_ORDER.get(m.type, 0) <= level]
+    if not filtered:
+        return
+    log_dir = pathlib.Path(CONSOLE_LOG_DIR)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    test_name = request.node.name.replace("/", "_").replace("::", "__").replace(" ", "_")
+    log_path = log_dir / f"console-{test_name}.log"
+    with log_path.open("w") as f:
+        for m in filtered:
+            f.write(m.format() + "\n")
+
+
 @pytest.fixture
-def assert_no_console_errors(console_errors: list[str]):
+def assert_no_console_errors(console_messages: list[ConsoleMessage], request):
     yield
-    _check_asset_errors(console_errors)
-    python_errors = [err for err in console_errors if any(pattern in err for pattern in _PYTHON_TRACEBACK_PATTERNS)]
+    _write_console_log(request, console_messages)
+    _check_asset_errors(console_messages)
+    python_errors = [
+        m for m in console_messages if m.type == "error" and any(p in m.text for p in _PYTHON_TRACEBACK_PATTERNS)
+    ]
     assert not python_errors, f"Python errors detected in browser console ({len(python_errors)}):\n" + "\n---\n".join(
-        python_errors
+        m.format() for m in python_errors
     )
 
 
 @pytest.fixture(autouse=True)
 def _check_console_errors_after_test(request):
-    console_errors = request.getfixturevalue("console_errors") if "page" in request.fixturenames else None
+    console_messages = request.getfixturevalue("console_messages") if "page" in request.fixturenames else None
     yield
-    if console_errors is not None:
-        _check_asset_errors(console_errors)
-        python_errors = [err for err in console_errors if any(pattern in err for pattern in _PYTHON_TRACEBACK_PATTERNS)]
+    if console_messages is not None:
+        _write_console_log(request, console_messages)
+        _check_asset_errors(console_messages)
+        python_errors = [
+            m for m in console_messages if m.type == "error" and any(p in m.text for p in _PYTHON_TRACEBACK_PATTERNS)
+        ]
         if python_errors:
             pytest.fail(
                 f"Python errors detected in browser console ({len(python_errors)}):\n"
-                + "\n---\n".join(python_errors[:5])
+                + "\n---\n".join(m.format() for m in python_errors[:5])
             )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -44,7 +44,6 @@ _ASSET_ERROR_PATTERNS = (
 )
 
 _CONSOLE_LEVEL_ORDER = {"off": 0, "error": 1, "warning": 2, "info": 3, "log": 4, "debug": 5}
-_CONSOLE_LEVEL_KEYS = ("error", "warning", "info", "log")
 
 
 def _parse_console_level(value: str | None, default: str) -> str:
@@ -128,14 +127,6 @@ def pytest_generate_tests(metafunc):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: End-to-end tests requiring a browser and server")
-
-
-def _collect_console_errors(page: Page, errors: list[str]):
-    def on_console_msg(msg):
-        if msg.type == "error":
-            errors.append(msg.text)
-
-    page.on("console", on_console_msg)
 
 
 def _check_asset_errors(messages: list[ConsoleMessage]):

--- a/tests/e2e/test_runtime_local.py
+++ b/tests/e2e/test_runtime_local.py
@@ -19,8 +19,8 @@ pytestmark = [
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 E2E_DIR = pathlib.Path(__file__).parent
-PORT = 8089
-TMP_DIR = PROJECT_ROOT / ".tmp" / "e2e-runtime-local"
+PORT = int(os.environ.get("RUNTIME_LOCAL_PORT", "8089"))
+TMP_DIR = pathlib.Path(os.environ.get("RUNTIME_LOCAL_TMP_DIR", str(PROJECT_ROOT / ".tmp" / "e2e-runtime-local")))
 
 
 class _QuietHandler(SimpleHTTPRequestHandler):

--- a/tests/e2e/test_standalone.py
+++ b/tests/e2e/test_standalone.py
@@ -14,7 +14,7 @@ pytestmark = [
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 E2E_DIR = pathlib.Path(__file__).parent
-TMP_DIR = PROJECT_ROOT / ".tmp" / "e2e-standalone"
+TMP_DIR = pathlib.Path(os.environ.get("STANDALONE_TMP_DIR", str(PROJECT_ROOT / ".tmp" / "e2e-standalone")))
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e_docs/conftest.py
+++ b/tests/e2e_docs/conftest.py
@@ -9,6 +9,7 @@ import threading
 import time
 import urllib.request
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
 from typing import TYPE_CHECKING
@@ -40,6 +41,46 @@ _ASSET_ERROR_PATTERNS = (
     "Failed to fetch",
     "ModuleNotFoundError",
 )
+
+_CONSOLE_LEVEL_ORDER = {"off": 0, "error": 1, "warning": 2, "info": 3, "log": 4, "debug": 5}
+_CONSOLE_LEVEL_KEYS = ("error", "warning", "info", "log")
+
+
+def _parse_console_level(value: str | None, default: str) -> str:
+    if value is None:
+        return default
+    if value not in _CONSOLE_LEVEL_ORDER:
+        raise ValueError(f"Invalid console level: {value!r}. Expected one of: {', '.join(_CONSOLE_LEVEL_ORDER)}")
+    return value
+
+
+CONSOLE_FILE_LEVEL = _parse_console_level(os.environ.get("CONSOLE_FILE_LEVEL"), "debug")
+CONSOLE_STDOUT_LEVEL = _parse_console_level(os.environ.get("CONSOLE_STDOUT_LEVEL"), "warning")
+CONSOLE_LOG_DIR = os.environ.get("CONSOLE_LOG_DIR")
+
+
+@dataclass
+class ConsoleMessage:
+    type: str
+    text: str
+    location: str
+
+    def format(self) -> str:
+        return f"[{self.type}] {self.text} ({self.location})"
+
+
+def _collect_console_messages(page: Page, messages: list[ConsoleMessage]):
+    def on_console_msg(msg):
+        loc = msg.location if isinstance(msg.location, dict) else {}
+        messages.append(
+            ConsoleMessage(
+                type=msg.type,
+                text=msg.text,
+                location=f"{loc.get('url', '')}:{loc.get('lineNumber', '')}:{loc.get('columnNumber', '')}",
+            )
+        )
+
+    page.on("console", on_console_msg)
 
 
 class _QuietHandler(SimpleHTTPRequestHandler):
@@ -89,21 +130,31 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: End-to-end tests requiring a browser and server")
 
 
-def _collect_console_errors(page: Page, errors: list[str]):
-    def on_console_msg(msg):
-        if msg.type == "error":
-            errors.append(msg.text)
-
-    page.on("console", on_console_msg)
-
-
-def _check_asset_errors(errors: list[str]):
-    asset_errors = [e for e in errors if any(p in e for p in _ASSET_ERROR_PATTERNS)]
+def _check_asset_errors(messages: list[ConsoleMessage]):
+    asset_errors = [m for m in messages if m.type == "error" and any(p in m.text for p in _ASSET_ERROR_PATTERNS)]
     if asset_errors:
         pytest.exit(
             f"Asset loading errors detected ({len(asset_errors)}) — aborting all tests:\n"
-            + "\n---\n".join(asset_errors)
+            + "\n---\n".join(m.format() for m in asset_errors)
         )
+
+
+def _wait_for_pyscript_init(page: Page, console_messages_list: list[ConsoleMessage]):
+    start_time = time.monotonic()
+    while True:
+        _check_asset_errors(console_messages_list)
+        try:
+            page.wait_for_selector("#webcompy-loading", state="hidden", timeout=PYSCRIPT_POLL_INTERVAL)
+            page.wait_for_selector("#webcompy-app:not([hidden])", timeout=PYSCRIPT_POLL_INTERVAL)
+            return
+        except Exception:
+            pass
+        if time.monotonic() - start_time > PYSCRIPT_INIT_TIMEOUT / 1000:
+            remaining = console_messages_list[-5:] if console_messages_list else []
+            pytest.fail(
+                f"PyScript did not initialize within {PYSCRIPT_INIT_TIMEOUT / 1000:.0f}s\n"
+                + f"Last console messages: {[m.format() for m in remaining]}"
+            )
 
 
 def _wait_for_pyscript_init(page: Page, console_errors_list: list[str]):
@@ -284,36 +335,77 @@ def docs_server_url(request, serving_mode, docs_static_server):
 
 
 @pytest.fixture
-def docs_console_errors(page: Page):
-    errors: list[str] = []
-    _collect_console_errors(page, errors)
-    yield errors
+def docs_console_messages(page: Page):
+    messages: list[ConsoleMessage] = []
+    _collect_console_messages(page, messages)
+    yield messages
 
 
 @pytest.fixture
-def docs_app_page(page: Page, docs_server_url, docs_console_errors):
+def docs_console_errors(docs_console_messages: list[ConsoleMessage]):
+    yield [m.text for m in docs_console_messages if m.type == "error"]
+
+
+@pytest.fixture
+def docs_app_page(page: Page, docs_server_url, docs_console_messages):
     page.goto(docs_server_url)
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)
     return page
 
 
 @pytest.fixture
-def docs_page_on(page: Page, docs_server_url, docs_console_errors) -> Callable[[str], Page]:
+def docs_page_on(page: Page, docs_server_url, docs_console_messages) -> Callable[[str], Page]:
     def _navigate(path: str) -> Page:
         page.goto(f"{docs_server_url}{path.lstrip('/')}")
-        _wait_for_pyscript_init(page, docs_console_errors)
+        _wait_for_pyscript_init(page, docs_console_messages)
         return page
 
     return _navigate
 
 
+def _write_console_log(request, console_messages_list: list[ConsoleMessage]):
+    if not CONSOLE_LOG_DIR:
+        return
+    level = _CONSOLE_LEVEL_ORDER[CONSOLE_FILE_LEVEL]
+    filtered = [m for m in console_messages_list if _CONSOLE_LEVEL_ORDER.get(m.type, 0) <= level]
+    if not filtered:
+        return
+    log_dir = pathlib.Path(CONSOLE_LOG_DIR)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    test_name = request.node.name.replace("/", "_").replace("::", "__").replace(" ", "_")
+    log_path = log_dir / f"console-{test_name}.log"
+    with log_path.open("w") as f:
+        for m in filtered:
+            f.write(m.format() + "\n")
+
+
 @pytest.fixture
-def assert_no_console_errors(docs_console_errors: list[str]):
+def assert_no_console_errors(docs_console_messages: list[ConsoleMessage], request):
     yield
-    _check_asset_errors(docs_console_errors)
+    _write_console_log(request, docs_console_messages)
+    _check_asset_errors(docs_console_messages)
     python_errors = [
-        err for err in docs_console_errors if any(pattern in err for pattern in _PYTHON_TRACEBACK_PATTERNS)
+        m for m in docs_console_messages if m.type == "error" and any(p in m.text for p in _PYTHON_TRACEBACK_PATTERNS)
     ]
     assert not python_errors, f"Python errors detected in browser console ({len(python_errors)}):\n" + "\n---\n".join(
-        python_errors
+        m.format() for m in python_errors
     )
+
+
+@pytest.fixture(autouse=True)
+def _check_console_errors_after_test(request):
+    docs_console_messages = request.getfixturevalue("docs_console_messages") if "page" in request.fixturenames else None
+    yield
+    if docs_console_messages is not None:
+        _write_console_log(request, docs_console_messages)
+        _check_asset_errors(docs_console_messages)
+        python_errors = [
+            m
+            for m in docs_console_messages
+            if m.type == "error" and any(p in m.text for p in _PYTHON_TRACEBACK_PATTERNS)
+        ]
+        if python_errors:
+            pytest.fail(
+                f"Python errors detected in browser console ({len(python_errors)}):\n"
+                + "\n---\n".join(m.format() for m in python_errors[:5])
+            )

--- a/tests/e2e_docs/conftest.py
+++ b/tests/e2e_docs/conftest.py
@@ -21,12 +21,14 @@ if TYPE_CHECKING:
 
 PROJECT_ROOT = pathlib.Path(__file__).parent.parent.parent
 DOCS_APP_DIR = PROJECT_ROOT / "docs_app"
-BASE_URL = "http://localhost:8081/"
-PORT = 8081
+PORT = int(os.environ.get("DOCS_E2E_PORT", "8081"))
+BASE_URL = f"http://localhost:{PORT}/"
 PYSCRIPT_INIT_TIMEOUT = 300_000
 PYSCRIPT_POLL_INTERVAL = 500
-SERVER_LOG = pathlib.Path(__file__).parent / ".e2e-docs-server.log"
-TMP_DIR = PROJECT_ROOT / ".tmp" / "e2e-docs-static"
+SERVER_LOG = pathlib.Path(
+    os.environ.get("DOCS_E2E_SERVER_LOG", str(pathlib.Path(__file__).parent / ".e2e-docs-server.log"))
+)
+TMP_DIR = pathlib.Path(os.environ.get("DOCS_E2E_TMP_DIR", str(PROJECT_ROOT / ".tmp" / "e2e-docs-static")))
 
 _PYTHON_TRACEBACK_PATTERNS = (
     "Traceback (most recent call last):",

--- a/tests/e2e_docs/conftest.py
+++ b/tests/e2e_docs/conftest.py
@@ -45,7 +45,6 @@ _ASSET_ERROR_PATTERNS = (
 )
 
 _CONSOLE_LEVEL_ORDER = {"off": 0, "error": 1, "warning": 2, "info": 3, "log": 4, "debug": 5}
-_CONSOLE_LEVEL_KEYS = ("error", "warning", "info", "log")
 
 
 def _parse_console_level(value: str | None, default: str) -> str:
@@ -156,24 +155,6 @@ def _wait_for_pyscript_init(page: Page, console_messages_list: list[ConsoleMessa
             pytest.fail(
                 f"PyScript did not initialize within {PYSCRIPT_INIT_TIMEOUT / 1000:.0f}s\n"
                 + f"Last console messages: {[m.format() for m in remaining]}"
-            )
-
-
-def _wait_for_pyscript_init(page: Page, console_errors_list: list[str]):
-    start_time = time.monotonic()
-    while True:
-        _check_asset_errors(console_errors_list)
-        try:
-            page.wait_for_selector("#webcompy-loading", state="hidden", timeout=PYSCRIPT_POLL_INTERVAL)
-            page.wait_for_selector("#webcompy-app:not([hidden])", timeout=PYSCRIPT_POLL_INTERVAL)
-            return
-        except Exception:
-            pass
-        if time.monotonic() - start_time > PYSCRIPT_INIT_TIMEOUT / 1000:
-            remaining_errors = console_errors_list[-5:] if console_errors_list else []
-            pytest.fail(
-                f"PyScript did not initialize within {PYSCRIPT_INIT_TIMEOUT / 1000:.0f}s\n"
-                + f"Last console errors: {remaining_errors}"
             )
 
 

--- a/tests/e2e_docs/test_documents.py
+++ b/tests/e2e_docs/test_documents.py
@@ -16,7 +16,7 @@ def test_documents_page_title(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_documents_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_documents_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/documents")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)

--- a/tests/e2e_docs/test_fetch.py
+++ b/tests/e2e_docs/test_fetch.py
@@ -12,7 +12,7 @@ def test_fetch_page_loads(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_fetch_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_fetch_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/sample/fetch")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)

--- a/tests/e2e_docs/test_fizzbuzz.py
+++ b/tests/e2e_docs/test_fizzbuzz.py
@@ -40,7 +40,7 @@ def test_fizzbuzz_hide_toggle(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_fizzbuzz_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_fizzbuzz_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/sample/fizzbuzz")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)

--- a/tests/e2e_docs/test_helloworld.py
+++ b/tests/e2e_docs/test_helloworld.py
@@ -19,7 +19,7 @@ def test_helloworld_page_text(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_helloworld_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_helloworld_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/sample/helloworld")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)

--- a/tests/e2e_docs/test_home.py
+++ b/tests/e2e_docs/test_home.py
@@ -37,6 +37,6 @@ def test_home_spa_navigation_back_from_helloworld(docs_page_on, assert_no_consol
 
 
 @pytest.mark.e2e
-def test_home_reload_no_error(docs_app_page, docs_console_errors, assert_no_console_errors):
+def test_home_reload_no_error(docs_app_page, docs_console_messages, assert_no_console_errors):
     docs_app_page.reload()
-    _wait_for_pyscript_init(docs_app_page, docs_console_errors)
+    _wait_for_pyscript_init(docs_app_page, docs_console_messages)

--- a/tests/e2e_docs/test_matplotlib.py
+++ b/tests/e2e_docs/test_matplotlib.py
@@ -36,7 +36,7 @@ def test_matplotlib_image_rendered(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_matplotlib_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_matplotlib_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/sample/matplotlib")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)

--- a/tests/e2e_docs/test_todo.py
+++ b/tests/e2e_docs/test_todo.py
@@ -32,7 +32,7 @@ def test_todo_remove_done_items(docs_page_on, assert_no_console_errors):
 
 
 @pytest.mark.e2e
-def test_todo_reload_no_error(docs_page_on, docs_console_errors, assert_no_console_errors):
+def test_todo_reload_no_error(docs_page_on, docs_console_messages, assert_no_console_errors):
     page = docs_page_on("/sample/todo")
     page.reload()
-    _wait_for_pyscript_init(page, docs_console_errors)
+    _wait_for_pyscript_init(page, docs_console_messages)


### PR DESCRIPTION
## Summary

Add a shared E2E test runner script (`scripts/run-e2e-tests.sh`) that unifies CI and local E2E test execution, add structured browser console output capture with configurable log levels, and enable parallel test execution with dynamic port allocation and isolated temp directories.

## Changes

### Shared E2E test runner script (`scripts/run-e2e-tests.sh`)
- Group-based test execution matching CI matrix definitions (10 core E2E groups + 4 docs groups)
- `--serving-mode` flag (`prod`, `static`, or both) with docs groups defaulting to `static` only
- `--parallel` flag for concurrent execution with dynamic port discovery and isolated temp dirs
- `--console-level` / `--console-file-level` flags for controlling console output verbosity
- Colored output with per-group timing and summary

### Browser console capture
- `ConsoleMessage` dataclass with `type`, `text`, `location` fields
- `console_messages` fixture capturing all levels, with `console_errors`/`docs_console_errors` kept for backward compatibility
- File output via `CONSOLE_LOG_DIR` env var, with `CONSOLE_FILE_LEVEL` / `CONSOLE_STDOUT_LEVEL` env vars for filtering
- Autouse `_check_console_errors_after_test` fixture added to `tests/e2e_docs/conftest.py` (was missing)

### Parallel execution
- `_find_free_port()` for dynamic port allocation
- `_run_single_bg()` for background process management with PID tracking
- Per-group isolated temp dirs under `.tmp/e2e-test-corpus/`
- Environment variables for port/dir isolation

### CI updates
- CI matrix now uses `matrix.group.name` instead of `matrix.group.files`
- Added `.tmp/e2e-test-corpus/` to artifact upload paths

### Bug fixes from review
- Removed duplicate `_wait_for_pyscript_init` that caused AttributeError at runtime
- Fixed word splitting bug in `_run_single` env var handling
- Removed dead code (`_collect_console_errors`, `_CONSOLE_LEVEL_KEYS`)
- Added `.tmp/e2e-test-corpus/` to CI artifact paths