### PR TITLE
chore: add OpenSpec proposals for SSR/SSG future work (AsyncScheduler, codec, signal transfer, compression)

### DIFF
--- a/openspec/changes/feat-async-scheduler-port/.openspec.yaml
+++ b/openspec/changes/feat-async-scheduler-port/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/feat-async-scheduler-port/design.md
+++ b/openspec/changes/feat-async-scheduler-port/design.md
@@ -1,0 +1,182 @@
+# Design: Async Scheduler Port
+
+## Context
+
+WebComPy operates in two runtime environments with fundamentally different event-loop lifecycles:
+
+- **Browser (PyScript/Emscripten)**: The event loop runs for the entire page lifetime. Fire-and-forget tasks (`asyncio.ensure_future`) complete eventually because the loop never exits during normal operation.
+- **Server (CPython)**: Each SSR/SSG render is a single-shot async operation. `await generate_html()` drives the render tree to completion, then `ctx.dispose()` tears down the DI scope. Any task scheduled via fire-and-forget may execute *after* disposal, accessing a torn-down DI scope and raising `InjectKey` resolution errors.
+
+The `fix-ssr-hydration-skip` change patched one manifestation (`DynamicElement._hydrate_node` scheduling `ensure_future(child._render())` that ran post-dispose). But five fire-and-forget scheduling sites remain:
+
+| Site | File | Current mechanism |
+|------|------|-------------------|
+| Root render + async callbacks | `aio/_aio.py` | `ensure_future` (browser) / `create_task` (server, never awaited) |
+| Hydrate unmounted children | `elements/types/_dynamic.py:75` | `ensure_future` |
+| Suspense browser resolve | `elements/types/_suspense.py:134` | `ensure_future` |
+| Suspense hydrate resolve | `elements/types/_suspense.py:232` | `ensure_future` |
+| FetchPort cleanup | `server/ports/_fetch.py` | `create_task` (`# noqa: RUF006`) |
+
+The server-side `_aio_run_server_tasks` list is appended to but **never gathered** — orphaned tasks accumulate without completion guarantees.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Centralize all async task scheduling behind a single typed, injectable port (`AsyncSchedulerPort`).
+- Guarantee that on the server, all scheduled tasks complete before `ctx.dispose()` runs, via a registry-and-drain pattern.
+- Eliminate the class of dual-environment lifecycle bugs (not just the `_hydrate_node` instance).
+- Preserve exact browser behavior (fire-and-forget on a long-lived loop remains correct).
+- Provide a testing-friendly fake port for browserless unit tests.
+
+**Non-Goals:**
+
+- Removing the `app._hydrate` environment guard (retained as defense-in-depth).
+- Making `_hydrate_node()` async (caused E2E regressions per `async-rendering` spec).
+- Parallel sibling rendering via `asyncio.gather` (separate future work).
+- Changing `HostPort.schedule_macro_task()` (already environment-aware; remains separate).
+- Adding retry/backoff/cancellation policies to scheduled tasks.
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                   AsyncSchedulerPort (ABC)                    │
+│   schedule(coro: Coroutine) -> asyncio.Task                   │
+│   await_pending() -> Awaitable[None]                          │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+          ┌──────────────┴──────────────┐
+          ▼                             ▼
+┌──────────────────────┐  ┌──────────────────────────────────┐
+│ BrowserAsyncScheduler│  │ ServerAsyncScheduler             │
+│                      │  │                                  │
+│ schedule:            │  │ schedule:                        │
+│   ensure_future(coro)│  │   task = create_task(coro)       │
+│   (fire-and-forget)  │  │   _registry.append(task)         │
+│                      │  │                                  │
+│ await_pending:       │  │ await_pending:                   │
+│   no-op (long-lived  │  │   done, pending = partition(...) │
+│   loop persists)     │  │   await gather(*pending)         │
+│                      │  │   (drains before ctx.dispose())  │
+└──────────────────────┘  └──────────────────────────────────┘
+```
+
+### Registry-and-Drain Flow (Server)
+
+```
+  generate_html() / ASGI handler
+      │
+      ▼
+  ctx = app.create_render_context(path)
+      │  (DI scope provides ServerAsyncSchedulerPort instance)
+      ▼
+  await ctx._root._render()
+      │  ├── Component._render() → may call aio_run(callback)
+      │  │     └── scheduler.schedule(callback_coro) → registered
+      │  ├── SuspenseElement._render() → scheduler.schedule(resolve)
+      │  │     └── registered
+      │  └── DynamicElement._hydrate_node() [browser-only path,
+      │        but if reached, scheduler.schedule(render)]
+      │
+      ▼
+  await scheduler.await_pending()    ← NEW: drain all registered tasks
+      │  (gather completes all pending coroutines)
+      ▼
+  ctx.dispose()                       ← safe: no orphaned tasks
+```
+
+## Decisions
+
+### D1: Single port for all async scheduling (broad scope)
+
+All five fire-and-forget sites route through `AsyncSchedulerPort`. This includes `aio_run` (the general-purpose resolver used by `resolve_async`, `AsyncWrapper`, and the root browser render).
+
+**Alternatives considered:**
+- **Narrow scope** (only the 4 render-task sites, leave `aio_run` as-is): Smaller change, but `_aio_run_server_tasks` remains a latent fire-and-forget. Any future code calling `resolve_async` during SSR would reintroduce the bug. Rejected — does not generalize the fix.
+- **Two ports** (`RenderSchedulerPort` for render tasks, `AsyncRunnerPort` for `aio_run`): Conceptually cleaner separation, but doubles the surface area and the server implementations would be nearly identical. Rejected — unnecessary complexity.
+
+**Rationale:** A single chokepoint makes the invariant "no bare `ensure_future`/`create_task` outside the port" enforceable and meaningful. The naming `AsyncSchedulerPort` (rather than `RenderSchedulerPort`) reflects the broader scope.
+
+### D2: Registry ownership — per-context, not module-global
+
+The `ServerAsyncSchedulerPort` instance is created per `RenderContext` and provisioned in the context's DI scope. Its internal `_registry: list[asyncio.Task]` is therefore per-request, not shared across concurrent SSR requests.
+
+**Alternatives considered:**
+- **Module-global registry** (single list shared across all requests): Simpler, but concurrent SSR requests would interleave tasks, and `await_pending()` for one request would await another request's tasks. Rejected — breaks request isolation.
+- **Registry on `RenderContext` directly** (not on the port): Requires the port to reach into the context. Coupling the port to a specific context type breaks port abstraction. Rejected.
+
+**Rationale:** The port owns its registry. Per-instance = per-request. The DI scope provides isolation naturally.
+
+### D3: `aio_run` delegation with fallback
+
+`aio_run` (selected at module load: `_aio_run_browser` or `_aio_run_server`) is refactored to attempt `inject(ASYNC_SCHEDULER_PORT_KEY)` at call time. If the injection succeeds (a DI scope is active), the task is scheduled via the port. If injection fails (called outside a render context, e.g., in CLI utilities or module-level code), the fallback creates the task directly and logs a warning.
+
+```
+  aio_run(coro):
+      try:
+          scheduler = inject(ASYNC_SCHEDULER_PORT_KEY)
+      except InjectionError:
+          # Fallback: no DI scope active
+          logging.warning("aio_run called outside render context; "
+                          "task may not be awaited on server")
+          task = ensure_future(coro)  # browser
+                  # or create_task(coro)  # server
+      else:
+          task = scheduler.schedule(coro)
+      _track_task(task)  # keep reference for GC safety
+```
+
+**Rationale:** `aio_run` is called from diverse contexts — some within render (component lifecycle hooks, Suspense resolution) and some outside (CLI bootstrap, testing utilities). The fallback preserves backward compatibility while the render-context path gets full registry-drain guarantees.
+
+### D4: `await_pending()` called by entry points, not by the port itself
+
+The port does not auto-drain. The SSR/SSG entry points explicitly call `await scheduler.await_pending()` after the render tree completes and before `ctx.dispose()`. This makes the drain timing explicit and auditable.
+
+**Call sites:**
+- `generate_html()` in `webcompy_server/_html.py`
+- ASGI HTML handler in `webcompy_cli/_server.py`
+- SSG route fetch loop in `webcompy_cli/_generate.py`
+
+**Rationale:** Auto-draining (e.g., in a `__del__` or context-manager exit) would hide the timing and make debugging harder. Explicit calls are self-documenting.
+
+### D5: Browser `await_pending()` is a no-op
+
+On the browser, the event loop is long-lived. Tasks scheduled via `ensure_future` complete naturally. `await_pending()` returns immediately (empty coroutine). This keeps the call sites symmetric across environments without imposing browser-side waiting.
+
+### D6: `ServerFetchPort.close()` cleanup tasks
+
+`ServerFetchPort.close()` currently uses `loop.create_task(self._external_client.aclose())` with `# noqa: RUF006`. Two options:
+
+- **Route through scheduler**: `scheduler.schedule(self._external_client.aclose())`. The task is registered and drained. But `close()` is typically called during teardown *after* `await_pending()`, so the registry drain may not cover it.
+- **Make `close()` async and await explicitly**: `await self._external_client.aclose()`. The caller (`ctx.dispose()` or the port's own teardown) awaits `close()`.
+
+**Decision:** Make `close()` async (or add an `aclose()` async variant) and have `ctx.dispose()` await it. This is more correct than relying on the scheduler for teardown-order cleanup. The scheduler handles *render-time* tasks; teardown cleanup is a separate lifecycle concern.
+
+### D7: Fake port for testing
+
+`FakeAsyncSchedulerPort` (in `webcompy_testing`) collects scheduled coroutines in a list. Tests can either:
+- Call `await fake_scheduler.drain()` to run all collected coroutines, or
+- Inspect the list to assert what was scheduled.
+
+This matches the existing fake-port pattern in `webcompy_testing/_ports.py`.
+
+## Risks / Trade-offs
+
+- **[Orphaned tasks if `await_pending()` is forgotten]** → Mitigation: Document the invariant in `app-lifecycle` spec that all SSR/SSG entry points MUST call `await_pending()` before `dispose()`. The `ci-review` agent enforces this invariant.
+
+- **[Fallback path masks missing DI scope]** → Mitigation: The fallback logs a warning. In development, the warning surfaces misconfigured code. In production, the fallback still creates the task (preserving behavior); it just lacks the drain guarantee.
+
+- **[Performance overhead of registry bookkeeping]** → Mitigation: The registry is a simple list append/remove. `await_pending()` gathers only the remaining tasks. For typical renders with 0-5 scheduled tasks, overhead is negligible.
+
+- **[Deadlock if a scheduled task schedules another task]** → Mitigation: `await_pending()` should handle this by re-checking for newly added tasks after the initial gather. Implementation: loop until the registry is empty (with a maximum iteration guard to prevent infinite loops from buggy recursive scheduling).
+
+- **[Browser behavior change]** → Mitigation: `BrowserAsyncSchedulerPort.schedule()` wraps the exact same `ensure_future` call. No behavioral change on browser. Existing E2E tests (`/reactive`, `/switch`, `/suspense` pages) verify no regression.
+
+## Open Questions
+
+1. **Should `await_pending()` have a timeout?** If a scheduled task hangs, `await_pending()` blocks forever. A configurable timeout (defaulting to the Suspense timeout of 10s, or a separate value) would prevent indefinite hangs. Deferred to implementation — a reasonable default can be chosen during coding.
+
+2. **Should the registry track task exceptions?** Currently, `ensure_future` tasks with exceptions log via `add_done_callback`. The port could centralize exception handling, but this overlaps with `resolve_async`'s `on_error` hook. Decision: keep exception handling at the call site; the port is a scheduling mechanism, not an error boundary.
+
+3. **Interaction with nested DI scopes (Suspense)**: `SuspenseElement._render()` provides `SUSPENSE_RESOLVING_KEY` in a child scope. Tasks scheduled within that scope use the same scheduler instance (DI traversal finds the nearest provision, which is the context-level scheduler). No issue expected, but needs verification during implementation.

--- a/openspec/changes/feat-async-scheduler-port/design.md
+++ b/openspec/changes/feat-async-scheduler-port/design.md
@@ -102,9 +102,26 @@ All five fire-and-forget sites route through `AsyncSchedulerPort`. This includes
 
 The `ServerAsyncSchedulerPort` instance is created per `RenderContext` and provisioned in the context's DI scope. Its internal `_registry: list[asyncio.Task]` is therefore per-request, not shared across concurrent SSR requests.
 
+**Concurrent modification guard:** Task `done_callback`s remove completed tasks from `_registry`. If a callback fires while `await_pending()` is iterating `_registry`, the list mutates during iteration, risking `RuntimeError: list changed size during iteration` or missed tasks. The implementation SHALL snapshot the registry before iteration:
+
+```python
+async def await_pending(self):
+    iteration = 0
+    while self._registry:
+        tasks = list(self._registry)  # snapshot — callbacks may mutate _registry concurrently
+        await asyncio.gather(*tasks, return_exceptions=True)
+        iteration += 1
+        if iteration > 20:
+            logging.warning("await_pending exceeded 20 drain iterations; "
+                            "possible recursive scheduling bug")
+            break
+```
+
+The `list(self._registry)` snapshot copies references at iteration start; concurrent `done_callback` removals affect the live list, not the snapshot. The snapshot approach is preferred over locking because `done_callback`s run synchronously on the event loop (not from another thread), and `await` points yield control — so a `deque` with locks would add complexity without benefit in the single-threaded asyncio model.
+
 **Alternatives considered:**
 - **Module-global registry** (single list shared across all requests): Simpler, but concurrent SSR requests would interleave tasks, and `await_pending()` for one request would await another request's tasks. Rejected — breaks request isolation.
-- **Registry on `RenderContext` directly** (not on the port): Requires the port to reach into the context. Coupling the port to a specific context type breaks port abstraction. Rejected.
+- **`collections.deque` with locks**: Over-engineered for single-threaded asyncio. The snapshot approach is simpler and sufficient.
 
 **Rationale:** The port owns its registry. Per-instance = per-request. The DI scope provides isolation naturally.
 
@@ -169,7 +186,7 @@ This matches the existing fake-port pattern in `webcompy_testing/_ports.py`.
 
 - **[Performance overhead of registry bookkeeping]** → Mitigation: The registry is a simple list append/remove. `await_pending()` gathers only the remaining tasks. For typical renders with 0-5 scheduled tasks, overhead is negligible.
 
-- **[Deadlock if a scheduled task schedules another task]** → Mitigation: `await_pending()` should handle this by re-checking for newly added tasks after the initial gather. Implementation: loop until the registry is empty (with a maximum iteration guard to prevent infinite loops from buggy recursive scheduling).
+- **[Deadlock if a scheduled task schedules another task]** → Mitigation: `await_pending()` should handle this by re-checking for newly added tasks after the initial gather. Implementation: loop until the registry is empty (with a maximum iteration guard of 20 and a warning log at the limit to surface genuine recursive-scheduling bugs early).
 
 - **[Browser behavior change]** → Mitigation: `BrowserAsyncSchedulerPort.schedule()` wraps the exact same `ensure_future` call. No behavioral change on browser. Existing E2E tests (`/reactive`, `/switch`, `/suspense` pages) verify no regression.
 

--- a/openspec/changes/feat-async-scheduler-port/proposal.md
+++ b/openspec/changes/feat-async-scheduler-port/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Async Scheduler Port
+
+## Why
+
+WebComPy's dual-environment architecture (browser via PyScript with a long-lived event loop, server via CPython with single-shot renders) creates an asymmetry in how asynchronous tasks should be scheduled. On the browser, fire-and-forget scheduling (`asyncio.ensure_future`) is correct because the event loop persists indefinitely. On the server, fire-and-forget tasks may execute after `ctx.dispose()` runs and the DI scope is torn down, causing `InjectKey` resolution failures and incomplete SSR/SSG output.
+
+This problem manifested concretely in `fix-ssr-hydration-skip` (#189 prerequisite), where `DynamicElement._hydrate_node()` scheduled `asyncio.ensure_future(child._render())` tasks that ran after the server render's await chain returned. The fix applied a minimal workaround (`app._hydrate = config.hydrate and ENVIRONMENT == "pyscript"`), but the root cause — scattered `asyncio.ensure_future` / `loop.create_task` calls with no environment-aware scheduling — remains. There are currently **five** fire-and-forget scheduling sites across the codebase (`_aio.py`, `_dynamic.py`, two in `_suspense.py`, `ServerFetchPort.close`), each a latent source of the same dual-environment lifecycle bug.
+
+This change introduces an `AsyncSchedulerPort` that becomes the single chokepoint for all async task scheduling. The server implementation registers tasks in a per-request registry and provides an `await_pending()` method that the SSR/SSG entry points call before `ctx.dispose()`, structurally guaranteeing that no orphaned tasks outlive the render context. This generalizes the fix beyond the specific `_hydrate_node` instance to the entire class of dual-environment scheduling bugs.
+
+## What Changes
+
+- **NEW** `AsyncSchedulerPort` ABC in `packages/webcompy/src/webcompy/ports/_async_scheduler.py` — Defines `schedule(coro: Coroutine) -> asyncio.Task` and `await_pending() -> Awaitable[None]` as the unified async scheduling interface.
+- **NEW** `BrowserAsyncSchedulerPort` in `packages/webcompy/src/webcompy/ports/_browser/_async_scheduler.py` — Wraps `asyncio.ensure_future` (fire-and-forget). `await_pending()` is a no-op because the browser event loop is long-lived.
+- **NEW** `ServerAsyncSchedulerPort` in `packages/webcompy-server/src/webcompy_server/ports/_async_scheduler.py` — Creates tasks via `loop.create_task` and registers them in an internal registry. `await_pending()` gathers all registered tasks, ensuring completion before the render context is disposed.
+- **NEW** `ASYNC_SCHEDULER_PORT_KEY: InjectKey[AsyncSchedulerPort]` in `packages/webcompy/src/webcompy/di/_keys.py`.
+- **MODIFIED** `packages/webcompy/src/webcompy/aio/_aio.py` — `_aio_run_browser` and `_aio_run_server` delegate to `AsyncSchedulerPort.schedule()` when a DI scope is active, with a fallback to direct task creation (plus a warning log) when called outside a render context.
+- **MODIFIED** `packages/webcompy/src/webcompy/elements/types/_dynamic.py` — `DynamicElement._hydrate_node()` calls `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(child._render())` instead of `asyncio.ensure_future`.
+- **MODIFIED** `packages/webcompy/src/webcompy/elements/types/_suspense.py` — Both `ensure_future` call sites (`_browser_render` and `_hydrate_node`) route through `AsyncSchedulerPort.schedule()`.
+- **MODIFIED** `packages/webcompy-server/src/webcompy_server/ports/_fetch.py` — `ServerFetchPort.close()` schedules cleanup tasks through the port (or awaits them explicitly) instead of bare `loop.create_task`.
+- **MODIFIED** `packages/webcompy/src/webcompy/app/_app.py` — The `app._hydrate` workaround is retained but its rationale is documented as "the scheduler port makes hydration scheduling safe; the environment guard is a defense-in-depth measure."
+- **MODIFIED** SSR/SSG entry points (`packages/webcompy-server/src/webcompy_server/_html.py`, `packages/webcompy-cli/src/webcompy_cli/_server.py`, `packages/webcompy-cli/src/webcompy_cli/_generate.py`) — Call `await scheduler.await_pending()` after the render tree completes and before `ctx.dispose()`.
+- **MODIFIED** `packages/webcompy-testing/src/webcompy_testing/_ports.py` — Add a `FakeAsyncSchedulerPort` for browserless testing that runs tasks synchronously or collects them for explicit awaiting.
+
+## Capabilities
+
+### New Capabilities
+
+- `async-scheduler`: A typed, injectable port that centralizes all async task scheduling. The server implementation maintains a per-request task registry drained before context disposal, structurally preventing dual-environment lifecycle bugs.
+
+### Modified Capabilities
+
+- `port-abstraction`: A new `AsyncSchedulerPort` ABC joins the existing port hierarchy alongside `DOMPort`, `FetchPort`, `HostPort`, etc.
+- `port-provisioning`: `ASYNC_SCHEDULER_PORT_KEY` is provisioned in both browser and server DI scopes during context initialization.
+- `async-rendering`: `_hydrate_node()` and Suspense's browser resolution schedule tasks via `AsyncSchedulerPort` instead of direct `asyncio.ensure_future`.
+- `app-lifecycle`: SSR/SSG entry points (`generate_html`, ASGI HTML handler, SSG route fetch) SHALL call `await_pending()` before `ctx.dispose()` to guarantee all scheduled tasks complete.
+- `elements`: `DynamicElement._hydrate_node()` and `SuspenseElement` use the scheduler port for async task creation.
+
+## Known Issues Addressed
+
+- **Dual-environment lifecycle bug (generalized)** — `fix-ssr-hydration-skip` patched the specific `_hydrate_node` manifestation. This change addresses the root cause: all fire-and-forget scheduling sites are routed through a port whose server implementation guarantees task completion before context disposal. The bug class is structurally eliminated (modulo the convention that no new bare `asyncio.ensure_future` / `loop.create_task` calls are added outside the port — enforced as a framework invariant).
+- **`_aio_run_server_tasks` never awaited** — `_aio_run_server` appends tasks to a module-level list that is never gathered. Tasks created via `resolve_async` / `AsyncWrapper` during server renders were orphaned. The scheduler port's registry-and-drain pattern resolves this.
+
+## Non-goals
+
+- **Removing the `app._hydrate` environment guard** — The `app._hydrate = config.hydrate and ENVIRONMENT == "pyscript"` line stays as a defense-in-depth measure. A future change may remove it once the scheduler port is battle-tested.
+- **Changing `_hydrate_node()` to be `async def`** — `_hydrate_node()` remains synchronous. The async render pipeline spec (`async-rendering`) documents that making `_hydrate_node` async caused E2E regressions. The scheduler port does not require this change.
+- **Changing the signal system or reactive contracts** — This change only affects task scheduling, not signal graph semantics.
+- **Parallel sibling rendering** — `asyncio.gather` for sibling children is tracked as separate future work. Sequential sibling rendering is preserved.
+- **Changing the `schedule_macro_task` API on `HostPort`** — `schedule_macro_task` is already environment-aware (server: synchronous, browser: `setTimeout`). It remains separate from `AsyncSchedulerPort`, which handles coroutine scheduling specifically.
+- **Adding retry or backoff semantics to task scheduling** — The port schedules tasks as-is; error handling remains the caller's responsibility.
+
+## Impact
+
+- **Affected modules**:
+  - `packages/webcompy/src/webcompy/ports/` (new ABC + browser impl + DI key)
+  - `packages/webcompy-server/src/webcompy_server/ports/` (new server impl)
+  - `packages/webcompy/src/webcompy/aio/` (`aio_run` delegation)
+  - `packages/webcompy/src/webcompy/elements/types/` (`_dynamic.py`, `_suspense.py`)
+  - `packages/webcompy/src/webcompy/app/` (`_app.py` documentation)
+  - `packages/webcompy-server/src/webcompy_server/` (`_html.py`, `_context.py` — `await_pending` hook)
+  - `packages/webcompy-cli/src/webcompy_cli/` (`_server.py`, `_generate.py` — `await_pending` call)
+  - `packages/webcompy-testing/src/webcompy_testing/` (fake port)
+- **Breaking**: None for public APIs. `aio_run` remains callable but internally delegates to the port when available. The `_aio_run_server_tasks` module-level list is superseded by the port's registry (the list is removed or kept only as the fallback path).
+- **Backward compatible**: All existing user code works unchanged. The port is an internal infrastructure improvement.
+- **Testing**: Unit tests for the registry-drain mechanism, the fallback path when no DI scope is active, and the `await_pending` timing relative to `ctx.dispose()`. E2E tests verify SSR/SSG output completeness (the existing `fix-ssr-hydration-skip` E2E test serves as a regression guard).

--- a/openspec/changes/feat-async-scheduler-port/specs/app-lifecycle/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/app-lifecycle/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: SSR/SSG entry points shall await pending tasks before context disposal
+
+All server-side rendering entry points (`generate_html()` in `webcompy_server._html`, the ASGI HTML handler in `webcompy_cli._server`, and the SSG route fetch loop in `webcompy_cli._generate`) SHALL call `await scheduler.await_pending()` after the render tree completes (`await ctx._root._render()`) and before `ctx.dispose()`. The scheduler SHALL be obtained from the render context's DI scope via `inject(ASYNC_SCHEDULER_PORT_KEY)`. This guarantees that all tasks scheduled during the render (via `aio_run`, `DynamicElement._hydrate_node`, `SuspenseElement`, etc.) complete before the DI scope is torn down.
+
+#### Scenario: generate_html drains tasks before disposal
+- **WHEN** `generate_html()` is called during SSR or SSG
+- **THEN** after `await ctx._root._render()` completes
+- **AND** before `ctx.dispose()` is called
+- **AND** `await scheduler.await_pending()` SHALL be invoked to drain all registered tasks
+
+#### Scenario: ASGI handler drains tasks before disposal
+- **WHEN** the ASGI HTML handler processes a request
+- **THEN** after the render tree completes
+- **AND** before `ctx.dispose()` is called
+- **AND** `await scheduler.await_pending()` SHALL be invoked
+
+### Requirement: app._hydrate shall remain environment-guarded as defense-in-depth
+
+`WebComPyApp.__init__` SHALL set `self._hydrate = self._config.hydrate and ENVIRONMENT == "pyscript"`. This guard remains in place as a defense-in-depth measure. The `AsyncSchedulerPort` provides the primary structural guarantee (task completion before disposal), and the environment guard ensures hydration-related scheduling is never attempted on the server even if the port's drain is bypassed.
+
+#### Scenario: Hydration disabled on server
+- **WHEN** a `WebComPyApp` is created in a non-pyscript environment with `WebComPyAppConfig(hydrate=True)`
+- **THEN** `app._hydrate` SHALL be `False`
+- **AND** `AppDocumentRoot._render()` SHALL skip the `_hydrate_node()` recursion
+- **AND** all children SHALL be rendered via the synchronous `await child._render()` path

--- a/openspec/changes/feat-async-scheduler-port/specs/async-rendering/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/async-rendering/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: The rendering pipeline shall support async _render() methods
+
+`ElementAbstract._render()`, `ElementWithChildren._render()`, `DynamicElement._render()`, `RepeatElement._render()`, `SwitchElement._render()`, `Component._render()`, and `AppDocumentRoot._render()` SHALL be `async def` methods. All callers of these methods SHALL `await` them. The `_mount_node()` method SHALL remain synchronous since DOM operations are not async.
+
+`_hydrate_node()` SHALL remain synchronous in this change. `ElementAbstract._hydrate_node()`, `ElementWithChildren._hydrate_node()`, and `DynamicElement._hydrate_node()` SHALL be `def` methods. All `_hydrate_node()` callers SHALL call them directly (no `await`). `DynamicElement._hydrate_node()` SHALL schedule the async render of unmounted children via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(child._render())`, attaching a done callback that logs exceptions via `webcompy.logging.error`. This eliminates the `RuntimeWarning: coroutine ... was never awaited` and ensures async render errors surface in the log, while routing all task scheduling through the central port so that server-side renders guarantee task completion before context disposal.
+
+#### Scenario: Rendering a component in the browser
+- **WHEN** `app.run()` is called in the browser
+- **THEN** the async render pipeline SHALL be scheduled via `resolve_async(ctx._root._render())`
+- **AND** the component tree SHALL render correctly as before
+
+#### Scenario: Rendering a component during SSG
+- **WHEN** `generate_html()` is called during static site generation
+- **THEN** `await app_root._render()` SHALL be called within the async pipeline
+- **AND** the HTML output SHALL match the previous synchronous output
+
+#### Scenario: Backward compatibility of sync _render() callers
+- **WHEN** existing code calls `await element._render()` on an element that performs no async operations
+- **THEN** the behavior SHALL be identical to the previous synchronous `_render()` call
+
+### Requirement: Sync-only leaf elements shall inherit a default no-op async _render()
+
+`Element._render()` (the base class inherited by `TextElement`, `VoidElement`, `InputElement`, and other sync-only leaf elements) SHALL be `async def` but SHALL have a default implementation with no `await` points. `_mount_node()` is called synchronously (not awaited) since it remains a sync method. The `async def` signature makes the method a coroutine that resolves immediately, so callers can `await` it without change. Custom user elements that override `_render()` SHALL follow the same pattern: if their `_render()` contains no async operations, `async def _render(self)` with no `await` points is valid Python and SHALL work correctly.
+
+#### Scenario: TextElement._render() remains sync internally
+- **WHEN** `await TextElement._render()` is called
+- **THEN** the text node SHALL be mounted synchronously
+- **AND** no `await` point SHALL exist in the method body
+
+### Requirement: Sibling children shall render sequentially via await
+
+`ElementWithChildren._render()` SHALL iterate over children and `await child._render()` for each child sequentially. Children SHALL NOT be rendered concurrently via `asyncio.gather()` in this change. The sequential ordering preserves DOM node index assignment correctness and short-circuit error propagation. Parallel rendering via `asyncio.gather()` is identified as future work requiring ContextVar isolation and atomic sibling cleanup.
+
+> **Future enhancement**: Parallel rendering via `asyncio.gather()` is identified as a future performance optimization. It will require careful DOM ordering guarantees, atomic cleanup of failed siblings, and ContextVar isolation across concurrent tasks. See the "Future Work" section.
+
+#### Scenario: Rendering multiple sibling children
+- **WHEN** `ElementWithChildren._render()` is called with 3 children
+- **THEN** `await child1._render()` SHALL be called first
+- **AND** after child1 completes, `await child2._render()` SHALL be called
+- **AND** after child2 completes, `await child3._render()` SHALL be called
+- **AND** the parent SHALL continue only after all 3 children complete
+
+#### Scenario: Sibling rendering preserves DOM order
+- **WHEN** children are rendered sequentially
+- **THEN** DOM node indices (`_node_idx`) SHALL be assigned before each child renders
+- **AND** the final DOM order SHALL match the children list order exactly
+
+#### Scenario: One child raises during sibling rendering
+- **WHEN** one child's `_render()` raises an unexpected exception during sequential rendering
+- **THEN** the exception SHALL propagate immediately via the `await`
+- **AND** subsequent children SHALL NOT be rendered (sequential short-circuit semantics)
+- **AND** the exception SHALL be re-raised to the caller
+- **AND** any previously rendered siblings SHALL remain in the DOM (no cleanup needed since no siblings were rendered after the failing one)

--- a/openspec/changes/feat-async-scheduler-port/specs/async-scheduler/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/async-scheduler/spec.md
@@ -39,7 +39,9 @@ The framework SHALL provide an `AsyncSchedulerPort` abstract base class that cen
 
 #### Scenario: Server drains all pending tasks
 - **WHEN** `ServerAsyncSchedulerPort.await_pending()` is called
-- **THEN** all tasks in `_registry` SHALL be awaited via `asyncio.gather`
+- **THEN** a snapshot of `_registry` SHALL be taken via `list(self._registry)` before iteration
+- **AND** the snapshot tasks SHALL be awaited via `asyncio.gather`
+- **AND** concurrent `done_callback` removals SHALL NOT cause iteration errors (the snapshot is independent of the live list)
 - **AND** tasks that complete during the gather SHALL be removed from `_registry`
 - **AND** after `await_pending()` returns, `_registry` SHALL be empty
 
@@ -48,7 +50,8 @@ The framework SHALL provide an `AsyncSchedulerPort` abstract base class that cen
 - **AND** `await_pending()` is called
 - **THEN** `await_pending()` SHALL re-check the registry after the initial gather completes
 - **AND** if newly added tasks exist, they SHALL be gathered in a subsequent iteration
-- **AND** this loop SHALL continue until the registry is empty or a maximum iteration guard is reached
+- **AND** this loop SHALL continue until the registry is empty or a maximum iteration guard of 20 is reached
+- **AND** when the guard is reached, a warning SHALL be logged indicating a possible recursive scheduling bug
 
 ### Requirement: aio_run shall delegate to AsyncSchedulerPort when a DI scope is active
 

--- a/openspec/changes/feat-async-scheduler-port/specs/async-scheduler/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/async-scheduler/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: AsyncSchedulerPort shall provide a unified async task scheduling interface
+
+The framework SHALL provide an `AsyncSchedulerPort` abstract base class that centralizes all async coroutine scheduling. The port SHALL define two methods: `schedule(coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]` for scheduling a coroutine as a task, and `await_pending() -> Awaitable[None]` for awaiting the completion of all scheduled tasks. The port SHALL be injectable via `ASYNC_SCHEDULER_PORT_KEY: InjectKey[AsyncSchedulerPort]`.
+
+#### Scenario: Scheduling a coroutine during render
+- **WHEN** any framework code needs to schedule an async task during the render pipeline
+- **THEN** the code SHALL call `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(coro)` instead of `asyncio.ensure_future(coro)` or `loop.create_task(coro)`
+
+#### Scenario: Injecting the scheduler port
+- **WHEN** a `RenderContext` is created in either browser or server environment
+- **THEN** the context's DI scope SHALL provide an `AsyncSchedulerPort` instance via `ASYNC_SCHEDULER_PORT_KEY`
+
+### Requirement: BrowserAsyncSchedulerPort shall use fire-and-forget scheduling
+
+`BrowserAsyncSchedulerPort.schedule(coro)` SHALL create a task via `asyncio.ensure_future(coro)` and return it. The task runs on the browser's long-lived event loop and completes naturally. `BrowserAsyncSchedulerPort.await_pending()` SHALL be a no-op (returns immediately without awaiting), because the browser event loop persists for the page lifetime.
+
+#### Scenario: Browser schedules a fire-and-forget task
+- **WHEN** `BrowserAsyncSchedulerPort.schedule(coro)` is called
+- **THEN** an `asyncio.Task` SHALL be created via `asyncio.ensure_future`
+- **AND** the task SHALL NOT be explicitly awaited by the scheduler
+- **AND** the task SHALL complete on the browser event loop
+
+#### Scenario: Browser await_pending is a no-op
+- **WHEN** `BrowserAsyncSchedulerPort.await_pending()` is called
+- **THEN** the method SHALL return immediately without blocking
+- **AND** no tasks SHALL be gathered or awaited
+
+### Requirement: ServerAsyncSchedulerPort shall register and drain tasks
+
+`ServerAsyncSchedulerPort.schedule(coro)` SHALL create a task via `loop.create_task(coro)`, register it in an internal per-instance registry (`_registry: list[asyncio.Task]`), and return the task. `ServerAsyncSchedulerPort.await_pending()` SHALL gather all tasks currently in the registry, awaiting their completion. After `await_pending()` returns, the registry SHALL be empty (all tasks completed or cancelled).
+
+#### Scenario: Server registers a scheduled task
+- **WHEN** `ServerAsyncSchedulerPort.schedule(coro)` is called
+- **THEN** a task SHALL be created via `loop.create_task(coro)`
+- **AND** the task SHALL be appended to the port instance's `_registry` list
+- **AND** the task reference SHALL be returned to the caller
+
+#### Scenario: Server drains all pending tasks
+- **WHEN** `ServerAsyncSchedulerPort.await_pending()` is called
+- **THEN** all tasks in `_registry` SHALL be awaited via `asyncio.gather`
+- **AND** tasks that complete during the gather SHALL be removed from `_registry`
+- **AND** after `await_pending()` returns, `_registry` SHALL be empty
+
+#### Scenario: Server handles tasks scheduled during drain
+- **WHEN** a task scheduled via `schedule()` itself schedules additional tasks (recursive scheduling)
+- **AND** `await_pending()` is called
+- **THEN** `await_pending()` SHALL re-check the registry after the initial gather completes
+- **AND** if newly added tasks exist, they SHALL be gathered in a subsequent iteration
+- **AND** this loop SHALL continue until the registry is empty or a maximum iteration guard is reached
+
+### Requirement: aio_run shall delegate to AsyncSchedulerPort when a DI scope is active
+
+The `aio_run` function (environment-selected from `_aio_run_browser` and `_aio_run_server`) SHALL attempt `inject(ASYNC_SCHEDULER_PORT_KEY)` at call time. If injection succeeds, the coroutine SHALL be scheduled via `scheduler.schedule(coro)`. If injection fails (no active DI scope), the fallback SHALL create the task directly (`asyncio.ensure_future` on browser, `loop.create_task` on server) and SHALL log a warning indicating the task may not be awaited on the server.
+
+#### Scenario: aio_run within a render context
+- **WHEN** `aio_run(coro)` is called during a render (DI scope active)
+- **THEN** the coroutine SHALL be scheduled via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(coro)`
+- **AND** on the server, the task SHALL be registered in the scheduler's registry
+
+#### Scenario: aio_run outside a render context
+- **WHEN** `aio_run(coro)` is called outside any DI scope (e.g., in CLI utilities)
+- **THEN** the fallback SHALL create the task directly via `asyncio.ensure_future` or `loop.create_task`
+- **AND** a warning SHALL be logged indicating the task is not registry-tracked
+
+### Requirement: No bare asyncio scheduling shall exist outside AsyncSchedulerPort
+
+The framework codebase SHALL NOT contain direct `asyncio.ensure_future()` or `asyncio.get_event_loop().create_task()` calls in the `webcompy`, `webcompy-server`, or `webcompy-cli` packages, except within `AsyncSchedulerPort` implementations and the `aio_run` fallback path. All async task scheduling SHALL route through `AsyncSchedulerPort.schedule()` or `aio_run()`. This invariant SHALL be enforced by the `ci-review` agent.
+
+#### Scenario: Code review detects bare ensure_future
+- **WHEN** a pull request introduces a new `asyncio.ensure_future()` call outside `AsyncSchedulerPort` implementations or `aio_run`
+- **THEN** the CI review SHALL flag it as an invariant violation
+
+### Requirement: A FakeAsyncSchedulerPort shall be provided for testing
+
+The `webcompy_testing` module SHALL provide a `FakeAsyncSchedulerPort` that collects scheduled coroutines in a list without executing them. Tests SHALL be able to call `await fake_scheduler.drain()` to execute all collected coroutines, or inspect the list to assert scheduling behavior.
+
+#### Scenario: Fake port collects scheduled coroutines
+- **WHEN** `FakeAsyncSchedulerPort.schedule(coro)` is called
+- **THEN** the coroutine SHALL be appended to an internal list without execution
+- **AND** a dummy `asyncio.Task` or placeholder SHALL be returned
+
+#### Scenario: Fake port drains collected coroutines
+- **WHEN** `await fake_scheduler.drain()` is called
+- **THEN** all collected coroutines SHALL be executed via `asyncio.gather`
+- **AND** the internal list SHALL be cleared

--- a/openspec/changes/feat-async-scheduler-port/specs/elements/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/elements/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: DynamicElement._hydrate_node shall schedule via AsyncSchedulerPort
+
+`DynamicElement._hydrate_node()` SHALL schedule the async render of unmounted children via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(child._render())` instead of calling `asyncio.ensure_future()` directly. The scheduled task SHALL be tracked in `self._pending_render_tasks` as before, and a done callback SHALL log exceptions via `webcompy.logging.error`. This routes all async scheduling through the central port, ensuring server-side renders guarantee task completion before context disposal.
+
+#### Scenario: Hydrating an unmounted child via the scheduler port
+- **WHEN** `DynamicElement._hydrate_node()` encounters a child that is not mounted
+- **THEN** the child's `_render()` coroutine SHALL be scheduled via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(child._render())`
+- **AND** the returned task SHALL be appended to `self._pending_render_tasks`
+- **AND** a done callback SHALL be attached that logs exceptions and removes the task from `_pending_render_tasks`
+
+### Requirement: SuspenseElement shall schedule browser resolution via AsyncSchedulerPort
+
+`SuspenseElement._browser_render()` and `SuspenseElement._hydrate_node()` SHALL schedule async resolution coroutines via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(coro)` instead of calling `asyncio.ensure_future()` directly. The scheduled task SHALL be tracked in `self._pending_tasks` as before.
+
+#### Scenario: Suspense schedules browser resolution via the scheduler port
+- **WHEN** `SuspenseElement._browser_render()` determines that children have unresolved async setup
+- **THEN** the resolution coroutine SHALL be scheduled via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(self._browser_resolve(...))`
+- **AND** the returned task SHALL be appended to `self._pending_tasks`
+
+#### Scenario: Suspense hydrate schedules resolution via the scheduler port
+- **WHEN** `SuspenseElement._hydrate_node()` determines that children lack resolved data
+- **THEN** the resolution coroutine SHALL be scheduled via `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(self._browser_resolve())`
+- **AND** the returned task SHALL be appended to `self._pending_tasks`

--- a/openspec/changes/feat-async-scheduler-port/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/port-abstraction/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: AsyncSchedulerPort shall be a port ABC in the port hierarchy
+
+`AsyncSchedulerPort` SHALL be an abstract base class in `packages/webcompy/src/webcompy/ports/_async_scheduler.py`, following the same pattern as `DOMPort`, `FetchPort`, `HostPort`, and other existing ports. It SHALL define `schedule(coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]` and `await_pending(self) -> Awaitable[None]` as abstract methods.
+
+#### Scenario: AsyncSchedulerPort ABC definition
+- **WHEN** the port hierarchy is inspected
+- **THEN** `AsyncSchedulerPort` SHALL be present as an ABC in the `webcompy.ports` package
+- **AND** it SHALL define `schedule` and `await_pending` as abstract methods
+
+### Requirement: BrowserAsyncSchedulerPort and ServerAsyncSchedulerPort shall implement AsyncSchedulerPort
+
+`BrowserAsyncSchedulerPort` SHALL be defined in `packages/webcompy/src/webcompy/ports/_browser/_async_scheduler.py` and SHALL only be instantiable when `ENVIRONMENT == "pyscript"`. `ServerAsyncSchedulerPort` SHALL be defined in `packages/webcompy-server/src/webcompy_server/ports/_async_scheduler.py` and SHALL only be used in server environments.
+
+#### Scenario: Browser port instantiation
+- **WHEN** `BrowserAsyncSchedulerPort()` is constructed in the pyscript environment
+- **THEN** the instance SHALL be created successfully
+
+#### Scenario: Browser port instantiation outside browser
+- **WHEN** `BrowserAsyncSchedulerPort()` is constructed in a non-pyscript environment
+- **THEN** a `WebComPyException` SHALL be raised

--- a/openspec/changes/feat-async-scheduler-port/specs/port-provisioning/spec.md
+++ b/openspec/changes/feat-async-scheduler-port/specs/port-provisioning/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: ASYNC_SCHEDULER_PORT_KEY shall be provisioned in all RenderContext DI scopes
+
+`ASYNC_SCHEDULER_PORT_KEY: InjectKey[AsyncSchedulerPort]` SHALL be defined in `packages/webcompy/src/webcompy/ports/_keys.py` alongside the existing port keys. The `ServerRenderContext._register_ports()` method SHALL provide a `ServerAsyncSchedulerPort` instance via this key. The browser render context SHALL provide a `BrowserAsyncSchedulerPort` instance via this key. The `FakeRenderContext` or equivalent in `webcompy_testing` SHALL provide a `FakeAsyncSchedulerPort` instance.
+
+#### Scenario: ASYNC_SCHEDULER_PORT_KEY in core keys
+- **WHEN** a developer writes `from webcompy.ports._keys import ASYNC_SCHEDULER_PORT_KEY`
+- **THEN** the key SHALL be importable without installing `webcompy-server`
+
+#### Scenario: Server context provisions ServerAsyncSchedulerPort
+- **WHEN** `ServerRenderContext._register_ports()` is called
+- **THEN** a `ServerAsyncSchedulerPort` instance SHALL be provided via `ASYNC_SCHEDULER_PORT_KEY` in the DI scope
+
+#### Scenario: Browser context provisions BrowserAsyncSchedulerPort
+- **WHEN** the browser render context is initialized
+- **THEN** a `BrowserAsyncSchedulerPort` instance SHALL be provided via `ASYNC_SCHEDULER_PORT_KEY` in the DI scope

--- a/openspec/changes/feat-async-scheduler-port/tasks.md
+++ b/openspec/changes/feat-async-scheduler-port/tasks.md
@@ -1,0 +1,74 @@
+## 1. Port ABC and DI Key
+
+- [ ] 1.1 Create `packages/webcompy/src/webcompy/ports/_async_scheduler.py` with `AsyncSchedulerPort` ABC defining `schedule(coro) -> asyncio.Task` and `await_pending() -> Awaitable[None]` abstract methods
+- [ ] 1.2 Add `ASYNC_SCHEDULER_PORT_KEY: InjectKey[AsyncSchedulerPort]` to `packages/webcompy/src/webcompy/ports/_keys.py`
+- [ ] 1.3 Export `AsyncSchedulerPort` from `packages/webcompy/src/webcompy/ports/__init__.py`
+
+## 2. Browser Implementation
+
+- [ ] 2.1 Create `packages/webcompy/src/webcompy/ports/_browser/_async_scheduler.py` with `BrowserAsyncSchedulerPort(AsyncSchedulerPort)` — `schedule()` uses `asyncio.ensure_future`, `await_pending()` is a no-op
+- [ ] 2.2 Guard `BrowserAsyncSchedulerPort.__init__` with `ENVIRONMENT == "pyscript"` check (raise `WebComPyException` otherwise), matching the `BrowserHostPort` pattern
+
+## 3. Server Implementation
+
+- [ ] 3.1 Create `packages/webcompy-server/src/webcompy_server/ports/_async_scheduler.py` with `ServerAsyncSchedulerPort(AsyncSchedulerPort)` — `schedule()` uses `loop.create_task` and appends to `_registry`; `await_pending()` gathers all registry tasks with recursive re-check loop
+- [ ] 3.2 Implement the recursive drain loop in `await_pending()`: gather, check for newly added tasks, repeat until empty (with a maximum iteration guard, e.g., 100, to prevent infinite loops from buggy recursive scheduling)
+- [ ] 3.3 Add a `done_callback` to each created task that removes it from `_registry` upon completion (so `await_pending` doesn't await already-finished tasks)
+
+## 4. Testing Fake Port
+
+- [ ] 4.1 Add `FakeAsyncSchedulerPort` to `packages/webcompy-testing/src/webcompy_testing/_ports.py` — `schedule()` collects coroutines in a list without execution; `drain()` method executes collected coroutines via `asyncio.gather`; `await_pending()` delegates to `drain()`
+
+## 5. DI Scope Provisioning
+
+- [ ] 5.1 Provision `BrowserAsyncSchedulerPort` via `ASYNC_SCHEDULER_PORT_KEY` in the browser render context's `_register_ports()` method
+- [ ] 5.2 Provision `ServerAsyncSchedulerPort` via `ASYNC_SCHEDULER_PORT_KEY` in `ServerRenderContext._register_ports()` in `packages/webcompy-server/src/webcompy_server/_context.py`
+- [ ] 5.3 Provision `FakeAsyncSchedulerPort` via `ASYNC_SCHEDULER_PORT_KEY` in the testing fake render context
+
+## 6. aio_run Delegation
+
+- [ ] 6.1 Refactor `_aio_run_browser` and `_aio_run_server` in `packages/webcompy/src/webcompy/aio/_aio.py` to attempt `inject(ASYNC_SCHEDULER_PORT_KEY)` at call time
+- [ ] 6.2 Implement the fallback path: if `InjectionError` is raised, create the task directly (`ensure_future` / `create_task`) and log a warning
+- [ ] 6.3 Keep the `_aio_run_browser_tasks` / `_aio_run_server_tasks` lists for GC safety in the fallback path, or remove them if the port handles GC (decide based on whether the fallback path still needs them)
+- [ ] 6.4 Remove the now-unused `_aio_run_server_tasks` list if the port's registry supersedes it (verify no other code references it)
+
+## 7. Element/Component Integration
+
+- [ ] 7.1 Replace `asyncio.ensure_future(child._render())` in `DynamicElement._hydrate_node()` (`packages/webcompy/src/webcompy/elements/types/_dynamic.py:75`) with `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(child._render())`
+- [ ] 7.2 Replace `asyncio.ensure_future(self._browser_resolve(...))` in `SuspenseElement._browser_render()` (`_suspense.py:134`) with `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(...)`
+- [ ] 7.3 Replace `asyncio.ensure_future(self._browser_resolve())` in `SuspenseElement._hydrate_node()` (`_suspense.py:232`) with `inject(ASYNC_SCHEDULER_PORT_KEY).schedule(...)`
+
+## 8. SSR/SSG Entry Point Hooks
+
+- [ ] 8.1 Add `await scheduler.await_pending()` call after `await ctx._root._render()` and before `ctx.dispose()` in `generate_html()` (`packages/webcompy-server/src/webcompy_server/_html.py`)
+- [ ] 8.2 Add `await scheduler.await_pending()` in the ASGI HTML handler (`packages/webcompy-cli/src/webcompy_cli/_server.py`) before `ctx.dispose()`
+- [ ] 8.3 Add `await scheduler.await_pending()` in the SSG route fetch path (`packages/webcompy-cli/src/webcompy_cli/_generate.py`) before `ctx.dispose()`
+
+## 9. ServerFetchPort Cleanup
+
+- [ ] 9.1 Refactor `ServerFetchPort.close()` to make cleanup tasks awaitable — either route through `AsyncSchedulerPort` or make `close()` / add `aclose()` async and have `ctx.dispose()` await it explicitly
+
+## 10. Documentation and Invariant
+
+- [ ] 10.1 Document the `app._hydrate` guard rationale in `WebComPyApp.__init__` as defense-in-depth (the scheduler port is the primary guarantee)
+- [ ] 10.2 Add the "No bare asyncio scheduling outside AsyncSchedulerPort" invariant to `.opencode/agents/ci-review.md` Critical Framework Invariants section
+- [ ] 10.3 Update the File → Spec Mapping table in `AGENTS.md` to include `async-scheduler` spec for affected modules
+
+## 11. Unit Tests
+
+- [ ] 11.1 Test `ServerAsyncSchedulerPort.schedule()` registers tasks in `_registry`
+- [ ] 11.2 Test `ServerAsyncSchedulerPort.await_pending()` drains all registered tasks and leaves registry empty
+- [ ] 11.3 Test recursive scheduling (a task scheduling another task) is handled by the re-check loop
+- [ ] 11.4 Test `BrowserAsyncSchedulerPort.schedule()` creates tasks via `ensure_future`
+- [ ] 11.5 Test `BrowserAsyncSchedulerPort.await_pending()` is a no-op
+- [ ] 11.6 Test `aio_run` delegation path (with DI scope → port; without DI scope → fallback + warning)
+- [ ] 11.7 Test `FakeAsyncSchedulerPort` collects and drains coroutines
+
+## 12. Verification
+
+- [ ] 12.1 Run `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] 12.2 Run `uv run pyright`
+- [ ] 12.3 Run `uv run python -m pytest tests/ --tb=short` (unit tests pass)
+- [ ] 12.4 Run `scripts/run-e2e-tests.sh` (all E2E groups pass, no regression on `/reactive`, `/switch`, `/suspense` pages)
+- [ ] 12.5 Verify SSR/SSG output completeness: `HomePage` DIV children are non-empty in SSG-generated HTML (existing `fix-ssr-hydration-skip` E2E test serves as regression guard)
+- [ ] 12.6 `npx @fission-ai/openspec@latest validate` passes

--- a/openspec/changes/feat-async-scheduler-port/tasks.md
+++ b/openspec/changes/feat-async-scheduler-port/tasks.md
@@ -12,7 +12,7 @@
 ## 3. Server Implementation
 
 - [ ] 3.1 Create `packages/webcompy-server/src/webcompy_server/ports/_async_scheduler.py` with `ServerAsyncSchedulerPort(AsyncSchedulerPort)` — `schedule()` uses `loop.create_task` and appends to `_registry`; `await_pending()` gathers all registry tasks with recursive re-check loop
-- [ ] 3.2 Implement the recursive drain loop in `await_pending()`: gather, check for newly added tasks, repeat until empty (with a maximum iteration guard, e.g., 100, to prevent infinite loops from buggy recursive scheduling)
+- [ ] 3.2 Implement the recursive drain loop in `await_pending()`: snapshot via `list(self._registry)`, gather, check for newly added tasks, repeat until empty (maximum iteration guard of 20, with warning log at the limit)
 - [ ] 3.3 Add a `done_callback` to each created task that removes it from `_registry` upon completion (so `await_pending` doesn't await already-finished tasks)
 
 ## 4. Testing Fake Port
@@ -30,7 +30,7 @@
 - [ ] 6.1 Refactor `_aio_run_browser` and `_aio_run_server` in `packages/webcompy/src/webcompy/aio/_aio.py` to attempt `inject(ASYNC_SCHEDULER_PORT_KEY)` at call time
 - [ ] 6.2 Implement the fallback path: if `InjectionError` is raised, create the task directly (`ensure_future` / `create_task`) and log a warning
 - [ ] 6.3 Keep the `_aio_run_browser_tasks` / `_aio_run_server_tasks` lists for GC safety in the fallback path, or remove them if the port handles GC (decide based on whether the fallback path still needs them)
-- [ ] 6.4 Remove the now-unused `_aio_run_server_tasks` list if the port's registry supersedes it (verify no other code references it)
+- [ ] 6.4 Remove the `_aio_run_server_tasks` module-level list — the port's registry supersedes it. After removal, grep to confirm no remaining references to `_aio_run_server_tasks` (this is a required step, not conditional: the design's central purpose is to eliminate the fire-and-forget pattern)
 
 ## 7. Element/Component Integration
 
@@ -46,12 +46,12 @@
 
 ## 9. ServerFetchPort Cleanup
 
-- [ ] 9.1 Refactor `ServerFetchPort.close()` to make cleanup tasks awaitable — either route through `AsyncSchedulerPort` or make `close()` / add `aclose()` async and have `ctx.dispose()` await it explicitly
+- [ ] 9.1 Make `ServerFetchPort.close()` an `async def` (or add an `aclose()` async variant) and have `ctx.dispose()` await it explicitly — per design D6, this is the chosen approach (not routing through `AsyncSchedulerPort`, because `close()` runs during teardown after `await_pending()`)
 
 ## 10. Documentation and Invariant
 
 - [ ] 10.1 Document the `app._hydrate` guard rationale in `WebComPyApp.__init__` as defense-in-depth (the scheduler port is the primary guarantee)
-- [ ] 10.2 Add the "No bare asyncio scheduling outside AsyncSchedulerPort" invariant to `.opencode/agents/ci-review.md` Critical Framework Invariants section
+- [ ] 10.2 Add the "No bare asyncio scheduling outside AsyncSchedulerPort" invariant to `.opencode/agents/ci-review.md` Critical Framework Invariants section — update AFTER this proposal is approved, BEFORE the implementation PR (requires coordination with the ci-review agent configuration)
 - [ ] 10.3 Update the File → Spec Mapping table in `AGENTS.md` to include `async-scheduler` spec for affected modules
 
 ## 11. Unit Tests

--- a/openspec/changes/feat-payload-compression/.openspec.yaml
+++ b/openspec/changes/feat-payload-compression/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/feat-payload-compression/design.md
+++ b/openspec/changes/feat-payload-compression/design.md
@@ -1,0 +1,86 @@
+# Design: Payload Compression
+
+## Context
+
+The hydration data transfer payload is embedded as a `<script type="application/json" id="__webcompy_data__">` tag in the HTML output. After `feat-signal-value-transfer`, the payload includes Signal values, which can significantly increase its size for stateful applications. The payload is transferred as part of the initial HTML response, so larger payloads increase page weight and parse time.
+
+Both server (CPython) and browser (PyScript/Emscripten) need to handle the payload. The compression algorithm must be available in both environments.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Compress the serialized payload using gzip (stdlib `zlib`) when it exceeds a configurable threshold.
+- Base64-encode the compressed bytes so they can be embedded in a JSON/HTML context safely.
+- Make compression transparent: the deserializer auto-detects compressed payloads.
+- Use only stdlib modules (`zlib`, `base64`) — no external dependencies.
+
+**Non-Goals:**
+
+- Brotli compression (requires native extension, may not work under PyScript).
+- Per-section or incremental compression.
+- HTTP-level response compression (handled by web server middleware).
+- Runtime-selectable compression algorithms.
+
+## Decisions
+
+### D1: Gzip via stdlib `zlib`
+
+The payload SHALL be compressed using `zlib.compress(data)` and decompressed using `zlib.decompress(data)`. The `zlib` module is part of the Python standard library and is compiled into CPython. Under PyScript/Emscripten, `zlib` is available because Emscripten provides zlib support and Pyodide includes it.
+
+**Alternatives considered:**
+- **Brotli**: Better compression ratio than gzip, but requires the `brotli` or `brotlic` third-party package (native extension). May not work under PyScript/Emscripten. Deferred.
+- **LZMA (`lzma` module)**: Higher compression ratio than gzip but slower. Available in stdlib but may have Emscripten support issues. Overkill for typical payload sizes.
+- **No compression**: Rejected — payload size growth from Signal transfer justifies the feature.
+
+### D2: Compression envelope structure
+
+When compressed, the payload JSON is replaced with an envelope:
+
+```json
+{
+    "__webcompy_compressed__": true,
+    "__webcompy_transfer_version__": 2,
+    "data": "<base64-encoded gzip-compressed original JSON>"
+}
+```
+
+The `__webcompy_compressed__` flag signals the deserializer to:
+1. Base64-decode the `data` field.
+2. Gzip-decompress the result.
+3. JSON-parse the decompressed string.
+
+**Rationale:** The envelope approach keeps the version field accessible without decompression (for diagnostics) and uses the reserved `__webcompy_` prefix consistent with the codec's type-tag convention.
+
+### D3: Threshold-based activation
+
+Compression SHALL only be applied when the serialized JSON exceeds a configurable byte threshold (`compression_threshold`). The default threshold SHALL be 1024 bytes. Payloads below the threshold SHALL be stored uncompressed (avoiding the base64 overhead, which increases size by ~33% for small payloads).
+
+**Threshold tuning:**
+- For small payloads (< threshold), compression + base64 expansion can actually increase size.
+- The threshold should be set above the breakeven point where gzip compression savings exceed base64 expansion overhead.
+- 1024 bytes is a conservative default. The threshold SHALL be configurable via `WebComPyAppConfig` or `GenerateConfig`.
+
+### D4: `__webcompy_compressed__` flag is independent of version
+
+The compression flag is orthogonal to `__webcompy_transfer_version__`. A version 2 payload can be compressed or uncompressed. The deserializer checks the flag first, decompresses if needed, then proceeds with version-based parsing. This avoids coupling two independent concerns.
+
+### D5: Compression level
+
+`zlib.compress(data, level)` accepts a level (0-9). The default SHALL be `zlib.Z_DEFAULT_COMPRESSION` (level 6), which balances speed and ratio. The level SHALL not be configurable in this change (deferred to future tuning).
+
+## Risks / Trade-offs
+
+- **[zlib under PyScript]** → Mitigation: Validation spike. Use `webcompy inspect` CLI to verify `zlib.compress()` / `zlib.decompress()` work under PyScript/Emscripten. Pyodide documentation indicates zlib is supported.
+
+- **[Base64 expansion offsetting compression gains for small payloads]** → Mitigation: The threshold parameter prevents compressing small payloads. Default threshold (1024 bytes) ensures compression is only applied when net savings are expected.
+
+- **[Compression CPU cost]** → Mitigation: `zlib` level 6 is fast for typical payload sizes (tens of KB). For very large payloads (MBs), compression may add latency, but this is an inherent trade-off for reduced transfer size.
+
+- **[Backward compatibility]** → Mitigation: Uncompressed payloads (no `__webcompy_compressed__` flag) decode exactly as before. The feature is purely additive.
+
+## Open Questions
+
+1. **Should the threshold be per-app or per-payload?** The threshold is set at the app/config level (`WebComPyAppConfig` or `GenerateConfig`). Each payload is independently evaluated against the threshold. Decision: per-app config, evaluated per-payload.
+
+2. **Should compression be disableable?** Setting `compression_threshold=None` or `0` disables compression entirely. This is the escape hatch for environments where compression is undesirable.

--- a/openspec/changes/feat-payload-compression/proposal.md
+++ b/openspec/changes/feat-payload-compression/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: Payload Compression
+
+## Why
+
+After `feat-signal-value-transfer`, the hydration data transfer payload includes Signal values alongside `AsyncResult` data and `FetchPort` response caches. For applications with significant server-side state, the payload (embedded as a `<script type="application/json" id="__webcompy_data__">` tag in the HTML) can grow substantially, increasing page size and parse time.
+
+This change adds optional gzip compression to the transfer payload. When the serialized payload exceeds a configurable threshold, it SHALL be gzip-compressed (using stdlib `zlib`/`gzip`), base64-encoded, and marked with a `compressed: true` flag in the payload metadata. The browser-side deserializer detects the flag and decompresses accordingly.
+
+## What Changes
+
+- **MODIFIED** `packages/webcompy/src/webcompy/hydration/_payload.py`:
+  - `serialize_payload()` SHALL accept a `compression_threshold: int | None` parameter (default e.g., 1024 bytes). When the serialized JSON exceeds the threshold, the payload SHALL be gzip-compressed via `zlib.compress()`, base64-encoded, and wrapped in a `{"__webcompy_compressed__": true, "data": "<base64>"}` envelope.
+  - `deserialize_payload()` SHALL detect the `__webcompy_compressed__` flag, base64-decode and gzip-decompress the `data` field before JSON parsing.
+  - The `__webcompy_transfer_version__` SHALL remain at the current version (compression is an orthogonal concern, signaled by the `__webcompy_compressed__` flag rather than a version bump).
+- **MODIFIED** SSR/SSG entry points that call `serialize_payload()` — Pass the `compression_threshold` from `WebComPyAppConfig` or `GenerateConfig`.
+
+## Capabilities
+
+### New Capabilities
+
+- `payload-compression`: Optional gzip compression of the hydration data transfer payload. Activated when the serialized payload exceeds a configurable byte threshold. Uses stdlib `zlib` for compression (pure Python, works in both CPython and PyScript/Emscripten). The compressed payload is base64-encoded and marked with a `__webcompy_compressed__` flag for browser-side detection.
+
+### Modified Capabilities
+
+- `hydration-data-transfer`: `serialize_payload()` and `deserialize_payload()` SHALL support compressed payloads. The compression flag is signaled via `__webcompy_compressed__` in the payload envelope, independent of `__webcompy_transfer_version__`.
+
+## Known Issues Addressed
+
+- **Payload size growth from Signal value transfer** — `feat-signal-value-transfer` adds the `signals` section, increasing payload size for stateful applications. Compression mitigates this.
+
+## Non-goals
+
+- **Brotli compression** — Brotli typically requires a native extension (`brotli` or `brotlic` package) that may not work under PyScript/Emscripten. Gzip via stdlib `zlib` is universally available. Brotli can be added as an optional layer in a future change.
+- **Per-section compression** — The entire payload is compressed as a single blob. Individual sections (`fetches`, `async_results`, `signals`) are not compressed independently.
+- **HTTP-level compression (Content-Encoding: gzip)** — This change compresses the payload embedded in the HTML, not the HTTP response. HTTP-level compression is handled by the web server (Starlette/uvicorn GZip middleware) and is orthogonal.
+- **Changing the compression algorithm at runtime** — The algorithm is fixed (gzip/zlib). A registry for multiple algorithms is deferred.
+- **Changing the public API of `serialize_payload()` beyond the optional threshold parameter** — The compression is transparent to callers who use the default threshold.
+
+## Dependencies
+
+- **Benefits from** `feat-signal-value-transfer` — Compression is most valuable when the payload includes Signal values. However, compression can be applied to any payload version (v1 or v2), so it is not a hard dependency.
+
+## Impact
+
+- **Affected modules**:
+  - `packages/webcompy/src/webcompy/hydration/_payload.py` (compression/decompression logic)
+- **Breaking**: None. Compression is opt-in via the threshold parameter. Existing payloads without compression decode correctly (the `__webcompy_compressed__` flag is absent, signaling uncompressed).
+- **Backward compatible**: An uncompressed payload (no `__webcompy_compressed__` flag) is decoded exactly as before.
+- **Testing**: Unit tests for compression round-trip, threshold boundary, and backward compatibility with uncompressed payloads. Verification that `zlib` works under PyScript (validation spike).

--- a/openspec/changes/feat-payload-compression/specs/hydration-data-transfer/spec.md
+++ b/openspec/changes/feat-payload-compression/specs/hydration-data-transfer/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: serialize_payload and deserialize_payload shall support compressed payloads
+
+`serialize_payload()` SHALL accept an optional `compression_threshold: int | None` parameter. When the serialized payload exceeds the threshold, it SHALL be gzip-compressed via `zlib`, base64-encoded, and wrapped in a `{"__webcompy_compressed__": true, ...}` envelope. `deserialize_payload()` SHALL detect the `__webcompy_compressed__` flag and decompress accordingly. Uncompressed payloads (without the flag) SHALL be processed as before, ensuring backward compatibility.
+
+#### Scenario: Round-trip compressed payload
+- **WHEN** a `TransferPayload` is serialized with compression enabled
+- **AND** the serialized size exceeds the threshold
+- **AND** the compressed output is passed to `deserialize_payload()`
+- **THEN** the resulting `TransferPayload` SHALL be equal to the original (all fields preserved)
+
+#### Scenario: Uncompressed payload backward compatibility
+- **WHEN** `deserialize_payload()` receives a payload without `__webcompy_compressed__`
+- **THEN** the payload SHALL be processed as uncompressed JSON
+- **AND** the behavior SHALL be identical to the pre-compression implementation

--- a/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
+++ b/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: serialize_payload shall support optional gzip compression
+
+`serialize_payload(payload, compression_threshold: int | None = 1024)` SHALL compress the serialized JSON when its byte length exceeds `compression_threshold`. Compression SHALL use `zlib.compress()` (stdlib). The compressed bytes SHALL be base64-encoded via `base64.b64encode()` and wrapped in an envelope: `{"__webcompy_compressed__": true, "__webcompy_transfer_version__": <version>, "data": "<base64>"}`. When the serialized JSON does not exceed the threshold, or when `compression_threshold` is `None` or `0`, the payload SHALL be stored uncompressed (no envelope).
+
+#### Scenario: Payload above threshold is compressed
+- **WHEN** `serialize_payload(payload, compression_threshold=1024)` is called
+- **AND** the serialized JSON exceeds 1024 bytes
+- **THEN** the output SHALL be the compression envelope with `"__webcompy_compressed__": true`
+- **AND** the `"data"` field SHALL contain the base64-encoded gzip-compressed JSON
+
+#### Scenario: Payload below threshold is not compressed
+- **WHEN** `serialize_payload(payload, compression_threshold=1024)` is called
+- **AND** the serialized JSON is 500 bytes
+- **THEN** the output SHALL be the uncompressed JSON (no envelope)
+- **AND** no `"__webcompy_compressed__"` key SHALL be present
+
+#### Scenario: Compression disabled by threshold=None
+- **WHEN** `serialize_payload(payload, compression_threshold=None)` is called
+- **THEN** the output SHALL be uncompressed regardless of payload size
+
+#### Scenario: Compression disabled by threshold=0
+- **WHEN** `serialize_payload(payload, compression_threshold=0)` is called
+- **THEN** the output SHALL be uncompressed regardless of payload size
+
+### Requirement: deserialize_payload shall detect and decompress compressed payloads
+
+`deserialize_payload(text)` SHALL check for the presence of `"__webcompy_compressed__"` in the parsed JSON. If present and `true`, the function SHALL base64-decode the `"data"` field, gzip-decompress it via `zlib.decompress()`, and JSON-parse the result. If the flag is absent or `false`, the function SHALL process the JSON as before (uncompressed path).
+
+#### Scenario: Deserializing a compressed payload
+- **WHEN** `deserialize_payload(text)` receives a JSON string containing `"__webcompy_compressed__": true`
+- **THEN** the `"data"` field SHALL be base64-decoded
+- **AND** the result SHALL be gzip-decompressed via `zlib.decompress()`
+- **AND` the decompressed string SHALL be JSON-parsed
+- **AND** the resulting `TransferPayload` SHALL be returned
+
+#### Scenario: Deserializing an uncompressed payload (backward compatibility)
+- **WHEN** `deserialize_payload(text)` receives a JSON string without `"__webcompy_compressed__"`
+- **THEN** the JSON SHALL be processed as before (uncompressed path)
+- **AND** the behavior SHALL be identical to the pre-compression implementation
+
+### Requirement: Compression shall use only stdlib modules
+
+The compression and decompression logic SHALL use only `zlib`, `base64`, and `json` from the Python standard library. No third-party compression libraries SHALL be required. This ensures the codec works in both CPython (server) and PyScript/Emscripten (browser) environments without external dependencies.
+
+#### Scenario: No third-party compression dependency
+- **WHEN** the `webcompy.hydration._payload` module is imported
+- **THEN** only stdlib modules (`zlib`, `base64`, `json`) SHALL be used for compression
+- **AND** no `import brotli` or similar third-party imports SHALL exist
+
+### Requirement: The compression envelope shall preserve the transfer version
+
+The compression envelope SHALL include the `"__webcompy_transfer_version__"` field at the top level (alongside `"__webcompy_compressed__"` and `"data"`). This allows version-based logic to proceed after decompression without needing to parse the compressed data first.
+
+#### Scenario: Envelope contains version field
+- **WHEN** a compressed payload is produced
+- **THEN** the envelope SHALL contain `"__webcompy_transfer_version__"` with the correct version number
+- **AND** after decompression, the inner JSON SHALL also contain the version (for consistency)

--- a/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
+++ b/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
@@ -51,9 +51,14 @@ The compression and decompression logic SHALL use only `zlib`, `base64`, and `js
 
 ### Requirement: The compression envelope shall preserve the transfer version
 
-The compression envelope SHALL include the `"__webcompy_transfer_version__"` field at the top level (alongside `"__webcompy_compressed__"` and `"data"`). This allows version-based logic to proceed after decompression without needing to parse the compressed data first.
+The compression envelope SHALL include the `"__webcompy_transfer_version__"` field at the top level (alongside `"__webcompy_compressed__"` and `"data"`). This field is **informational/diagnostic** — it allows version inspection without decompression. The **authoritative** version is the one inside the decompressed JSON. If the two disagree, the inner (decompressed) version SHALL take precedence and the envelope version SHALL be treated as a stale cache. The serializer SHALL keep both in sync at serialization time.
 
 #### Scenario: Envelope contains version field
 - **WHEN** a compressed payload is produced
 - **THEN** the envelope SHALL contain `"__webcompy_transfer_version__"` with the correct version number
 - **AND** after decompression, the inner JSON SHALL also contain the version (for consistency)
+
+#### Scenario: Inner version is authoritative on mismatch
+- **WHEN** the envelope's `"__webcompy_transfer_version__"` differs from the decompressed JSON's version
+- **THEN** the inner (decompressed) version SHALL be treated as authoritative
+- **AND** the envelope version SHALL be treated as informational only

--- a/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
+++ b/openspec/changes/feat-payload-compression/specs/payload-compression/spec.md
@@ -32,7 +32,7 @@
 - **WHEN** `deserialize_payload(text)` receives a JSON string containing `"__webcompy_compressed__": true`
 - **THEN** the `"data"` field SHALL be base64-decoded
 - **AND** the result SHALL be gzip-decompressed via `zlib.decompress()`
-- **AND` the decompressed string SHALL be JSON-parsed
+- **AND** the decompressed string SHALL be JSON-parsed
 - **AND** the resulting `TransferPayload` SHALL be returned
 
 #### Scenario: Deserializing an uncompressed payload (backward compatibility)

--- a/openspec/changes/feat-payload-compression/tasks.md
+++ b/openspec/changes/feat-payload-compression/tasks.md
@@ -1,0 +1,43 @@
+## 1. Compression Logic
+
+- [ ] 1.1 Add `compression_threshold: int | None = 1024` parameter to `serialize_payload()` in `packages/webcompy/src/webcompy/hydration/_payload.py`
+- [ ] 1.2 After JSON serialization and HTML escaping, check if the byte length exceeds `compression_threshold`
+- [ ] 1.3 If threshold is exceeded (and threshold is not `None` or `0`), compress the JSON string via `zlib.compress(json_str.encode("utf-8"))`
+- [ ] 1.4 Base64-encode the compressed bytes via `base64.b64encode(compressed).decode("ascii")`
+- [ ] 1.5 Wrap in envelope: `{"__webcompy_compressed__": true, "__webcompy_transfer_version__": <version>, "data": "<base64>"}`
+- [ ] 1.6 HTML-escape the envelope JSON string and return
+
+## 2. Decompression Logic
+
+- [ ] 2.1 In `deserialize_payload()`, after `html_module.unescape()` and `json.loads()`, check for `"__webcompy_compressed__"` key
+- [ ] 2.2 If present and `true`, extract the `"data"` field, base64-decode via `base64.b64decode(data)`
+- [ ] 2.3 Gzip-decompress via `zlib.decompress(decoded_bytes)`
+- [ ] 2.4 Decode to string via `.decode("utf-8")`, then `json.loads()` the decompressed string
+- [ ] 2.5 Proceed with normal version-based `TransferPayload` construction
+- [ ] 2.6 If `"__webcompy_compressed__"` is absent, process as uncompressed (existing path)
+
+## 3. Imports
+
+- [ ] 3.1 Add `import zlib` and `import base64` to `packages/webcompy/src/webcompy/hydration/_payload.py`
+
+## 4. Validation Spike
+
+- [ ] 4.1 Verify `zlib.compress()` and `zlib.decompress()` work under PyScript using `webcompy inspect` CLI with a minimal test — confirm gzip compression/decompression round-trips in the browser environment
+
+## 5. Unit Tests
+
+- [ ] 5.1 Test compression round-trip: serialize with threshold → deserialize → original payload preserved
+- [ ] 5.2 Test payload below threshold is not compressed (no `__webcompy_compressed__` key)
+- [ ] 5.3 Test `compression_threshold=None` disables compression
+- [ ] 5.4 Test `compression_threshold=0` disables compression
+- [ ] 5.5 Test backward compatibility: uncompressed payload (no flag) deserializes correctly
+- [ ] 5.6 Test compressed payload is smaller than uncompressed for typical Signal-heavy data
+- [ ] 5.7 Test envelope contains `__webcompy_transfer_version__` at top level
+
+## 6. Verification
+
+- [ ] 6.1 Run `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] 6.2 Run `uv run pyright`
+- [ ] 6.3 Run `uv run python -m pytest tests/ --tb=short`
+- [ ] 6.4 Run `scripts/run-e2e-tests.sh` — verify hydration data transfer works with compression enabled
+- [ ] 6.5 `npx @fission-ai/openspec@latest validate` passes

--- a/openspec/changes/feat-signal-value-transfer/.openspec.yaml
+++ b/openspec/changes/feat-signal-value-transfer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/feat-signal-value-transfer/design.md
+++ b/openspec/changes/feat-signal-value-transfer/design.md
@@ -190,4 +190,9 @@ No special handling needed — their `_value` is a plain list/dict that the code
 
 2. **Should the `signals` section be optional in the payload?** Yes — payloads without Signals (e.g., components with no `self`-assigned Signals) produce an empty `signals: {}` section. This is harmless and keeps the schema uniform.
 
-3. **What about Signals created in `on_before_rendering` hooks?** These hooks run after setup. If they assign Signals to `self`, the `__setattr__` captures them. However, collection happens after the full render, so these Signals' final values are captured. This should work correctly.
+3. **What about Signals created in `on_before_rendering` hooks?** These hooks run after setup but before template evaluation. There are two phases to consider:
+
+   - **Collection (SSR side):** Collection happens after the full render (after `await_pending`), so Signals created or mutated in `on_before_rendering` hooks have their final values captured correctly.
+   - **Restoration (browser side):** Restoration happens after `__setup()` / `__init_component()` completes and **before** `on_before_rendering` hooks execute. If a Signal is first created (assigned to `self`) inside an `on_before_rendering` hook, it does not yet exist at restoration time, so its value cannot be restored on the **first** hydration cycle. The hook runs with the Signal at its default value. On **subsequent** hydration cycles (navigations within the SPA), the Signal exists and its transferred value is available.
+
+   **Limitation to document:** Signals first created in `on_before_rendering` hooks are captured for transfer, but on the initial hydration their transferred values are not restored (the Signal does not exist yet at restoration time). They behave correctly on subsequent navigations. Developers who need server-computed values available immediately in such hooks should create the Signal in `__setup()` instead.

--- a/openspec/changes/feat-signal-value-transfer/design.md
+++ b/openspec/changes/feat-signal-value-transfer/design.md
@@ -162,6 +162,8 @@ The `signals` section is added to `TransferPayload`. The `__webcompy_transfer_ve
 - Version 1: ignores `signals` section (forward compatibility — a v1 browser skips unknown sections).
 - Version 2: parses `signals` section.
 
+**Version negotiation strategy (explicit):** The current `_payload.py` uses a strict equality check (`version != _SUPPORTED_VERSION`). This change shifts from strict equality to an **accept-list**. `_SUPPORTED_VERSION` becomes `_SUPPORTED_VERSIONS = {1, 2}`, and `deserialize_payload()` accepts any version in the set. Version 1 payloads default `TransferPayload.signals` to an empty dict `{}`. This allows old payloads (generated before Signal transfer landed) to decode correctly alongside new ones. The accept-list pattern (rather than a range) is intentional — it forces explicit acknowledgment when a new version is introduced, preventing accidental acceptance of future unknown versions.
+
 ### D7: ReactiveList and ReactiveDict serialization
 
 `ReactiveList` and `ReactiveDict` extend `SignalBase` and store their value in `_value` (a list or dict). They are collected and restored the same way as `Signal`:

--- a/openspec/changes/feat-signal-value-transfer/design.md
+++ b/openspec/changes/feat-signal-value-transfer/design.md
@@ -1,0 +1,193 @@
+# Design: Signal Value Transfer
+
+## Context
+
+The hydration data transfer mechanism (`feat-suspense-and-hydration-data-transfer`) transfers `AsyncResult` states and `FetchPort` response caches from server to browser. However, application-level `Signal` values — the primary state primitive in WebComPy — are not transferred. This causes a flash of default values during hydration for any component that derives UI from Signals.
+
+Key infrastructure already in place:
+- `SignalReceivable.__signal_members__` auto-tracks all Signal instances assigned to `self` attributes via `__setattr__`.
+- The codec engine (`feat-transfer-codec`) provides type-preserving serialization.
+- `collect_transfer_data()` already walks the component tree for AsyncResult collection.
+
+The challenge is: keying (the current `id()`-keyed registry is unstable across environments), Computed handling (recompute vs cached value), and restoration timing (after setup, before first render).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Automatically collect all `self`-assigned Signal values from the component tree during SSR.
+- Transfer them via the codec engine with type fidelity.
+- Restore them on the browser after component setup, eliminating the flash of defaults.
+- Include `Computed` cached values (option 2: transfer cached value, skip recompute on restore).
+
+**Non-Goals:**
+
+- Transferring local (non-`self`) Signal variables.
+- Transferring the reactive dependency graph (rebuilt during setup).
+- Triggering notifications on restore (direct `_value` set, no `set_value()`).
+- Payload compression.
+
+## Architecture Overview
+
+```
+┌──────────────────── SERVER (SSR/SSG) ─────────────────────┐
+│                                                            │
+│  await ctx._root._render()                                 │
+│      └─ Component setup creates Signals on self            │
+│         self.count = Reactive(5)                           │
+│         self.doubled = Computed(lambda: self.count * 2)    │
+│                                                            │
+│  await scheduler.await_pending()                           │
+│      └─ Async-resolved values settled                      │
+│                                                            │
+│  collect_transfer_data(root):                              │
+│      for each Component in tree:                           │
+│          for name, signal in component.__signal_members__: │
+│              signals[component_id][name] = encode(signal._value)│
+│                                                            │
+│  TransferPayload v2:                                       │
+│      { fetches, async_results, signals }                   │
+└────────────────────────┬───────────────────────────────────┘
+                         │ HTML + <script> payload
+                         ▼
+┌──────────────────── BROWSER (PyScript) ───────────────────┐
+│                                                            │
+│  app.run()                                                 │
+│      └─ Read payload from <script id="__webcompy_data__">  │
+│      └─ Deserialize payload (decode via codec)             │
+│      └─ ctx._root._render()                                │
+│          └─ Component setup (creates Signals with defaults)│
+│             self.count = Reactive(0)                       │
+│             self.doubled = Computed(...) → evaluates to 0  │
+│                                                            │
+│      └─ restore_signal_values(component, signals_data):    │
+│          for name, encoded_value in signals_data.items():  │
+│              signal = component.__signal_members__[name]   │
+│              signal._value = decode(encoded_value)         │
+│          # count restored to 5, doubled restored to 10     │
+│          # (direct _value set, no notification)            │
+│                                                            │
+│      └─ First render uses restored values (no flash)       │
+└────────────────────────────────────────────────────────────┘
+```
+
+## Decisions
+
+### D1: `__signal_members__` keyed by attribute name (not id)
+
+The current `WeakValueDictionary` uses `id(value)` as the key — unstable across server/browser memory spaces. This change switches to a regular `dict` keyed by attribute name:
+
+```python
+# Before
+__signal_members__: WeakValueDictionary[int, SignalBase]  # {id(signal): signal}
+
+# After
+__signal_members__: dict[str, SignalBase]  # {attr_name: signal}
+```
+
+`__set_signal_member__` is called from `__setattr__(name, value)`, which already has the `name`. The method signature gains a `name` parameter.
+
+**Backward compatibility**: `__purge_signal_members__()` iterates `.values()`, unaffected by the key type. No public code accesses `__signal_members__` keys directly.
+
+**Alternatives considered:**
+- **Keep `id()` keys, add a parallel name registry**: Doubles bookkeeping. Rejected.
+- **Use `WeakValueDictionary` with string keys**: `WeakValueDictionary` supports any hashable key, but weak references to Signals could be GC'd before collection runs. A regular dict keeps strong references until `__purge_signal_members__()` is called. Safer for collection timing.
+
+### D2: Computed cached value transfer (option 2)
+
+`Computed` signals store their cached result in `_value`. During SSR, this value is already computed (the render read it). This change transfers the cached `_value` directly:
+
+```
+  Server: Computed._value = 10  (already computed during render)
+          → transfer {"doubled": encode(10)}
+
+  Browser: Component setup creates Computed → evaluates to 0 (default source)
+           Restore: Computed._value = 10  (overwritten, no recompute)
+           → First render reads 10 (correct, no flash)
+           → When source changes via user interaction, normal recompute kicks in
+```
+
+**Why not option 1 (source-only transfer + force recompute)?**
+- Requires distinguishing source Signals from Computed Signals during restore.
+- Requires a "force recompute" mechanism after source restoration.
+- Ordering complexity: sources must be restored before Computed recompute.
+- Option 2 is simpler: transfer everything, restore everything, no recompute logic.
+
+**Trade-off**: The transferred Computed value is a "stale cache" until a source changes. This is acceptable because:
+1. The value was correct at SSR time.
+2. If no source changes, the value is still correct.
+3. If a source changes, the normal reactive graph recomputes.
+
+### D3: Direct `_value` set on restore (no notification)
+
+Restoration sets `signal._value = decoded_value` directly, bypassing `set_value()`. This means:
+- No notifications are fired during restore.
+- Downstream consumers are not triggered.
+- `Computed` signals do not recompute.
+
+This is correct because all values (sources and Computed) are restored from the same coherent SSR snapshot. There is nothing to recompute — the entire state is consistent.
+
+If `set_value()` were used, it would trigger a cascade of notifications and recomputations during restore, which is wasteful and could cause render thrashing.
+
+### D4: Restoration timing — after setup, before first render
+
+Signal restoration SHALL occur after component setup completes (Signals exist on `self`) and before the first render reads them:
+
+```
+  Component._render():
+      1. __setup()  ← creates Signals with defaults
+      2. restore_signal_values(self, payload.signals.get(self._id))
+         ← overwrites _value with transferred values
+      3. on_before_rendering hooks
+      4. template evaluation ← reads restored values, no flash
+```
+
+**Integration point**: The restoration is called from `Component._render()` (or a hook within it), after `__init_component()` / `__setup()` completes and before template evaluation.
+
+### D5: Collection timing — after await_pending, before dispose
+
+On the server, Signal value collection SHALL occur after `await scheduler.await_pending()` (so async-resolved Signal values are settled) and before `ctx.dispose()`:
+
+```
+  generate_html():
+      await ctx._root._render()
+      await scheduler.await_pending()       ← async values settled
+      payload = collect_transfer_data(root) ← collects Signals + AsyncResults
+      ctx.dispose()
+```
+
+### D6: TransferPayload version 2
+
+The `signals` section is added to `TransferPayload`. The `__webcompy_transfer_version__` bumps to `2`. The `deserialize_payload()` function checks the version:
+- Version 1: ignores `signals` section (forward compatibility — a v1 browser skips unknown sections).
+- Version 2: parses `signals` section.
+
+### D7: ReactiveList and ReactiveDict serialization
+
+`ReactiveList` and `ReactiveDict` extend `SignalBase` and store their value in `_value` (a list or dict). They are collected and restored the same way as `Signal`:
+- `encode(reactive_list._value)` → list with type tags for non-JSON elements.
+- `restore: reactive_list._value = decode(encoded)`.
+
+No special handling needed — their `_value` is a plain list/dict that the codec handles.
+
+## Risks / Trade-offs
+
+- **[Local variables not transferred]** → Mitigation: Document that only `self`-assigned Signals are transferred. This matches the existing `__signal_members__` scope. Developers who need transfer for local Signals should assign them to `self`.
+
+- **[Computed stale cache]** → Mitigation: The stale cache is correct until a source changes. When a source changes (user interaction), the normal reactive graph recomputes. Documented behavior.
+
+- **[Non-serializable Signal values]** → Mitigation: The codec drops non-serializable values with a warning (best-effort). The Signal falls back to its default value on the browser.
+
+- **[`__signal_members__` key type change]** → Mitigation: Internal API, no public consumers of the key. `__purge_signal_members__` is unaffected. Unit tests verify no regression.
+
+- **[Payload size increase]** → Mitigation: Only `self`-assigned Signals are included. For large Signal values, `feat-payload-compression` addresses size. The codec's type tags add minimal overhead for plain JSON values (no tags).
+
+- **[Component ID stability]** → Mitigation: Component IDs (`_property["component_id"]`) are derived from the component tree structure (MD5 hash). As long as the same tree is rendered (hydration guarantee), IDs match. This is the same stability assumption used by AsyncResult transfer.
+
+## Open Questions
+
+1. **Should restoration happen in `Component._render()` or in a separate post-setup hook?** Integrating into `_render()` after `__init_component__` is the simplest. A dedicated hook (e.g., `_restore_signals()`) would be cleaner but adds lifecycle complexity. Decision: integrate into `_render()` with a clearly marked restoration block.
+
+2. **Should the `signals` section be optional in the payload?** Yes — payloads without Signals (e.g., components with no `self`-assigned Signals) produce an empty `signals: {}` section. This is harmless and keeps the schema uniform.
+
+3. **What about Signals created in `on_before_rendering` hooks?** These hooks run after setup. If they assign Signals to `self`, the `__setattr__` captures them. However, collection happens after the full render, so these Signals' final values are captured. This should work correctly.

--- a/openspec/changes/feat-signal-value-transfer/proposal.md
+++ b/openspec/changes/feat-signal-value-transfer/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: Signal Value Transfer
+
+## Why
+
+After `feat-suspense-and-hydration-data-transfer`, the server-to-browser transfer mechanism covers `AsyncResult` states and `FetchPort` response caches. However, application-level `Signal` values computed during SSR are not serialized. Components that derive UI state directly from `Signal` values (not via `AsyncResult`) experience a **flash of default values** during hydration — the browser re-initializes signals with their defaults and only converges to the correct state when user interaction or async data updates them.
+
+The current workaround is to wrap Signal-derived state in `Suspense` or `ClientOnly` boundaries, but this is a developer burden and doesn't cover all cases (e.g., UI toggles, cached computations, form state initialized from server data).
+
+This change extends the hydration data transfer to include Signal values. The `SignalReceivable.__signal_members__` mechanism already auto-tracks all Signal instances assigned to a component's `self` attributes — no explicit registration boilerplate is needed. Signal values (including `Computed` cached values) are collected, encoded via the codec engine (`feat-transfer-codec`), and restored on the browser after component setup.
+
+## What Changes
+
+- **MODIFIED** `packages/webcompy/src/webcompy/signal/_container.py` — `SignalReceivable.__signal_members__` SHALL change from `WeakValueDictionary` keyed by `id(value)` to a regular `dict` keyed by attribute name. `__set_signal_member__` SHALL accept the attribute name parameter (passed from `__setattr__`). `computed_property` SHALL integrate with the name-based registry (it already stores `instance.__dict__[name]`).
+- **MODIFIED** `packages/webcompy/src/webcompy/hydration/_collect.py` — `collect_transfer_data()` SHALL traverse `__signal_members__` on each `Component` in the render tree, collecting Signal/Computed/ReactiveList/ReactiveDict values. Each value SHALL be encoded via `encode()` from `webcompy.hydration._codec`.
+- **MODIFIED** `packages/webcompy/src/webcompy/hydration/_payload.py` — `TransferPayload` gains a `signals: dict[str, dict[str, Any]]` field mapping component ID to `{attr_name: encoded_value}`. `__webcompy_transfer_version__` bumps to `2`.
+- **NEW** `packages/webcompy/src/webcompy/hydration/_restore.py` — `restore_signal_values(component, signals_data)` restores Signal values by directly setting `_value` on each Signal instance (bypassing `set_value()` to avoid triggering notifications). `Computed` cached values are restored the same way (option 2: transfer cached value, skip recompute).
+- **MODIFIED** `packages/webcompy/src/webcompy/app/_app.py` — `app.run()` SHALL read `payload.signals` and restore values after component setup.
+- **MODIFIED** `packages/webcompy/src/webcompy/app/_root_component.py` — After SSR rendering completes (before `collect_transfer_data`), Signal values SHALL be collected from the component tree.
+
+## Capabilities
+
+### New Capabilities
+
+- `signal-value-transfer`: Server-to-browser transfer of Signal values (`Signal`, `Computed`, `ReactiveList`, `ReactiveDict`) via the hydration data payload. Values are collected automatically from `__signal_members__` (no explicit registration), encoded via the codec engine, and restored on the browser after component setup. `Computed` cached values are transferred as-is (no recompute on restore).
+
+### Modified Capabilities
+
+- `hydration-data-transfer`: `TransferPayload` gains a `signals` section and bumps to version 2. The payload schema is forward-compatible (version 1 browsers ignore the `signals` section).
+- `reactive`: `SignalReceivable.__signal_members__` changes key type from `id()` to attribute name. `Computed` instances registered via `computed_property` are included by name.
+- `components`: After browser component setup, Signal values from the transfer payload SHALL be restored to the component's Signal instances before the first render.
+- `async-rendering`: The collection of Signal values SHALL occur after `await_pending()` completes (so async-resolved values are captured), and before `ctx.dispose()`.
+
+## Known Issues Addressed
+
+- **Flash of default Signal values during hydration** — Components that store UI state in `Signal` instances (not `AsyncResult`) showed default values until user interaction or async updates. This change transfers the SSR-computed values to the browser, eliminating the flash.
+
+## Non-goals
+
+- **Local (non-`self`) Signal variables** — Signals created as local variables in component setup (`count = Reactive(0)`) without being assigned to `self` are NOT captured by `__signal_members__` and are NOT transferred. This matches the existing tracking scope. A future change could add an explicit registration API, but this is out of scope.
+- **Signal value restoration triggering notifications** — Restore sets `_value` directly, bypassing `set_value()`. Downstream `Computed` signals that depend on restored sources do NOT automatically recompute. This is acceptable because `Computed` cached values are also transferred (option 2). When a source Signal changes via user interaction, the normal reactive graph handles propagation.
+- **Signal graph dependency serialization** — The reactive dependency graph (producer/consumer edges) is NOT transferred. It is rebuilt naturally during browser component setup.
+- **Payload compression** — gzip/brotli compression is `feat-payload-compression`.
+- **Changing `useAsyncResult` API** — `useAsyncResult` is unchanged; it transparently benefits from transfer data via existing mechanisms.
+
+## Dependencies
+
+- **Requires** `feat-transfer-codec` — Signal values SHALL be encoded/decoded via the codec engine. Without the codec, only plain JSON-serializable values could be transferred, severely limiting usefulness.
+- **Benefits from** `feat-async-scheduler-port` — The collection of Signal values occurs after `await_pending()` completes. The scheduler port ensures all async-resolved Signal values are captured before collection.
+
+## Impact
+
+- **Affected modules**:
+  - `packages/webcompy/src/webcompy/signal/_container.py` (`__signal_members__` key type change)
+  - `packages/webcompy/src/webcompy/hydration/_collect.py` (Signal value collection)
+  - `packages/webcompy/src/webcompy/hydration/_payload.py` (`signals` section, version 2)
+  - `packages/webcompy/src/webcompy/hydration/_restore.py` (new — value restoration)
+  - `packages/webcompy/src/webcompy/hydration/__init__.py` (export restore function)
+  - `packages/webcompy/src/webcompy/app/_app.py` (browser restore)
+  - `packages/webcompy/src/webcompy/app/_root_component.py` (SSR collection)
+- **Breaking**: `__signal_members__` internal key type changes from `int` (id) to `str` (attribute name). This is an internal API; no public consumers use the key directly. `__purge_signal_members__()` iterates `.values()`, which is unaffected by the key change.
+- **Backward compatible**: Existing components without Signal-based state work unchanged. Payload version 2 includes a `signals` section that version 1 browsers ignore.
+- **Testing**: Unit tests for Signal value collection, encoding round-trip, restoration, and Computed cached value transfer. E2E tests verifying no flash of default values during hydration.

--- a/openspec/changes/feat-signal-value-transfer/specs/async-rendering/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/async-rendering/spec.md
@@ -1,0 +1,10 @@
+## ADDED Requirements
+
+### Requirement: Signal value collection shall occur after await_pending completes
+
+During SSR/SSG, `collect_transfer_data(root)` SHALL be called after `await scheduler.await_pending()` completes and before `ctx.dispose()`. This ensures that any Signal values modified by async-resolved tasks (e.g., `AsyncResult` callbacks that set Signal values) are captured in their final state.
+
+#### Scenario: Collection timing relative to scheduler drain
+- **WHEN** the SSR pipeline runs `generate_html()` or the ASGI handler processes a request
+- **THEN** the call order SHALL be: `await ctx._root._render()` → `await scheduler.await_pending()` → `collect_transfer_data(root)` → `ctx.dispose()`
+- **AND** Signal values modified during `await_pending()` SHALL be reflected in the collected payload

--- a/openspec/changes/feat-signal-value-transfer/specs/components/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/components/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Components shall restore Signal values after setup during hydration
+
+During browser hydration, `Component._render()` SHALL call signal value restoration after `__init_component()` / `__setup()` completes and before template evaluation. The restoration SHALL read `payload.signals[component_id]` from the transfer payload (provided via `HYDRATION_DATA_KEY` DI) and restore each `(attr_name, encoded_value)` pair by decoding the value via `decode()` from `webcompy.hydration._codec` and setting `component.__signal_members__[attr_name]._value = decoded_value` directly (bypassing `set_value()`).
+
+#### Scenario: Component restores Signal values before first render
+- **WHEN** a component is hydrated in the browser
+- **AND** the transfer payload contains Signal values for the component's ID
+- **THEN** after `__setup()` creates Signals with default values
+- **AND** before template evaluation reads Signal values
+- **AND** each Signal's `_value` SHALL be overwritten with the decoded transfer value
+
+#### Scenario: Component without transfer data renders with defaults
+- **WHEN** a component is hydrated
+- **AND** the transfer payload does not contain an entry for the component's ID
+- **THEN** Signals SHALL retain their default values from setup
+- **AND** no restoration SHALL occur

--- a/openspec/changes/feat-signal-value-transfer/specs/components/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/components/spec.md
@@ -16,3 +16,12 @@ During browser hydration, `Component._render()` SHALL call signal value restorat
 - **AND** the transfer payload does not contain an entry for the component's ID
 - **THEN** Signals SHALL retain their default values from setup
 - **AND** no restoration SHALL occur
+
+#### Scenario: Signals first created in on_before_rendering are not restored on initial hydration
+- **WHEN** a component creates a Signal inside an `on_before_rendering` hook (not in `__setup__()`)
+- **AND** the transfer payload contains a value for that Signal's attribute name
+- **THEN** on the initial hydration cycle, restoration SHALL run before `on_before_rendering`, so the Signal does not yet exist in `__signal_members__`
+- **AND** the restoration for that attribute name SHALL be skipped (best-effort, no error)
+- **AND** the hook SHALL execute with the Signal at its default value
+- **AND** on subsequent navigation-based hydration cycles, the Signal SHALL exist and its transferred value SHALL be restored
+- **AND** developers who need server-computed values available in hooks SHOULD create the Signal in `__setup()` instead

--- a/openspec/changes/feat-signal-value-transfer/specs/hydration-data-transfer/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/hydration-data-transfer/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: TransferPayload shall include fetches, async_results, and signals
+
+`TransferPayload` SHALL contain `__webcompy_transfer_version__: int`, `fetches: dict[str, TransferFetchEntry]`, `async_results: dict[str, TransferAsyncResultEntry]`, and `signals: dict[str, dict[str, Any]]`. The `signals` field maps component ID to a dict of `{attr_name: encoded_value}` where encoded values are produced by `encode()` from `webcompy.hydration._codec`. The supported version SHALL be `2`. The `deserialize_payload()` function SHALL accept version 1 payloads (treating a missing `signals` section as empty) and version 2 payloads.
+
+#### Scenario: Serializing a version 2 payload
+- **WHEN** `serialize_payload()` is called with a `TransferPayload` containing signals
+- **THEN** the JSON output SHALL include `"__webcompy_transfer_version__": 2`
+- **AND** the `"signals"` key SHALL be present in the output
+
+#### Scenario: Deserializing a version 2 payload
+- **WHEN** `deserialize_payload()` receives a version 2 JSON string
+- **THEN** the resulting `TransferPayload` SHALL have the `signals` dict populated from the JSON
+
+#### Scenario: Deserializing a version 1 payload (backward compatibility)
+- **WHEN** `deserialize_payload()` receives a version 1 JSON string (no `signals` key)
+- **THEN** the resulting `TransferPayload.signals` SHALL be an empty dict `{}`
+- **AND** no error SHALL be raised
+
+### Requirement: collect_transfer_data shall collect fetches, async_results, and signals
+
+`collect_transfer_data(root)` SHALL traverse the component tree and populate three sections of the `TransferPayload`: `fetches` (from `FetchPort.get_transfer_data()`), `async_results` (from `Component._async_results`), and `signals` (from `Component.__signal_members__`). Signal values SHALL be encoded via `encode()` from `webcompy.hydration._codec`. Non-serializable Signal values SHALL be dropped with a warning.
+
+#### Scenario: collect_transfer_data gathers all three sections
+- **WHEN** `collect_transfer_data(root)` is called after SSR rendering
+- **THEN** the returned `TransferPayload` SHALL have `fetches`, `async_results`, and `signals` populated
+
+#### Scenario: collect_transfer_data handles components with no signals
+- **WHEN** a component has no `__signal_members__` entries
+- **THEN** that component's ID SHALL not appear in the `signals` dict (or shall map to an empty dict)

--- a/openspec/changes/feat-signal-value-transfer/specs/reactive/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/reactive/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: SignalReceivable shall track signal members by attribute name
+
+`SignalReceivable.__signal_members__` SHALL be a `dict[str, SignalBase]` mapping attribute name to the Signal instance assigned to that attribute. `__setattr__` SHALL call `__set_signal_member__(name, value)` when the value is a `SignalBase` instance, passing the attribute name. `computed_property` SHALL register its `Computed` instances by the method name, consistent with the attribute-name keying.
+
+#### Scenario: Signal assigned to self is tracked by name
+- **WHEN** a component executes `self.count = Reactive(0)`
+- **THEN** `self.__signal_members__["count"]` SHALL reference the `Reactive` instance
+
+#### Scenario: Computed property is tracked by name
+- **WHEN** a component has a `@computed_property` method named `doubled`
+- **AND** the property is accessed (triggering Computed creation)
+- **THEN** `self.__signal_members__["doubled"]` SHALL reference the `Computed` instance
+
+#### Scenario: Reassigning a Signal attribute updates the registry
+- **WHEN** a component executes `self.count = Reactive(0)` then `self.count = Reactive(5)`
+- **THEN** `self.__signal_members__["count"]` SHALL reference the second `Reactive(5)` instance
+- **AND** the first `Reactive(0)` instance SHALL no longer be in the registry
+
+#### Scenario: Non-Signal attributes are not tracked
+- **WHEN** a component executes `self.name = "Alice"` (a plain string)
+- **THEN** `self.__signal_members__` SHALL NOT contain `"name"`

--- a/openspec/changes/feat-signal-value-transfer/specs/signal-value-transfer/spec.md
+++ b/openspec/changes/feat-signal-value-transfer/specs/signal-value-transfer/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Signal values shall be collected from __signal_members__ during SSR
+
+During SSR/SSG, after the render tree completes and `await_pending()` finishes, the framework SHALL traverse the component tree and collect Signal values from each `Component`'s `__signal_members__` registry. For each `(attr_name, signal)` pair, the Signal's `_value` SHALL be encoded via `encode()` from `webcompy.hydration._codec` and stored in the payload as `signals[component_id][attr_name] = encoded_value`. Only `Signal`, `Computed`, `ReactiveList`, and `ReactiveDict` instances (subclasses of `SignalBase`) SHALL be collected.
+
+#### Scenario: Collecting Signal values from a component
+- **WHEN** `collect_transfer_data(root)` traverses a `Component` with `self.count = Reactive(5)` and `self.name = Reactive("Alice")`
+- **THEN** the payload's `signals` section SHALL contain `{component_id: {"count": 5, "name": "Alice"}}`
+
+#### Scenario: Collecting Computed cached values
+- **WHEN** a `Component` has `self.doubled = Computed(lambda: self.count * 2)` where `self.count = Reactive(5)`
+- **AND** the Computed has been evaluated during render (cached value is 10)
+- **THEN** the payload's `signals` section SHALL include `{"doubled": 10}` (the cached value)
+
+#### Scenario: Collecting ReactiveList values
+- **WHEN** a `Component` has `self.items = ReactiveList([1, 2, 3])`
+- **THEN** the payload's `signals` section SHALL include `{"items": [1, 2, 3]}`
+
+#### Scenario: Non-serializable Signal value is dropped with warning
+- **WHEN** a Signal holds a value that the codec cannot encode (e.g., a file handle)
+- **AND** `collect_transfer_data(root)` processes it
+- **THEN** the Signal SHALL be excluded from the payload
+- **AND** a warning SHALL be logged
+
+#### Scenario: Component with no self-assigned Signals
+- **WHEN** a `Component` has no Signal instances assigned to `self`
+- **THEN** the payload's `signals` section SHALL contain an empty dict `{}` for that component ID (or omit it entirely)
+
+### Requirement: Signal values shall be restored on the browser after component setup
+
+During browser hydration, after component `__setup()` / `__init_component()` completes and before template evaluation, the framework SHALL restore Signal values from the transfer payload. For each `(attr_name, encoded_value)` in `payload.signals[component_id]`, the framework SHALL locate `component.__signal_members__[attr_name]`, decode the value via `decode()` from `webcompy.hydration._codec`, and set `signal._value = decoded_value` directly (bypassing `set_value()` to avoid triggering notifications).
+
+#### Scenario: Restoring Signal values eliminates flash
+- **WHEN** a component has `self.count = Reactive(0)` (default) during setup
+- **AND** the transfer payload contains `{"count": 5}` for this component
+- **THEN** after restoration, `self.count._value` SHALL be `5`
+- **AND** the first render SHALL read `5` (no flash of `0`)
+
+#### Scenario: Restoring Computed cached value
+- **WHEN** a component has `self.doubled = Computed(...)` that evaluates to `0` during setup (default source)
+- **AND** the transfer payload contains `{"doubled": 10}` for this component
+- **THEN** after restoration, `self.doubled._value` SHALL be `10`
+- **AND** no recompute SHALL be triggered
+- **AND** the first render SHALL read `10`
+
+#### Scenario: Restoration does not trigger notifications
+- **WHEN** Signal values are restored via direct `_value` assignment
+- **THEN** no `on_before_updating` / `on_after_updating` callbacks SHALL fire
+- **AND** no downstream `Computed` signals SHALL recompute
+- **AND** no `CallbackConsumerNode` instances SHALL be triggered
+
+#### Scenario: Missing component ID in payload
+- **WHEN** a component's ID is not present in `payload.signals`
+- **THEN** no restoration SHALL occur for that component
+- **AND** Signals SHALL retain their default values from setup
+
+#### Scenario: Missing attr_name in __signal_members__
+- **WHEN** the payload contains `{"count": 5}` for a component
+- **AND** the component's `__signal_members__` does not contain `"count"` (e.g., component structure changed)
+- **THEN** the restoration for `"count"` SHALL be skipped
+- **AND** no error SHALL be raised (best-effort restoration)
+
+### Requirement: Signal collection shall occur after await_pending and before ctx.dispose
+
+On the server, `collect_transfer_data()` SHALL be called after `await scheduler.await_pending()` completes (so that async-resolved Signal values are settled) and before `ctx.dispose()` (so that the component tree and its Signal instances are still accessible).
+
+#### Scenario: Collection timing in generate_html
+- **WHEN** `generate_html()` runs the SSR pipeline
+- **THEN** the call order SHALL be: `await ctx._root._render()` → `await scheduler.await_pending()` → `collect_transfer_data(root)` → `ctx.dispose()`
+
+### Requirement: TransferPayload shall include a signals section at version 2
+
+`TransferPayload` SHALL include a `signals: dict[str, dict[str, Any]]` field mapping component ID to a dict of `{attr_name: encoded_value}`. The `__webcompy_transfer_version__` SHALL be `2` for payloads containing the `signals` section. The `deserialize_payload()` function SHALL accept both version 1 (no `signals` section) and version 2 (with `signals` section) payloads.
+
+#### Scenario: Version 2 payload structure
+- **WHEN** `serialize_payload()` produces a payload with Signal values
+- **THEN** the JSON SHALL include `"__webcompy_transfer_version__": 2`
+- **AND** a `"signals"` key SHALL be present
+
+#### Scenario: Version 1 payload backward compatibility
+- **WHEN** `deserialize_payload()` receives a version 1 payload (no `signals` section)
+- **THEN** the `TransferPayload.signals` field SHALL default to an empty dict `{}`
+- **AND** no Signal restoration SHALL occur

--- a/openspec/changes/feat-signal-value-transfer/tasks.md
+++ b/openspec/changes/feat-signal-value-transfer/tasks.md
@@ -1,0 +1,67 @@
+## 1. __signal_members__ Key Type Migration
+
+- [ ] 1.1 Change `SignalReceivable.__signal_members__` from `WeakValueDictionary[int, SignalBase]` to `dict[str, SignalBase]` in `packages/webcompy/src/webcompy/signal/_container.py`
+- [ ] 1.2 Update `__set_signal_member__` signature to accept `name: str` parameter: `__set_signal_member__(self, name: str, value: SignalBase)`
+- [ ] 1.3 Update `__setattr__` to pass the attribute name: `self.__set_signal_member__(name, value)`
+- [ ] 1.4 Update `computed_property` in `packages/webcompy/src/webcompy/signal/_computed.py` to register by method name (it already uses `instance.__dict__[name]`; ensure `__set_signal_member__(name, _computed)` is called)
+- [ ] 1.5 Verify `__purge_signal_members__()` still works correctly (iterates `.values()`, unaffected by key type)
+- [ ] 1.6 Grep for any code that accesses `__signal_members__` keys directly (expecting `id()` keys) and update
+
+## 2. Payload Schema — signals Section
+
+- [ ] 2.1 Add `signals: dict[str, dict[str, Any]]` field to `TransferPayload` dataclass in `packages/webcompy/src/webcompy/hydration/_payload.py`
+- [ ] 2.2 Bump `__webcompy_transfer_version__` default to `2` and update `_SUPPORTED_VERSION = 2`
+- [ ] 2.3 Update `_to_serializable()` to include the `signals` section in the output dict
+- [ ] 2.4 Update `serialize_payload()` to encode signal values via `encode()` from `webcompy.hydration._codec`
+- [ ] 2.5 Update `deserialize_payload()` to parse the `signals` section and decode values via `decode()`
+- [ ] 2.6 Handle version 1 backward compatibility in `deserialize_payload()` — if version is 1, default `signals` to `{}`
+
+## 3. Signal Value Collection
+
+- [ ] 3.1 Add Signal collection to `collect_transfer_data()` in `packages/webcompy/src/webcompy/hydration/_collect.py`
+- [ ] 3.2 Extend the `_walk_component_*` tree traversal to also collect `__signal_members__` from each `Component`
+- [ ] 3.3 For each `(name, signal)` in `__signal_members__`, call `encode(signal._value)` and store in `signals[component_id][name]`
+- [ ] 3.4 Handle codec failures gracefully — if `encode()` raises or returns a non-serializable value, drop the entry with a warning
+- [ ] 3.5 Ensure collection happens after `await scheduler.await_pending()` in the SSR/SSG entry points (coordinate with `feat-async-scheduler-port` call ordering)
+
+## 4. Signal Value Restoration
+
+- [ ] 4.1 Create `packages/webcompy/src/webcompy/hydration/_restore.py` with `restore_signal_values(component, signals_data: dict[str, Any]) -> None`
+- [ ] 4.2 For each `(name, encoded_value)` in `signals_data`, look up `component.__signal_members__.get(name)` and set `signal._value = decode(encoded_value)` directly (no `set_value()`)
+- [ ] 4.3 Handle missing `attr_name` in `__signal_members__` gracefully (skip with no error — best-effort)
+- [ ] 4.4 Export `restore_signal_values` from `packages/webcompy/src/webcompy/hydration/__init__.py`
+
+## 5. Browser Restoration Integration
+
+- [ ] 5.1 Modify `Component._render()` in `packages/webcompy/src/webcompy/components/_component.py` to call `restore_signal_values(self, ...)` after `__init_component()` / `__setup()` completes and before template evaluation
+- [ ] 5.2 Read the component's signal data from `payload.signals.get(self._property["component_id"], {})` via `HYDRATION_DATA_KEY`
+- [ ] 5.3 Ensure restoration only runs in browser environment (or when transfer data is present)
+- [ ] 5.4 Guard: if `HYDRATION_DATA_KEY` is not provided (no transfer data), skip restoration entirely
+
+## 6. SSR Collection Integration
+
+- [ ] 6.1 Verify `collect_transfer_data(root)` is called after `await scheduler.await_pending()` in `generate_html()` (`packages/webcompy-server/src/webcompy_server/_html.py`)
+- [ ] 6.2 Verify the same call ordering in the ASGI HTML handler (`packages/webcompy-cli/src/webcompy_cli/_server.py`)
+- [ ] 6.3 Verify the same call ordering in the SSG route fetch path (`packages/webcompy-cli/src/webcompy_cli/_generate.py`)
+
+## 7. Unit Tests
+
+- [ ] 7.1 Test `__signal_members__` tracks Signals by attribute name (assign, reassign, non-Signal values)
+- [ ] 7.2 Test `computed_property` registers Computed by method name
+- [ ] 7.3 Test `collect_transfer_data()` collects Signal, Computed, ReactiveList, ReactiveDict values
+- [ ] 7.4 Test collection drops non-serializable values with warning
+- [ ] 7.5 Test `restore_signal_values()` restores `_value` directly without triggering notifications
+- [ ] 7.6 Test Computed cached value is restored without recompute
+- [ ] 7.7 Test missing attr_name in `__signal_members__` is handled gracefully
+- [ ] 7.8 Test version 2 payload serialization/deserialization with signals section
+- [ ] 7.9 Test version 1 payload backward compatibility (signals defaults to `{}`)
+- [ ] 7.10 Test component with no `self`-assigned Signals produces empty signals entry
+- [ ] 7.11 Test round-trip: SSR collect → encode → serialize → deserialize → decode → browser restore produces correct values
+
+## 8. Verification
+
+- [ ] 8.1 Run `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] 8.2 Run `uv run pyright`
+- [ ] 8.3 Run `uv run python -m pytest tests/ --tb=short`
+- [ ] 8.4 Run `scripts/run-e2e-tests.sh` — verify no flash of default values during hydration on pages with Signal-based state
+- [ ] 8.5 `npx @fission-ai/openspec@latest validate` passes

--- a/openspec/changes/feat-transfer-codec/.openspec.yaml
+++ b/openspec/changes/feat-transfer-codec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-04

--- a/openspec/changes/feat-transfer-codec/design.md
+++ b/openspec/changes/feat-transfer-codec/design.md
@@ -187,7 +187,7 @@ Lists are encoded as plain JSON arrays (no tag).
 
 ## Risks / Trade-offs
 
-- **[importlib under PyScript]** → Mitigation: Validation spike before full implementation. Use `webcompy inspect` CLI to test `importlib.import_module("myapp.models")` in a PyScript context. If importlib is unavailable, dataclass/enum reconstruction falls back to dict representation with a warning.
+- **[importlib under PyScript]** → Mitigation: Validation spike before full implementation. Use `webcompy inspect` CLI to test `importlib.import_module("myapp.models")` in a PyScript context. If importlib is unavailable, dataclass/enum reconstruction falls back to dict representation with a warning. **Fallback architecture:** If the validation spike reveals that `importlib.import_module()` cannot reliably import arbitrary bundled modules under Pyodide (Pyodide has known limitations on dynamic imports for packages not pre-loaded), the decoder SHALL fall back to a **bundle-time class registry**: the framework collects `{fully_qualified_name: cls}` mappings at wheel-build time (via import scanning) and the decoder looks up the class in the registry instead of calling `importlib.import_module()`. This registry would be populated by the wheel builder and shipped as part of the browser bundle. The encoder schema (module + name) is identical either way, so the fallback is transparent to the payload format.
 
 - **[Payload size increase from type tags]** → Mitigation: Type tags are only added for non-JSON-native values. Plain JSON values (the majority of typical payloads) are unchanged. For large data, `feat-payload-compression` addresses size at a higher layer.
 

--- a/openspec/changes/feat-transfer-codec/design.md
+++ b/openspec/changes/feat-transfer-codec/design.md
@@ -1,0 +1,193 @@
+# Design: Transfer Codec Engine
+
+## Context
+
+WebComPy's hydration data transfer serializes server-side state into a JSON payload embedded in HTML. The current serializer (`hydration/_payload.py`) uses `json.dumps(value, default=str)` — a blunt instrument that stringifies any non-JSON-native value, losing type information. When the browser deserializes, it receives a string instead of a `datetime`, `set`, or `dataclass` instance.
+
+The upcoming `feat-signal-value-transfer` will extend transfer to all Signal values, where the type variety is much broader. A robust codec is a prerequisite.
+
+The codec must work in **both environments**:
+- **Server (CPython)**: Encoding during SSR/SSG.
+- **Browser (PyScript/Emscripten)**: Decoding during hydration.
+
+This rules out native-extension-backed libraries (Pydantic v2's `pydantic-core` is Rust and may not run under Emscripten). The codec must be pure Python, with no external dependencies.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Encode/decode common Python standard-library types (datetime, set, enum, dataclass, Decimal, bytes, tuple, Path, UUID) in pure Python.
+- Provide a plugin API (`register_type_handler`) for custom and third-party types.
+- Avoid key collisions with user data via a reserved `__webcompy_` key prefix.
+- Detect and gracefully handle circular references (drop with warning).
+- Be backward-compatible with existing plain-JSON payloads.
+
+**Non-Goals:**
+
+- Signal value collection/restoration (that's `feat-signal-value-transfer`).
+- Payload compression (that's `feat-payload-compression`).
+- Pydantic/msgspec/marshmallow integration (future plugins via the Layer 2 API).
+- Streaming or incremental encoding (single-pass encode/decode).
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  encode(value) -> JSON-safe structure                        │
+│  decode(value) -> Python object                              │
+│                                                             │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  Layer 2: Pluggable Type Registry                      │  │
+│  │  register_type_handler(cls, encoder, decoder)          │  │
+│  │  • Checked first during encode                         │  │
+│  │  • Pydantic/custom classes plug in here (future)       │  │
+│  └──────────────────────────┬────────────────────────────┘  │
+│                              ▼                               │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  Layer 1: Built-in Extended Encoders (pure Python)     │  │
+│  │  datetime → {"__webcompy_type__":"datetime",            │  │
+│  │             "__webcompy_value__":"2026-07-04T12:00:00"} │  │
+│  │  set      → {"__webcompy_type__":"set",                 │  │
+│  │             "__webcompy_value__":[...]}                 │  │
+│  │  enum    → {"__webcompy_type__":"enum",                 │  │
+│  │            "__webcompy_value__":{"module":...,"name":...,│  │
+│  │                              "value":...}}              │  │
+│  │  dataclass→ {"__webcompy_type__":"dataclass",           │  │
+│  │             "__webcompy_value__":{"module":...,"name":...,│  │
+│  │                              "fields":{...}}}           │  │
+│  │  ... (date, time, frozenset, bytes, Decimal, tuple,    │  │
+│  │       Path, UUID)                                      │  │
+│  └──────────────────────────┬────────────────────────────┘  │
+│                              ▼                               │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  Layer 0: stdlib json (passthrough)                    │  │
+│  │  str, int, float, bool, None, list, dict               │  │
+│  │  → encoded as-is (no type tag)                         │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Decisions
+
+### D1: Inline type-tagged dicts with reserved `__webcompy_` prefix
+
+Each non-JSON-native value is wrapped in a two-key dict:
+
+```python
+{
+    "__webcompy_type__": "datetime",
+    "__webcompy_value__": "2026-07-04T12:00:00"
+}
+```
+
+**Key collision avoidance:**
+- The `__webcompy_` prefix is **framework-reserved**, analogous to Python's `__dunder__` convention. User data dicts should not use keys starting with `__webcompy_`.
+- During decode, a dict is treated as a type tag **if and only if** it contains the key `"__webcompy_type__"`. A user dict without this key is decoded as a normal dict.
+- During encode, if a user dict legitimately contains `__webcompy_type__` (a reserved-key violation), the encoder SHALL detect this and emit a warning. The value is still encoded, but the decode side will interpret it as a type tag — this is documented as undefined behavior for reserved-key violations.
+
+**Alternatives considered:**
+- **Separated format (superjson style)**: `{"json": <clean data>, "meta": {"paths": {"0.key": ["Date"]}}}` — keeps data clean and readable by external tools. But requires path tracking and two-pass encoding. Rejected for implementation complexity; the payload is internal, not consumed by external JSON tools.
+- **Opaque base64 wrapper**: Encode the entire value as a base64 blob. Loses readability and debuggability entirely. Rejected.
+
+### D2: Layer 2 plugin API — global registry, checked first
+
+```python
+_type_handlers: dict[type, tuple[Callable, Callable]] = {}
+
+def register_type_handler(
+    cls: type,
+    encoder: Callable[[Any], dict],   # instance -> {"__webcompy_type__": "...", ...}
+    decoder: Callable[[dict], Any],   # {"__webcompy_value__": ...} -> instance
+) -> None:
+    _type_handlers[cls] = (encoder, decoder)
+```
+
+During `encode()`, the encoder checks `_type_handlers` **first** (Layer 2), then built-in handlers (Layer 1), then JSON-native passthrough (Layer 0). This allows custom handlers to override built-in behavior if desired (e.g., a Pydantic handler that handles dataclass-like models differently).
+
+Registration is **module-global** (not per-request). App code calls `register_type_handler(MyClass, ...)` at import time. Both server and browser run the same app code (bundled in the wheel), so both sides register the same handlers.
+
+**Rationale:** Global registry is simplest and matches Python's module-level singleton pattern. Per-request registries would require DI plumbing and complicate the codec's usage in `_payload.py`.
+
+### D3: dataclass and enum reconstruction via importlib
+
+For `dataclass` and `enum` types, the encoder stores the fully-qualified module and class name:
+
+```python
+# dataclass
+{"__webcompy_type__": "dataclass",
+ "__webcompy_value__": {"module": "myapp.models", "name": "UserProfile",
+                         "fields": {"name": "Alice", "age": 30}}}
+
+# enum
+{"__webcompy_type__": "enum",
+ "__webcompy_value__": {"module": "myapp.enums", "name": "Status",
+                         "value": "active"}}
+```
+
+The decoder uses `importlib.import_module(module)` to retrieve the class, then reconstructs:
+- dataclass: `cls(**fields)`
+- enum: `cls(value)` (lookup by value)
+
+**Key assumption:** The app code is bundled into the browser wheel via PyScript. The same modules exist on both server and browser. `importlib.import_module()` must work under PyScript — this is a **validation spike** (see Risks).
+
+### D4: Circular reference detection via id() tracking
+
+`encode()` maintains a `set[int]` of `id()` values for objects currently being encoded (the ancestor chain). If an object's `id()` is already in the set, a circular reference is detected. The encoder SHALL:
+
+1. Log a warning: "Circular reference detected in transfer value; dropping."
+2. Return `None` for the circular reference (the key is preserved with a `None` value).
+
+This is consistent with the existing AsyncResult behavior of dropping non-serializable values with a warning.
+
+### D5: bytes encoding via base64
+
+`bytes` values are base64-encoded as strings:
+
+```python
+{"__webcompy_type__": "bytes",
+ "__webcompy_value__": "aGVsbG8="}
+```
+
+Base64 is used (not hex) for compactness with large byte sequences.
+
+### D6: Decimal encoding as string
+
+`Decimal` values are encoded as their string representation to preserve precision:
+
+```python
+{"__webcompy_type__": "decimal",
+ "__webcompy_value__": "3.14159"}
+```
+
+`Decimal(str)` reconstructs the exact value on decode.
+
+### D7: tuple vs list distinction
+
+JSON has no tuple type. Tuples are encoded with a type tag to distinguish them from lists:
+
+```python
+{"__webcompy_type__": "tuple",
+ "__webcompy_value__": [1, 2, 3]}
+```
+
+Lists are encoded as plain JSON arrays (no tag).
+
+## Risks / Trade-offs
+
+- **[importlib under PyScript]** → Mitigation: Validation spike before full implementation. Use `webcompy inspect` CLI to test `importlib.import_module("myapp.models")` in a PyScript context. If importlib is unavailable, dataclass/enum reconstruction falls back to dict representation with a warning.
+
+- **[Payload size increase from type tags]** → Mitigation: Type tags are only added for non-JSON-native values. Plain JSON values (the majority of typical payloads) are unchanged. For large data, `feat-payload-compression` addresses size at a higher layer.
+
+- **[Reserved key violation by user data]** → Mitigation: The `__webcompy_` prefix is documented as reserved. The encoder warns on detection. The probability of natural collision is near-zero for well-named data.
+
+- **[Global registry thread safety]** → Mitigation: Registration happens at import time (single-threaded module load). The registry is read-only during encode/decode. No locking needed.
+
+- **[Performance of recursive encode/decode]** → Mitigation: The codec processes typical payloads ( dozens of entries, not millions). Recursive traversal of nested structures has acceptable overhead. A hot-path optimization (pre-checking `json.dumps` success before codec traversal) can be added if profiling indicates a need.
+
+## Open Questions
+
+1. **Should `datetime` encoding include timezone info?** `datetime.isoformat()` includes timezone if present. This should be sufficient for round-trip fidelity. Verify during implementation.
+
+2. **Should the codec support `NamedTuple`?** NamedTuples are tuples with field names. They can be encoded as regular tuples (losing field names) or with a dedicated handler. Deferred — regular tuple encoding is the baseline; a NamedTuple handler can be added via Layer 2 if needed.
+
+3. **Should the codec handle `__slots__`-based classes?** These are not dataclasses and have no standard serialization protocol. Deferred to Layer 2 custom handlers.

--- a/openspec/changes/feat-transfer-codec/design.md
+++ b/openspec/changes/feat-transfer-codec/design.md
@@ -125,8 +125,21 @@ For `dataclass` and `enum` types, the encoder stores the fully-qualified module 
 ```
 
 The decoder uses `importlib.import_module(module)` to retrieve the class, then reconstructs:
-- dataclass: `cls(**fields)`
+- dataclass: `cls(**{k: decode(v) for k, v in fields.items()})` — each field value is decoded recursively before being passed to the constructor
 - enum: `cls(value)` (lookup by value)
+
+**Critical: nested dataclass fidelity.** The encoder MUST NOT use `dataclasses.asdict()`, because `asdict()` recursively converts nested dataclass instances to plain dicts before the codec's `encode()` can process them. A dataclass like `User(name="Alice", address=Address(city="NYC"))` would lose the `Address` type tag if `asdict()` were used. Instead, the encoder SHALL use `dataclasses.fields(instance)` and call `encode()` on each field value individually, so nested dataclasses (and any other non-JSON-native field types) are type-tagged correctly:
+
+```python
+fields = {f.name: encode(getattr(instance, f.name)) for f in dataclasses.fields(instance)}
+```
+
+The decoder SHALL apply `decode()` to each field value before passing them to the constructor, so nested type tags are reconstructed:
+
+```python
+decoded_fields = {k: decode(v) for k, v in fields.items()}
+instance = cls(**decoded_fields)
+```
 
 **Key assumption:** The app code is bundled into the browser wheel via PyScript. The same modules exist on both server and browser. `importlib.import_module()` must work under PyScript — this is a **validation spike** (see Risks).
 

--- a/openspec/changes/feat-transfer-codec/proposal.md
+++ b/openspec/changes/feat-transfer-codec/proposal.md
@@ -1,0 +1,51 @@
+# Proposal: Transfer Codec Engine
+
+## Why
+
+WebComPy's hydration data transfer (`feat-suspense-and-hydration-data-transfer`) serializes server-resolved `AsyncResult` data and `FetchPort` response caches into a JSON payload embedded in the HTML. The current serialization (`hydration/_payload.py`) uses `json.dumps(value)` with a `default=str` fallback — any non-JSON-serializable value (datetime, set, enum, dataclass, Decimal, bytes, tuple) is silently dropped or stringified, losing type information and breaking hydration fidelity.
+
+The upcoming `feat-signal-value-transfer` change will extend transfer to all Signal values, where the variety of stored types is far broader than AsyncResult data. A robust, extensible serialization engine is needed before Signal transfer can be reliable. This change introduces a layered codec inspired by superjson: a pure-Python extended encoder/decoder covering common standard-library types, with a pluggable type-handler registry for custom and third-party types.
+
+## What Changes
+
+- **NEW** `packages/webcompy/src/webcompy/hydration/_codec.py` — The extended codec engine:
+  - `encode(value: Any) -> Any` — Recursively encodes a Python value into a JSON-safe structure. Non-serializable types are wrapped in type-tagged dicts using a reserved `__webcompy_type__` / `__webcompy_value__` key pair.
+  - `decode(value: Any) -> Any` — Recursively decodes a JSON-parsed structure back into Python objects, reconstructing typed values from type-tagged dicts.
+  - `register_type_handler(cls: type, encoder: Callable[[Any], dict], decoder: Callable[[dict], Any]) -> None` — Layer 2 plugin API for custom and third-party type support.
+  - Built-in Layer 1 type handlers for: `datetime.datetime`, `datetime.date`, `datetime.time`, `set`, `frozenset`, `enum.Enum`, `bytes`, `decimal.Decimal`, `dataclasses.dataclass` instances, `tuple`, `pathlib.Path`, `uuid.UUID`.
+- **MODIFIED** `packages/webcompy/src/webcompy/hydration/_payload.py` — `_try_serialize_value()` and `serialize_payload()` use `encode()` instead of `json.dumps()` probing. `deserialize_payload()` uses `decode()` after JSON parsing. `TransferPayload.__webcompy_transfer_version__` bumps to `2` when the `signals` section is present (introduced by `feat-signal-value-transfer`); the codec itself is version-agnostic and works with both v1 and v2 payloads.
+- **MODIFIED** `packages/webcompy/src/webcompy/hydration/_collect.py` — Uses `encode()` when serializing `AsyncResult` data for the payload (instead of raw `entry.data`).
+
+## Capabilities
+
+### New Capabilities
+
+- `transfer-codec`: A layered serialization engine for hydration data transfer. Layer 0 wraps stdlib JSON for basic types. Layer 1 provides pure-Python encoders/decoders for common standard-library types (datetime, set, enum, dataclass, etc.). Layer 2 exposes a plugin API for custom type handlers. All type tags use a reserved `__webcompy_` key prefix to avoid collisions with user data.
+
+### Modified Capabilities
+
+- `hydration-data-transfer`: `TransferAsyncResultEntry.data` and `TransferFetchEntry.body` SHALL be encoded/decoded via the codec engine instead of raw `json.dumps`. Non-serializable values are no longer silently dropped (unless they fail even the extended codec, in which case they are dropped with a warning as before).
+
+## Known Issues Addressed
+
+- **Non-serializable AsyncResult data silently dropped** — Currently, if `AsyncResult` data contains a `datetime` or `dataclass`, it is either stringified (`default=str`) or dropped entirely. The codec engine preserves type information so the browser reconstructs the correct type.
+
+## Non-goals
+
+- **Signal value transfer** — This change provides the codec engine only. Collecting and restoring Signal values is `feat-signal-value-transfer`.
+- **Payload compression** — gzip/brotli compression is `feat-payload-compression`. The codec produces uncompressed JSON; compression is applied at a higher layer.
+- **Pydantic as a core dependency** — Pydantic v2's `pydantic-core` is Rust-backed and may not work in PyScript/Emscripten. Pydantic integration is deferred to a separate optional plugin that registers handlers via `register_type_handler()`. The codec's Layer 2 API is designed to accommodate it.
+- **Custom transfer keys** — Type tags use the reserved `__webcompy_` prefix. User-defined keys are not supported (the prefix is framework-reserved).
+- **Circular reference reconstruction** — Circular references in transferred values are detected and dropped with a warning (not reconstructed).
+- **Changing the `TransferPayload` schema version** — The codec is version-agnostic. The payload version bump to 2 happens in `feat-signal-value-transfer` (which adds the `signals` section).
+
+## Impact
+
+- **Affected modules**:
+  - `packages/webcompy/src/webcompy/hydration/_codec.py` (new)
+  - `packages/webcompy/src/webcompy/hydration/_payload.py` (modified — encode/decode integration)
+  - `packages/webcompy/src/webcompy/hydration/_collect.py` (modified — encode AsyncResult data)
+  - `packages/webcompy/src/webcompy/hydration/__init__.py` (export public codec API)
+- **Breaking**: None. The codec is backward-compatible with existing v1 payloads (type-tagged dicts only appear where the encoder wraps non-JSON values; plain JSON values are unchanged).
+- **Backward compatible**: Existing AsyncResult data that is plain JSON-serializable encodes identically to before. The codec only adds type tags for values that `json.dumps` would fail on or stringify.
+- **Testing**: Unit tests for each Layer 1 type handler (encode + decode round-trip), circular reference detection, plugin API registration, and backward compatibility with plain JSON values.

--- a/openspec/changes/feat-transfer-codec/specs/hydration-data-transfer/spec.md
+++ b/openspec/changes/feat-transfer-codec/specs/hydration-data-transfer/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: TransferPayload serialization shall use the codec engine
+
+`serialize_payload()` SHALL apply `encode()` from `webcompy.hydration._codec` to `TransferAsyncResultEntry.data` and `TransferFetchEntry.body` before `json.dumps()`. `deserialize_payload()` SHALL apply `decode()` after `json.loads()`. The `__webcompy_transfer_version__` field SHALL remain `1` for payloads without the `signals` section (Signal value transfer, which adds the `signals` section and bumps to version 2, is a separate change). The codec is version-agnostic and works with both v1 and v2 payloads.
+
+Non-serializable values that fail even the codec's extended encoders SHALL be dropped with a warning (consistent with the existing `_try_serialize_value` behavior), preserving the best-effort transfer philosophy.
+
+#### Scenario: AsyncResult data with datetime is transferred correctly
+- **WHEN** an `AsyncResult` resolves to a value containing a `datetime` during SSR
+- **AND** `serialize_payload()` is called
+- **THEN** the datetime SHALL be encoded via the codec as a type-tagged dict `{"__webcompy_type__": "datetime", "__webcompy_value__": "..."}`
+- **AND** the browser-side `deserialize_payload()` SHALL reconstruct the `datetime` instance via `decode()`
+
+#### Scenario: AsyncResult data with a dataclass is transferred correctly
+- **WHEN** an `AsyncResult` resolves to a dataclass instance during SSR
+- **AND** `serialize_payload()` is called
+- **THEN** the dataclass SHALL be encoded via the codec with module, class name, and field values
+- **AND** the browser-side `deserialize_payload()` SHALL reconstruct the dataclass instance via `importlib.import_module` and `cls(**fields)`
+
+#### Scenario: Non-serializable value failing the codec is dropped
+- **WHEN** an `AsyncResult` resolves to a value that the codec cannot encode (e.g., a file handle or socket object)
+- **AND** `serialize_payload()` is called
+- **THEN** the entry SHALL be dropped from the payload
+- **AND** a warning SHALL be logged
+
+#### Scenario: Backward compatibility with plain JSON AsyncResult data
+- **WHEN** an `AsyncResult` resolves to a plain JSON-native value (e.g., `{"name": "Alice"}`)
+- **AND** `serialize_payload()` is called
+- **THEN** the value SHALL pass through the codec unchanged (no type tags added)
+- **AND** the encoded output SHALL be identical to the previous `json.dumps` output

--- a/openspec/changes/feat-transfer-codec/specs/transfer-codec/spec.md
+++ b/openspec/changes/feat-transfer-codec/specs/transfer-codec/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: The codec shall provide encode and decode functions for hydration data
+
+The `webcompy.hydration._codec` module SHALL provide `encode(value: Any) -> Any` and `decode(value: Any) -> Any` functions. `encode()` recursively transforms a Python value into a JSON-safe structure where non-JSON-native types are wrapped in type-tagged dicts. `decode()` recursively transforms a JSON-parsed structure back into Python objects, reconstructing typed values from type-tagged dicts. Both functions SHALL be pure Python with no external dependencies, ensuring they work in both CPython (server) and PyScript/Emscripten (browser) environments.
+
+#### Scenario: Encoding a plain JSON-native value
+- **WHEN** `encode(42)` is called
+- **THEN** the return value SHALL be `42` (no type tag)
+
+#### Scenario: Encoding a nested structure with mixed types
+- **WHEN** `encode({"name": "Alice", "created": datetime(2026, 7, 4), "tags": {"a", "b"}})` is called
+- **THEN** the return value SHALL be a dict with `"name"` as plain string, `"created"` as a type-tagged dict, and `"tags"` as a type-tagged dict
+
+#### Scenario: Decoding a type-tagged structure
+- **WHEN** `decode({"name": "Alice", "created": {"__webcompy_type__": "datetime", "__webcompy_value__": "2026-07-04T00:00:00"}})` is called
+- **THEN** the return value SHALL be a dict with `"name"` as `"Alice"` and `"created"` as a `datetime.datetime(2026, 7, 4)` instance
+
+#### Scenario: Round-trip encode then decode preserves value
+- **WHEN** a value containing datetime, set, enum, and dataclass instances is encoded then decoded
+- **THEN** the decoded value SHALL be equal to the original value (same types, same data)
+
+### Requirement: Type tags shall use the reserved __webcompy_ key prefix
+
+All type-tagged dicts SHALL use exactly two keys: `"__webcompy_type__"` (string identifying the type) and `"__webcompy_value__"` (the type-specific payload). The `"__webcompy_"` key prefix is framework-reserved. During decode, a dict SHALL be treated as a type tag if and only if it contains the key `"__webcompy_type__"`. A user dict without this key SHALL be decoded as a normal dict.
+
+#### Scenario: Type-tagged dict structure
+- **WHEN** `encode(datetime(2026, 7, 4))` is called
+- **THEN** the return value SHALL be `{"__webcompy_type__": "datetime", "__webcompy_value__": "2026-07-04T00:00:00"}`
+
+#### Scenario: User dict without reserved key is not treated as type tag
+- **WHEN** `decode({"name": "Alice", "age": 30})` is called
+- **THEN** the return value SHALL be `{"name": "Alice", "age": 30}` (decoded as a normal dict, no type reconstruction)
+
+#### Scenario: Reserved key violation emits a warning
+- **WHEN** `encode({"__webcompy_type__": "custom", "data": 123})` is called (user data contains the reserved key)
+- **THEN** a warning SHALL be logged about the reserved-key violation
+- **AND** the encode behavior for the violating dict is undefined (the decode side may interpret it as a type tag)
+
+### Requirement: Layer 1 built-in encoders shall cover common standard-library types
+
+The codec SHALL include built-in type handlers for the following types: `datetime.datetime`, `datetime.date`, `datetime.time`, `set`, `frozenset`, `enum.Enum`, `bytes`, `decimal.Decimal`, dataclass instances (via `dataclasses.is_dataclass`), `tuple`, `pathlib.Path`, and `uuid.UUID`. Each handler SHALL produce a type-tagged dict that round-trips correctly through `decode()`.
+
+#### Scenario: Encoding datetime
+- **WHEN** `encode(datetime.datetime(2026, 7, 4, 12, 0, tzinfo=timezone.utc))` is called
+- **THEN** the type tag SHALL be `"datetime"` and the value SHALL be the ISO-format string
+- **AND** `decode(result)` SHALL reconstruct an equal `datetime` instance with the same timezone
+
+#### Scenario: Encoding set
+- **WHEN** `encode({1, 2, 3})` is called
+- **THEN** the type tag SHALL be `"set"` and the value SHALL be a list representation
+- **AND** `decode(result)` SHALL reconstruct a `set` equal to `{1, 2, 3}`
+
+#### Scenario: Encoding enum
+- **WHEN** `encode(MyEnum.ACTIVE)` is called where `MyEnum` is defined in module `myapp.enums`
+- **THEN** the type tag SHALL be `"enum"` and the value SHALL include the module name, enum class name, and member value
+- **AND** `decode(result)` SHALL reconstruct the `MyEnum.ACTIVE` member via `importlib.import_module`
+
+#### Scenario: Encoding a dataclass instance
+- **WHEN** `encode(UserProfile(name="Alice", age=30))` is called where `UserProfile` is a dataclass in module `myapp.models`
+- **THEN** the type tag SHALL be `"dataclass"` and the value SHALL include the module name, class name, and field dict
+- **AND** `decode(result)` SHALL reconstruct a `UserProfile` instance via `importlib.import_module` and `cls(**fields)`
+
+#### Scenario: Encoding bytes
+- **WHEN** `encode(b"hello")` is called
+- **THEN** the type tag SHALL be `"bytes"` and the value SHALL be the base64-encoded string `"aGVsbG8="`
+- **AND** `decode(result)` SHALL reconstruct `b"hello"`
+
+#### Scenario: Encoding Decimal
+- **WHEN** `encode(Decimal("3.14159"))` is called
+- **THEN** the type tag SHALL be `"decimal"` and the value SHALL be the string `"3.14159"`
+- **AND** `decode(result)` SHALL reconstruct `Decimal("3.14159")`
+
+#### Scenario: Encoding tuple
+- **WHEN** `encode((1, 2, 3))` is called
+- **THEN** the type tag SHALL be `"tuple"` and the value SHALL be `[1, 2, 3]`
+- **AND** `decode(result)` SHALL reconstruct `(1, 2, 3)` as a tuple (not a list)
+
+### Requirement: The codec shall support a pluggable type-handler registry (Layer 2)
+
+The codec SHALL provide `register_type_handler(cls: type, encoder: Callable[[Any], dict], decoder: Callable[[dict], Any]) -> None`. Registered handlers SHALL be checked **first** during encode (before Layer 1 built-in handlers), allowing custom types to override built-in behavior. Registration is module-global and happens at import time. Both server and browser environments run the same app code, so both register the same handlers.
+
+#### Scenario: Registering and using a custom type handler
+- **WHEN** `register_type_handler(MyClass, my_encoder, my_decoder)` is called at import time
+- **AND** `encode(MyClass(...))` is called during SSR
+- **THEN** `my_encoder` SHALL be invoked to produce the type-tagged dict
+- **AND** `decode(result)` SHALL invoke `my_decoder` to reconstruct the `MyClass` instance
+
+#### Scenario: Layer 2 handler takes precedence over Layer 1
+- **WHEN** a handler for `datetime.datetime` is registered via `register_type_handler`
+- **AND** `encode(some_datetime)` is called
+- **THEN** the registered handler SHALL be used instead of the built-in datetime encoder
+
+### Requirement: The codec shall detect and handle circular references
+
+`encode()` SHALL maintain a set of `id()` values for objects currently in the encoding ancestor chain. If a circular reference is detected (an object's `id()` is already in the set), the encoder SHALL log a warning and return `None` for that value. The key containing the circular reference SHALL be preserved in the parent structure with a `None` value.
+
+#### Scenario: Circular reference is dropped with warning
+- **WHEN** `encode` encounters a dict that contains a reference to itself (directly or transitively)
+- **THEN** a warning SHALL be logged indicating a circular reference was detected and dropped
+- **AND** the circular value SHALL be replaced with `None` in the encoded output
+
+### Requirement: The codec shall be backward-compatible with plain JSON values
+
+Values that are already JSON-native (`str`, `int`, `float`, `bool`, `None`, `list`, `dict` without type tags) SHALL pass through `encode()` and `decode()` unchanged. This ensures existing v1 payloads without type tags decode correctly, and values that do not need type wrapping remain compact.
+
+#### Scenario: Plain dict passes through unchanged
+- **WHEN** `encode({"key": "value", "count": 42})` is called
+- **THEN** the return value SHALL be `{"key": "value", "count": 42}` (no type tags added)
+
+#### Scenario: v1 payload without type tags decodes correctly
+- **WHEN** `decode({"async_results": {"cid": {"state": "success", "data": {"name": "Alice"}}}})` is called
+- **THEN** the structure SHALL be returned as-is (no type reconstruction, since no `__webcompy_type__` keys are present)

--- a/openspec/changes/feat-transfer-codec/specs/transfer-codec/spec.md
+++ b/openspec/changes/feat-transfer-codec/specs/transfer-codec/spec.md
@@ -59,7 +59,14 @@ The codec SHALL include built-in type handlers for the following types: `datetim
 #### Scenario: Encoding a dataclass instance
 - **WHEN** `encode(UserProfile(name="Alice", age=30))` is called where `UserProfile` is a dataclass in module `myapp.models`
 - **THEN** the type tag SHALL be `"dataclass"` and the value SHALL include the module name, class name, and field dict
-- **AND** `decode(result)` SHALL reconstruct a `UserProfile` instance via `importlib.import_module` and `cls(**fields)`
+- **AND** each field value SHALL be encoded via the codec's recursive `encode()` (using `dataclasses.fields()`, NOT `dataclasses.asdict()`)
+- **AND** `decode(result)` SHALL reconstruct a `UserProfile` instance via `importlib.import_module` and `cls(**decoded_fields)` where each field value is decoded recursively
+
+#### Scenario: Encoding a nested dataclass preserves type fidelity
+- **WHEN** `encode(User(name="Alice", address=Address(city="NYC")))` is called where both `User` and `Address` are dataclasses
+- **THEN** the `address` field value SHALL be a type-tagged dict (`{"__webcompy_type__": "dataclass", ...}`), NOT a plain dict
+- **AND** `decode(result)` SHALL reconstruct the `User` instance with `address` as an `Address` instance (not a dict)
+- **AND** the encoder SHALL NOT use `dataclasses.asdict()` (which recursively strips type information from nested dataclasses)
 
 #### Scenario: Encoding bytes
 - **WHEN** `encode(b"hello")` is called

--- a/openspec/changes/feat-transfer-codec/tasks.md
+++ b/openspec/changes/feat-transfer-codec/tasks.md
@@ -1,0 +1,62 @@
+## 1. Codec Core
+
+- [ ] 1.1 Create `packages/webcompy/src/webcompy/hydration/_codec.py` with `encode(value: Any) -> Any` and `decode(value: Any) -> Any` function signatures
+- [ ] 1.2 Implement the Layer 0 passthrough: JSON-native types (`str`, `int`, `float`, `bool`, `None`, `list`, `dict`) are returned as-is by `encode()` and `decode()` (with dict/list recursive traversal)
+- [ ] 1.3 Implement circular reference detection in `encode()` using an `id()` set tracking the ancestor chain; on detection, log a warning and return `None`
+
+## 2. Layer 1 Built-in Type Handlers
+
+- [ ] 2.1 Implement `datetime.datetime` handler — encode via `isoformat()`, decode via `datetime.fromisoformat()`
+- [ ] 2.2 Implement `datetime.date` handler — encode via `isoformat()`, decode via `date.fromisoformat()`
+- [ ] 2.3 Implement `datetime.time` handler — encode via `isoformat()`, decode via `time.fromisoformat()`
+- [ ] 2.4 Implement `set` handler — encode as list, decode via `set()`
+- [ ] 2.5 Implement `frozenset` handler — encode as list with `"frozenset"` tag, decode via `frozenset()`
+- [ ] 2.6 Implement `enum.Enum` handler — encode as `{"module": ..., "name": ..., "value": ...}`, decode via `importlib.import_module(module).Name(value)`
+- [ ] 2.7 Implement `bytes` handler — encode via `base64.b64encode()`, decode via `base64.b64decode()`
+- [ ] 2.8 Implement `decimal.Decimal` handler — encode as string, decode via `Decimal(str)`
+- [ ] 2.9 Implement `dataclass` instance handler — encode via `dataclasses.asdict()` plus module/name metadata, decode via `importlib.import_module(module).Name(**fields)`
+- [ ] 2.10 Implement `tuple` handler — encode as list with `"tuple"` tag, decode via `tuple()`
+- [ ] 2.11 Implement `pathlib.Path` handler — encode as string, decode via `Path(str)`
+- [ ] 2.12 Implement `uuid.UUID` handler — encode as string, decode via `UUID(str)`
+- [ ] 2.13 Register all Layer 1 handlers in the encode/decode dispatch tables
+
+## 3. Layer 2 Plugin API
+
+- [ ] 3.1 Implement `register_type_handler(cls: type, encoder: Callable, decoder: Callable) -> None` storing handlers in a module-global `_type_handlers` dict
+- [ ] 3.2 Ensure Layer 2 handlers are checked **first** in `encode()` (before Layer 1 built-in handlers)
+- [ ] 3.3 Implement reserved-key violation detection in `encode()`: if a plain dict contains `"__webcompy_type__"`, log a warning
+
+## 4. Public API Exports
+
+- [ ] 4.1 Export `encode`, `decode`, `register_type_handler` from `packages/webcompy/src/webcompy/hydration/__init__.py`
+
+## 5. Payload Integration
+
+- [ ] 5.1 Modify `_try_serialize_value()` in `packages/webcompy/src/webcompy/hydration/_payload.py` to use `encode()` instead of `json.dumps()` probing
+- [ ] 5.2 Modify `serialize_payload()` to apply `encode()` to `TransferAsyncResultEntry.data` before `json.dumps()`
+- [ ] 5.3 Modify `deserialize_payload()` to apply `decode()` after `json.loads()`
+- [ ] 5.4 Modify `_collect.py` to pass `AsyncResult` data through `encode()` when building `TransferAsyncResultEntry`
+- [ ] 5.5 Verify `__webcompy_transfer_version__` remains `1` (the codec does not change the payload schema; version bump to 2 is deferred to `feat-signal-value-transfer`)
+
+## 6. Validation Spike
+
+- [ ] 6.1 Verify `importlib.import_module("myapp.models")` works under PyScript using `webcompy inspect` CLI with a minimal test app containing a dataclass — confirm dataclass reconstruction is feasible in the browser environment
+
+## 7. Unit Tests
+
+- [ ] 7.1 Test round-trip encode/decode for each Layer 1 type (datetime, date, time, set, frozenset, enum, bytes, Decimal, dataclass, tuple, Path, UUID)
+- [ ] 7.2 Test nested structures (dict containing set containing datetime, etc.) round-trip correctly
+- [ ] 7.3 Test circular reference detection (dict containing self-reference) drops the value with warning
+- [ ] 7.4 Test Layer 2 plugin registration and precedence over Layer 1
+- [ ] 7.5 Test reserved-key violation detection (user dict with `__webcompy_type__`) emits warning
+- [ ] 7.6 Test backward compatibility: plain JSON values pass through unchanged
+- [ ] 7.7 Test that existing AsyncResult transfer still works (payload v1 compatibility)
+- [ ] 7.8 Test non-serializable value (e.g., file object) is dropped with warning
+
+## 8. Verification
+
+- [ ] 8.1 Run `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] 8.2 Run `uv run pyright`
+- [ ] 8.3 Run `uv run python -m pytest tests/ --tb=short`
+- [ ] 8.4 Run `scripts/run-e2e-tests.sh` (no regression in existing hydration data transfer)
+- [ ] 8.5 `npx @fission-ai/openspec@latest validate` passes

--- a/openspec/changes/feat-transfer-codec/tasks.md
+++ b/openspec/changes/feat-transfer-codec/tasks.md
@@ -14,7 +14,7 @@
 - [ ] 2.6 Implement `enum.Enum` handler — encode as `{"module": ..., "name": ..., "value": ...}`, decode via `importlib.import_module(module).Name(value)`
 - [ ] 2.7 Implement `bytes` handler — encode via `base64.b64encode()`, decode via `base64.b64decode()`
 - [ ] 2.8 Implement `decimal.Decimal` handler — encode as string, decode via `Decimal(str)`
-- [ ] 2.9 Implement `dataclass` instance handler — encode via `dataclasses.asdict()` plus module/name metadata, decode via `importlib.import_module(module).Name(**fields)`
+- [ ] 2.9 Implement `dataclass` instance handler — encode via `dataclasses.fields()` with per-field recursive `encode()` (NOT `asdict()`, which strips nested type info), plus module/name metadata; decode via `importlib.import_module(module).Name(**{k: decode(v) for k, v in fields.items()})`
 - [ ] 2.10 Implement `tuple` handler — encode as list with `"tuple"` tag, decode via `tuple()`
 - [ ] 2.11 Implement `pathlib.Path` handler — encode as string, decode via `Path(str)`
 - [ ] 2.12 Implement `uuid.UUID` handler — encode as string, decode via `UUID(str)`
@@ -46,6 +46,7 @@
 
 - [ ] 7.1 Test round-trip encode/decode for each Layer 1 type (datetime, date, time, set, frozenset, enum, bytes, Decimal, dataclass, tuple, Path, UUID)
 - [ ] 7.2 Test nested structures (dict containing set containing datetime, etc.) round-trip correctly
+- [ ] 7.2a Test nested dataclass round-trip: a dataclass field whose value is another dataclass instance SHALL preserve the inner type tag through encode/decode (verify `asdict()` is NOT used)
 - [ ] 7.3 Test circular reference detection (dict containing self-reference) drops the value with warning
 - [ ] 7.4 Test Layer 2 plugin registration and precedence over Layer 1
 - [ ] 7.5 Test reserved-key violation detection (user dict with `__webcompy_type__`) emits warning


### PR DESCRIPTION
## Description

This PR adds four OpenSpec proposals for the future work identified in
the recent async SSR/SSG rollout retrospective. The proposals capture
the design decisions reached during exploration and provide the
implementation roadmap. No code changes — artifacts only.

The four changes form a layered roadmap:

1. **`feat-async-scheduler-port`** — Centralizes all async task
   scheduling through an injectable `AsyncSchedulerPort`. Structurally
   resolves the dual-environment lifecycle bug class: fire-and-forget
   tasks on the server run after `ctx.dispose()`, causing `InjectKey`
   errors and incomplete SSR/SSG output. The server implementation
   maintains a per-request registry drained before context disposal.
   Generalizes the specific fix from `fix-ssr-hydration-skip` to the
   entire class of dual-environment scheduling bugs across the five
   scattered `ensure_future` / `create_task` call sites.

2. **`feat-transfer-codec`** — Pure-Python layered serialization
   engine for hydration data transfer, inspired by superjson.
   Replaces the blunt `json.dumps(default=str)` approach with
   type-preserving encoding for `datetime`, `set`, `enum`, `dataclass`,
   `Decimal`, `bytes`, `tuple`, `Path`, `UUID`, and other common
   standard-library types. Three layers: stdlib JSON passthrough,
   built-in pure-Python encoders, and a `register_type_handler()` plugin
   API. Type tags use the reserved `__webcompy_` prefix to avoid
   collisions with user data. No third-party dependencies (Pydantic is
   deferred to a Layer 2 plugin because `pydantic-core` is Rust-backed
   and may not work under PyScript/Emscripten).

3. **`feat-signal-value-transfer`** — Extends hydration data transfer
   to include Signal values, eliminating the flash of default values
   during hydration for components that derive UI state from Signals.
   `__signal_members__` switches from `id()`-keyed to attribute-name-
   keyed for stable cross-environment identification. `Computed`
   cached values are transferred as-is (option 2), skipping recompute
   on restore. Depends on the codec engine for type fidelity.

4. **`feat-payload-compression`** — Optional gzip compression of the
   hydration payload via stdlib `zlib`. Threshold-based activation
   (default 1024 bytes) to avoid base64 expansion overhead for small
   payloads. Compressed payloads use an `__webcompy_compressed__`
   envelope. Most valuable after Signal value transfer expands the
   payload.

## Related Resources

- OpenSpec Changes:
  - `feat-async-scheduler-port`
  - `feat-transfer-codec`
  - `feat-signal-value-transfer`
  - `feat-payload-compression`
- Specs affected (new):
  - `openspec/specs/async-scheduler/spec.md`
  - `openspec/specs/transfer-codec/spec.md`
  - `openspec/specs/signal-value-transfer/spec.md`
  - `openspec/specs/payload-compression/spec.md`
- Specs affected (delta):
  - `openspec/specs/port-abstraction/spec.md`
  - `openspec/specs/port-provisioning/spec.md`
  - `openspec/specs/async-rendering/spec.md`
  - `openspec/specs/app-lifecycle/spec.md`
  - `openspec/specs/elements/spec.md`
  - `openspec/specs/hydration-data-transfer/spec.md`
  - `openspec/specs/reactive/spec.md`
  - `openspec/specs/components/spec.md`
- Related retrospective: the dual-environment lifecycle bug class was
  first surfaced in `fix-ssr-hydration-skip` (prerequisite PR in the
  SSG via SSR rollout).

## Type of Change

- [x] chore — Maintenance, dependencies, CI

(OpenSpec artifacts only; no code changes.)

## Breaking Changes?

- [x] No

## Checklist

- [x] Change type matches branch name prefix (`chore/future-work-opensec-proposals`)
- [ ] OpenSpec change is archived (if applicable)
  - Not applicable: proposals are pre-archive artifacts in `openspec/changes/`.
- [x] Tests added/updated for changed code
  - Not applicable: no code changes. Unit/E2E test tasks are documented
    in each proposal'\''s `tasks.md` for future implementation phases.
- [x] E2E tests pass (if UI-affecting change)
  - Not applicable: artifacts only, no UI-affecting code.
- [x] Dual environment verified (browser + server)
  - Not applicable: artifacts only. Validation spikes (e.g., PyScript
    `importlib`/`zlib` availability) are documented in each proposal.
- [x] No new module-level globals introduced (use DI instead)
  - Not applicable: artifacts only. Proposals explicitly mandate DI
    via `AsyncSchedulerPort` and the existing DI system.
- [x] `webcompy generate` produces correct output (if SSG-visible)
  - Not applicable: artifacts only.

---

🤖 Generated with opencode