### PR TITLE
docs: add template engine design artifacts (OpenSpec)

### DIFF
--- a/openspec/changes/feat-template-component-tags/.openspec.yaml
+++ b/openspec/changes/feat-template-component-tags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-component-tags/design.md
+++ b/openspec/changes/feat-template-component-tags/design.md
@@ -1,0 +1,86 @@
+## Context
+
+Change 1 established that all tags in templates are treated as HTML elements. This change adds component resolution: when a template tag is not in the `HtmlTags` literal, the binder attempts to resolve it as a component via the DI-accessible `ComponentStore`. This enables declarative component usage in templates while keeping imports (and thus registration) explicit in Python.
+
+The `ComponentStore` is already per-app and populated via `@define_component` when modules are imported. The template engine simply looks up component names in this store at bind time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Resolve non-HTML tags as component references via ComponentStore DI lookup
+- Support static props (`prop="value"`) and dynamic props (`:prop="var"`)
+- Convert kebab-case component names to PascalCase for lookup
+- Convert kebab-case prop names to snake_case for Python props dict
+- Pass component body content as the default slot
+- Handle self-closing component tags
+
+**Non-Goals:**
+- Named slots (only default slot in MVP)
+- Event handlers on component tags (`@click` on `<card>`) — these would require special emitter semantics
+- Expression evaluation in static props (always literal strings)
+- Auto-import of component modules (developer must import explicitly for registration)
+
+## Decisions
+
+### D1: ComponentStore lookup via DI injection
+
+The binder calls `inject(_COMPONENT_STORE_KEY)` to get the per-app ComponentStore. Component names are resolved by kebab→PascalCase conversion and dict lookup.
+
+**Rationale**: The ComponentStore is already per-app via DI. No new global registry needed. Since `render_template` is called during component setup (which runs inside a DI scope), injection always succeeds.
+
+**Note**: `_COMPONENT_STORE_KEY` is defined as `InjectKey[object]` (`di/_keys.py:8`), so `inject(_COMPONENT_STORE_KEY)` returns `object`. The binder SHALL cast the result to `ComponentStore`. If `_COMPONENT_STORE_KEY` is later retyped to `InjectKey[ComponentStore]`, the cast SHALL be removed and this note serves as a reminder to do so.
+
+### D2: Hyphen convention for component tag classification
+
+Tags containing hyphens (`-`) that are NOT found in ComponentStore raise an error. Tags without hyphens that are not found are treated as HTML (lenient).
+
+**Rationale**: Vue convention — hyphens disambiguate: `<my-card>` is always a component. `<widget>` without hyphen could be a future HTML element, so lenient fallback is safer.
+
+**Naming convention**: The `ComponentStore` is keyed by the function's `__name__` (`_generator.py:279`). The kebab→PascalCase conversion (`kebab_to_pascal("user-card")` → `"UserCard"`) only succeeds when the component definition function uses PascalCase naming (e.g., `def UserCard(ctx):`). Functions named in snake_case (e.g., `def user_card(ctx):`) will not match the converted name and cause a lookup error. This convention MUST be documented for component authors.
+
+**Hyphen detection logic**: The kebab→PascalCase conversion SHALL only be invoked when the tag name contains at least one hyphen. Tags without hyphens (e.g., `<UserCard>` in PascalCase, `<usercard>` in lowercase) SHALL be passed directly to `ComponentStore` lookup using the tag name as-is. If the lookup fails for a non-hyphenated tag, it SHALL fall back to HTML element treatment (lenient fallback), consistent with the convention that only hyphenated unknown tags raise an error.
+
+| Tag form | Example | Hyphen? | ComponentStore lookup | Failed lookup behavior |
+|---|---|---|---|---|
+| kebab-case | `<user-card>` | Yes | kebab→PascalCase (`UserCard`) | `WebComPyException` ("Component not found") |
+| PascalCase | `<UserCard>` | No | as-is (`UserCard`) | lenient → treated as HTML |
+| lowercase | `<usercard>` | No | as-is (`usercard`) | lenient → treated as HTML |
+
+**Rationale**: The hyphen is the unambiguous signal that a tag is a component reference. PascalCase naming without a hyphen is ambiguous — it could be a component or a future HTML custom element (`HTMLUnknownElement`). The lenient fallback for non-hyphenated tags is the safer choice.
+
+**Tag name type casting**: When the lenient fallback creates an `Element` from a non-hyphenated tag name, it SHALL use the same `cast("HtmlTags", tag_name)` strategy as Change 1's `bind_element` (see interpolation design D6).
+
+### D3: Static props as literal strings, dynamic props as variable references
+
+`title="Hello"` → literal string `"Hello"`. `:count="my_signal"` → variable lookup `context["my_signal"]`.
+
+**Rationale**: The `:` prefix clearly separates "string literal" from "variable reference". This matches Vue's `:prop` convention and keeps the `{{ }}` syntax for interpolation within HTML attributes only.
+
+### D4: kebab→snake_case for prop name conversion
+
+`<card :item-count="x">` → `props["item_count"] = x`. Simple `replace("-", "_")`.
+
+**Rationale**: Python component props use snake_case (`TypedDict` with `item_count`). HTML attribute names are conventionally kebab-case.
+
+### D5: Default slot from body content
+
+Body content is parsed and wrapped in a `lambda` generator, matching the `NodeGenerator` signature expected by components.
+
+**Rationale**: Single-element body: passed directly. Multi-element body: wrapped in `FragmentElement` (from Change 2). This matches the existing `slots={"default": lambda: ...}` convention.
+
+### D6: Component attribute interpolation via resolve_attr
+
+Regular (non-`:` prefixed) component attributes MAY contain `{{ }}` interpolation patterns. These SHALL be processed by `resolve_attr` (from Change 1). When the interpolated variable is a `Signal`, the resulting `Computed` SHALL be passed as the prop value, enabling reactive prop updates.
+
+**Rationale**: Consistency with HTML element attributes. Component authors receive a `Computed` prop and read `.value` to access the current interpolated string. The `resolve_attr` function in Change 1 handles both reactive and static evaluation automatically based on whether the interpolated variable is a `SignalBase`.
+
+## Risks / Trade-offs
+
+- **[Risk] Component not found due to missing import** → Mitigation: Clear error message: `"Component 'UserCard' not found. Component tags require PascalCase component function names (e.g., <user-card> resolves to UserCard). If your component is defined with a different name, use the Python API instead. Did you forget to import it? Available: ['Navbar', ...]"`.
+- **[Risk] Name collision with future HTML elements** → Mitigation: Hyphen convention. Unknown non-hyphenated tags are lenient (future-proof).
+- **[Risk] Prop name clashes** (e.g., `data-value` and `data_value` both map to `data_value`) → Mitigation: Document the convention. `replace("-", "_")` is deterministic and predictable.
+- **[Trade-off] No named slots in MVP** → Acceptable. Default slot covers most use cases. Named slots can be added later (e.g., Vue-style `<template #name>` syntax).
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-component-tags/proposal.md
+++ b/openspec/changes/feat-template-component-tags/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+Currently, components must be invoked via Python API (`Card({"title": "Hi"}, slots={...})`) and embedded in templates as variables (`{{ card }}`). This makes component usage look like data interpolation rather than explicit component invocation. Being able to write `<user-card title="Hi">` directly in templates gives developers a declarative, HTML-like way to compose components — matching the experience of Vue, Svelte, and Angular — while keeping the import-based registration explicit in Python.
+
+## What Changes
+
+- Template engine resolves non-HTML tags as component references via `ComponentStore` (DI-based lookup)
+- Kebab-case tag names (`<user-card>`) convert to PascalCase (`UserCard`) for ComponentStore lookup
+- Static props: `title="Hello"` → `props["title"] = "Hello"`
+- Dynamic props: `:count="my_signal"` → `props["count"] = context["my_signal"]` (Signal preserved)
+- Prop name kebab→snake_case conversion: `:item-count="x"` → `props["item_count"]`
+- Component body content becomes the default slot
+- Self-closing syntax (`<user-card />`) supported for slotless components
+- Hyphenated unknown tags raise error (likely missing import), non-hyphenated unknown tags treated as HTML (lenient)
+
+## Capabilities
+
+### New Capabilities
+_None — extends `template-engine`_
+
+### Modified Capabilities
+- `template-engine`: Tag resolution extended to support component lookup via ComponentStore, with static/dynamic prop binding and default slot passthrough
+
+## Known Issues Addressed
+_None — this is a new capability layered on Changes 1-3_
+
+## Non-goals
+- Named slots (only default slot in MVP)
+- Event handlers on component tags (`@click` on `<card>`) — requires special emitter semantics
+- Expression evaluation in static props (always literal strings)
+- Auto-import of component modules (developer must import explicitly for registration)
+
+## Impact
+
+- **Modified file**: `template/_binder.py` — `bind_element` extended with component tag resolution logic
+- **Integration**: ComponentStore accessed via `inject(_COMPONENT_STORE_KEY)` from DI
+- **New helper functions**: `kebab_to_pascal`, `kebab_to_snake` for name conversions
+- **Existing code leveraged**: ComponentGenerator `__call__`, slot generators, Component lifecycle
+- **No breaking changes**: HTML tag handling unchanged, component resolution is a new code path
+
+## Dependencies
+
+- **Depends on**: Change 1 (parser + binder infrastructure including `resolve_attr` with Computed generation for `{{ }}` in component attributes) [required]; Change 2 (FragmentElement for multi-child default slot wrapping) [required]
+- **Required by**: Change 6 (markdown — component tags `<user-card>` in Markdown HTML blocks)
+- **Recommended implementation order**: Third template-engine change (0 → 1 → 2 → **3** → 4 → 5 → 6 → 7)

--- a/openspec/changes/feat-template-component-tags/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-component-tags/specs/template-engine/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Template engine shall resolve non-HTML tags as components via ComponentStore
+
+Tags not in the `HtmlTags` literal SHALL be resolved as component references. The component name SHALL be converted from kebab-case to PascalCase and looked up in the DI-accessible `ComponentStore`.
+
+#### Scenario: Component tag resolution
+- **WHEN** `<user-card>` is used and `UserCard` is registered in the ComponentStore
+- **THEN** the `UserCard` component SHALL be instantiated and embedded as a child element
+
+#### Scenario: Component not found with hyphen
+- **WHEN** `<my-widget>` is used but no component matches in ComponentStore
+- **THEN** `WebComPyException` SHALL be raised with a message that includes the looked-up component name, the available component names, and guidance that component tags require PascalCase component function names (kebab-case tag `<my-widget>` resolves to `MyWidget`)
+
+#### Scenario: Unknown tag without hyphen
+- **WHEN** `<widget>` is used and not found in ComponentStore or HtmlTags
+- **THEN** the tag SHALL be treated as a regular HTML element (`Element("widget", ...)`)
+
+#### Scenario: Self-closing component tag
+- **WHEN** `<user-card title="Hi" />` is used with self-closing syntax
+- **THEN** the component SHALL be instantiated with no default slot content
+
+#### Scenario: HTML tags unaffected
+- **WHEN** `<div>`, `<p>`, `<span>`, etc. are used
+- **THEN** they SHALL continue to be treated as HTML elements (no ComponentStore lookup)
+
+### Requirement: Component tags shall support static and dynamic props
+
+Component attributes SHALL be converted to component props. Plain attributes SHALL be literal strings. `:`-prefixed attributes SHALL be variable references from the context.
+
+#### Scenario: Static prop
+- **WHEN** `<user-card title="Hello">` is used
+- **THEN** `props = {"title": "Hello"}` SHALL be passed to the component
+
+#### Scenario: Dynamic prop with Signal
+- **WHEN** `<user-card :count="my_count">` is used and `my_count` is a Signal
+- **THEN** `props = {"count": context["my_count"]}` SHALL be passed (Signal preserved for reactivity)
+
+#### Scenario: Prop name kebab to snake_case conversion
+- **WHEN** `<user-card :item-count="items">` is used
+- **THEN** the prop name SHALL be converted from `item-count` to `item_count` in the props dict
+
+#### Scenario: Interpolation in component attribute with Signal
+- **WHEN** `<user-card title="Hello {{ name }}">` is used with `name` being a `Signal`
+- **THEN** `resolve_attr` SHALL be called on the attribute parts
+- **AND** a `Computed` SHALL be generated and passed as `props["title"]`
+- **AND** the prop SHALL update reactively when the Signal changes
+
+#### Scenario: Interpolation in component attribute without Signal
+- **WHEN** `<user-card title="Hello {{ name }}">` is used with `name` being `"Alice"`
+- **THEN** the prop value SHALL be the static string `"Hello Alice"`
+
+### Requirement: Component body shall be passed as default slot
+
+The children of a component tag SHALL be parsed and passed as the default slot content.
+
+#### Scenario: Default slot
+- **WHEN** `<user-card title="Hi"><p>Content</p></user-card>` is used
+- **THEN** `slots = {"default": lambda: Element("p", {}, [TextElement("Content")])}` SHALL be passed
+
+#### Scenario: Multiple children in default slot
+- **WHEN** the component body has multiple elements
+- **THEN** they SHALL be wrapped in a `FragmentElement` within the slot generator

--- a/openspec/changes/feat-template-component-tags/tasks.md
+++ b/openspec/changes/feat-template-component-tags/tasks.md
@@ -1,0 +1,59 @@
+## 1. Name Conversion Utilities
+
+- [ ] 1.1 Implement `kebab_to_pascal(kebab: str) -> str` (e.g., `"user-card"` → `"UserCard"`)
+- [ ] 1.2 Implement `kebab_to_snake(kebab: str) -> str` (e.g., `"item-count"` → `"item_count"`)
+
+## 2. Tag Resolution
+
+- [ ] 2.1 Implement `resolve_tag(tag: str, store: ComponentStore)` returning `TagResolution` (NEWLINE, HTML, or COMPONENT)
+- [ ] 2.2 Implement hyphen-based error vs lenient fallback: hyphenated unknown → error, non-hyphenated → HTML element
+- [ ] 2.3 Integrate tag resolution into `bind_element` — intercept before HTML element creation, route to component path or HTML path
+- [ ] 2.4 Implement ComponentStore injection: `store = inject(_COMPONENT_STORE_KEY)` — note that `_COMPONENT_STORE_KEY` is typed `InjectKey[object]` (`di/_keys.py:8`) so the return value is `object` and requires a cast to `ComponentStore`
+
+## 3. Props Binding
+
+- [ ] 3.1 Implement static prop resolution: attribute value used as-is (literal string)
+- [ ] 3.2 Implement dynamic prop resolution: `:-prefixed` attribute → `resolve_var(value, ctx)` → stored in props dict
+- [ ] 3.3 Apply `kebab_to_snake` conversion to prop names before storing
+- [ ] 3.4 Implement `{{ }}` interpolation in regular component attributes using `resolve_attr` (reactive Computed for Signal values, static string for non-Signals)
+
+## 4. Slot Binding
+
+- [ ] 4.1 Implement default slot generation: bind component body children, wrap multi-element in FragmentElement, create lambda generator
+- [ ] 4.2 Pass empty `slots={}` for self-closing tags (no body)
+
+## 5. Component Instantiation
+
+- [ ] 5.1 Call `generator(props, slots=slots)` to create Component instance, returning it as the child element
+
+## 6. Unit Tests
+
+- [ ] 6.1 Test component tag resolution (kebab→PascalCase lookup, successful match)
+- [ ] 6.2 Test component not found with hyphen (error with available names)
+- [ ] 6.3 Test unknown tag without hyphen (lenient HTML fallback)
+- [ ] 6.4 Test self-closing component tag
+- [ ] 6.5 Test static prop binding (string literal)
+- [ ] 6.6 Test dynamic prop binding (variable lookup, Signal preservation)
+- [ ] 6.7 Test prop name kebab→snake_case conversion
+- [ ] 6.8 Test default slot with single child
+- [ ] 6.9 Test default slot with multiple children (FragmentElement wrapping)
+- [ ] 6.10 Test empty default slot (self-closing)
+- [ ] 6.11 Test HTML tags unaffected (no component resolution for `<div>`, etc.)
+- [ ] 6.12 Test `<br>` still maps to NewLine (not component lookup)
+
+## 7. Integration Tests
+
+- [ ] 7.1 Test end-to-end: `render_template` with `<user-card>` in component setup
+- [ ] 7.2 Test component receives reactive Signal via `:prop` and updates when Signal changes
+- [ ] 7.3 Test nested component tags (component inside component)
+
+## 8. SSR & Hydration
+
+- [ ] 8.1 Test `render_app_html_sync(app)` with a component using `<user-card>` in template — verify SSR HTML includes the component's rendered output
+- [ ] 8.2 Test `TestRenderer.render()` with component tags — verify prerendered component nodes have correct `webcompy-component` attribute and `__webcompy_prerendered_node__` flags
+- [ ] 8.3 E2E: verify (a) pre-rendered HTML from `<user-card>` component tag matches expected structure, (b) hydration reuses existing component DOM nodes, (c) reactive prop changes (`:count="signal"`) propagate to the child component after hydration
+
+## 9. CI Review Update
+
+- [ ] 9.1 Update `.opencode/agents/ci-review.md`: add component-tag resolution pattern (DI-based ComponentStore lookup via `_COMPONENT_STORE_KEY`, kebab→PascalCase name conversion, kebab→snake_case prop conversion, hyphen convention for component-vs-HTML disambiguation)
+- [ ] 9.2 Update `AGENTS.md` File→Spec Mapping: `webcompy/template/_binder.py` component tag path → `template-engine` spec

--- a/openspec/changes/feat-template-control-flow/.openspec.yaml
+++ b/openspec/changes/feat-template-control-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-control-flow/design.md
+++ b/openspec/changes/feat-template-control-flow/design.md
@@ -1,0 +1,104 @@
+## Context
+
+Change 1 provides HTML parsing and `{{ }}` interpolation. This change adds control flow blocks (`{% if %}`, `{% for %}`) using Jinja2-compatible syntax. The key challenge is mapping these block constructs to WebComPy's reactive primitives (`switch()`, `repeat()`) while supporting multiple child elements per branch/iteration.
+
+HTMLParser treats `{% %}` directives as plain text data, interleaved with HTML element events. The template engine must scan text nodes for `{% %}` patterns, split them into directive tokens, and restructure the flat element tree into control flow AST nodes (IfNode, ForNode).
+
+The existing `switch()` and `repeat()` functions each expect single-child returns from their generators. To support multiple children per branch/iteration (common in Jinja2 templates), we introduce `FragmentElement` — a minimal `DynamicElement` that transparently renders multiple children without a DOM wrapper.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse `{% if %}`, `{% elif %}`, `{% else %}`, `{% endif %}` into conditional AST nodes
+- Parse `{% for item in items %}`, `{% endfor %}` into loop AST nodes
+- Map reactive Signal conditions to `switch()` (reactive DOM updates)
+- Map static (non-Signal) conditions to truthiness evaluation at bind time
+- Map `ReactiveList`/`ReactiveDict` iterables to `repeat()` (reactive DOM updates)
+- Map plain `list`/`dict` iterables to list comprehension (static)
+- Support multiple children per branch/iteration via `FragmentElement`
+- Support nested control flow (if inside for, for inside if)
+- Support dot notation in conditions and iterable references
+
+**Non-Goals:**
+- `{% else %}` within `{% for %}` (empty-iterable fallback)
+- Expression evaluation in conditions (`{% if x > 0 %}`) — variable reference only
+- `{% extends %}`, `{% block %}`, `{% include %}` — component system handles composition
+- `{# comment #}` syntax — HTML comments already supported
+- `{% set %}`, `{% macro %}`, filters (`|`)
+
+## Decisions
+
+### D1: FragmentElement — transparent DynamicElement wrapper
+
+`FragmentElement(DynamicElement)` holds a list of children and renders them directly in the parent DOM without a wrapper element. It leverages `DynamicElement._render()` which already positions children sequentially and `DynamicElement._node_count` which sums child counts.
+
+**Rationale**: Both `switch()` and `repeat()` require single-child returns from generators. FragmentElement wraps multiple children into a single `ChildNode`-compatible value. Existing `_position_element_nodes` and `_render` infrastructure handles positioning correctly.
+
+**Note**: The class hierarchy is `DynamicElement → ElementWithChildren → ElementAbstract`, NOT `ElementBase` (which extends `ElementWithChildren` as a sibling of `DynamicElement`). The `refactor-element-foundations` change widens `ChildNode` from `ElementBase`-based to `ElementAbstract`-based, making `FragmentElement` (and `SwitchElement` / `RepeatElement` / `MultiLineTextElement`) automatically valid as `ChildNode` without a per-element type-alias addition. The FragmentElement implementation does not need its own `ChildNode` edit.
+
+**Alternatives considered**: Extending `repeat()` API for multi-child returns would add ~5 new overloads. Creating entirely new element types (TemplateIfElement, TemplateForElement) would duplicate `SwitchElement`/`RepeatElement` behavior (~200+ lines each).
+
+### Regex: DIRECTIVE_PATTERN
+
+Control flow directives SHALL be matched by:
+
+```python
+DIRECTIVE_PATTERN = re.compile(
+    r"\{%\s*(?P<directive>if|elif|else|endif|for|endfor)\b(?P<args>[^%]*)%\}"
+)
+```
+
+Directive argument parsing:
+- `if`/`elif`: args = variable path (e.g., `show`, `item.visible`)
+- `for`: args = `item in items` or `key, value in items` — split on ` in ` to extract left-hand side and iterable_path; if left-hand side contains `,`, the loop variables are unpacked as a tuple (e.g., `["key", "value"]`)
+- `else`/`endif`/`endfor`: no args
+The `[^%]*` capture group includes leading/trailing whitespace (e.g., `" show "` for `{% if show %}`). The extracted args SHALL be `.strip()`ed before further processing.
+
+### D2: Two-phase parsing for {% %} blocks
+
+Phase 1: HTMLParser builds element tree (same as Change 1). Phase 2: Text nodes are scanned for `{% %}` patterns, split into directive tokens and literal text. Phase 3: Bracket matching groups directive tokens with their children into IfNode/ForNode AST nodes.
+
+**Rationale**: HTMLParser treats `{% %}` as text. Post-processing the element tree is simpler than modifying HTMLParser's event stream. Bracket matching naturally handles nesting (if inside for, etc.).
+
+### D3: Signal detection for reactive vs static dispatch
+
+`bind_if` and `bind_for` inspect resolved values at bind time. If any condition or iterable is a `SignalBase`, the reactive path (`switch()`/`repeat()`) is taken. Otherwise, static evaluation is performed.
+
+**Rationale**: Single code path per call. The detection is O(n) where n is the number of branches/iterations — negligible. No special syntax needed for reactive vs static — it's automatic based on variable type.
+
+### D4: Multi-child in for body — FragmentElement for reactive, list extension for static
+
+For reactive `{% for %}`, each iteration's body children are wrapped in `FragmentElement` (if >1) and passed to `repeat()`. For static, children are appended directly to the parent's children list.
+
+**Rationale**: `repeat()` requires single `ChildNode` return. FragmentElement satisfies this for the reactive case. For static, direct append avoids the overhead of FragmentElement creation.
+
+### D5: Dot notation in conditions and iterables
+
+The same `resolve_var` function from Change 1 handles dot notation in `{% if item.visible %}` and `{% for item in user.posts %}`.
+
+**Rationale**: Consistency with `{{ }}` interpolation. No new parsing or resolution infrastructure needed.
+
+### D6: Dict key-value unpacking in {% for %}
+
+When the for directive's left-hand side contains a comma (e.g., `{% for key, value in my_dict %}`), the loop variables are split into a tuple and the `repeat()` overload `Callable[[V, K], ChildNode]` is used. The `repeat()` callback receives `(value, key)` in that order (matching the `RepeatElement` signature). The binder maps template variable names by position: `key` → `callback_arg[1]`, `value` → `callback_arg[0]`, and both are added to the per-iteration context.
+
+**Rationale**: The `repeat()` function already supports dict iteration with key access via the `Callable[[V, K], ChildNode]` overload. Adding tuple unpacking in the template syntax surfaces this capability without new element types. Single-variable `{% for value in dict %}` uses the existing `Callable[[V], ChildNode]` overload.
+
+### D7: Mixed Signal and plain values in if-elif chains
+
+When an `{% if %}` / `{% elif %}` chain contains a mix of Signal and plain value conditions (e.g., `{% if signal_a %}A{% elif plain_bool %}B{% endif %}`), the presence of any Signal triggers the reactive path (`switch()`). `SwitchElement._select_generator()` already handles mixed types at runtime — it calls `isinstance(cond, SignalBase)` to decide `.value` extraction vs. direct `truth()` evaluation, and registers `on_after_updating` callbacks only for Signal conditions.
+
+To support mixed-type conditions, `SwitchCasesSignal` (`_switch.py:23`) SHALL be widened from `list[tuple[SignalBase[Any], NodeGenerator]]` to `list[tuple[Any, NodeGenerator]]`. This makes the type alias match the runtime contract in `_select_generator()` (which casts to `list[tuple[SignalBase[Any] | Any, NodeGenerator]]` at `_switch.py:44`). It also achieves consistency with `SwitchCasesSignalList` (`_switch.py:24`), which already uses `Any` for conditions. The public `switch()` function still enforces `SignalBase` via the `SwitchCase` TypedDict (`generators.py:114-116`), so the public API contract is preserved.
+
+**Rationale**: The type alias was narrower than the runtime contract — `_select_generator()` already handles non-Signal conditions via `isinstance`. Widening aligns the type with actual behavior and avoids a `cast()` in binder code. No behavioral change; pure type-level fix.
+
+## Risks / Trade-offs
+
+- **[Risk] `{% %}` bracket matching fails on malformed templates** → Mitigation: Raise clear error with line context. Jinja2 also errors on unmatched `{% %}` blocks.
+- **[Risk] Whitespace around `{% %}` produces extra text nodes** → Mitigation: Browser normalizes whitespace; no visual impact. Jinja2's `trim_blocks` equivalent can be added later.
+- **[Risk] FragmentElement in `_is_patchable` returns False (DynamicElements are never patchable)** → Mitigation: Non-patchable means full redraw, which is expected for conditional branches. No correctness impact.
+- **[Risk] FragmentElement with 0 children** → Mitigation: 0-children case is valid (empty branch). `DynamicElement._render()` handles empty `_children` gracefully.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-control-flow/proposal.md
+++ b/openspec/changes/feat-template-control-flow/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+After establishing the template interpolation foundation in Change 1, the next essential capability is control flow — conditionals and loops. Without `{% if %}` and `{% for %}`, templates are limited to static structure with data interpolation only. Any meaningful UI requires conditional rendering (show/hide elements) and iteration (lists, collections). These map naturally to Jinja2's `{% %}` block syntax, which Python web developers already know.
+
+## What Changes
+
+- Add `{% if var %}` / `{% elif var %}` / `{% else %}` / `{% endif %}` conditional blocks that map to `switch()` for reactive Signal conditions and static evaluation for plain values
+- Add `{% for item in items %}` / `{% endfor %}` loop blocks that map to `repeat()` for `ReactiveList`/`ReactiveDict` and list comprehension for plain iterables
+- Add `FragmentElement` — a minimal `DynamicElement` that renders multiple children transparently without a DOM wrapper, enabling multiple elements per branch/iteration. After `refactor-element-foundations`, `FragmentElement` (an `ElementAbstract` subclass) is automatically a valid `ChildNode`; no separate type-alias edit is needed.
+- Support dot notation (`item.visible`) in conditions and iterable references
+- Support nested control flow (`{% if %}` inside `{% for %}` and vice versa)
+- Support `{% elif %}` and `{% else %}` within `{% if %}` blocks
+
+## Capabilities
+
+### New Capabilities
+_None — all capabilities extend `template-engine` from Change 1_
+
+### Modified Capabilities
+- `template-engine`: Added conditional and loop control flow blocks (`{% if %}`, `{% for %}`), FragmentElement for multi-child support
+
+## Known Issues Addressed
+_None — this is a new capability layered on Change 1_
+
+## Non-goals
+- `{% else %}` within `{% for %}` (empty-iterable fallback)
+- Expression evaluation in conditions (`{% if x > 0 %}`) — variable reference only
+- `{% extends %}`, `{% block %}`, `{% include %}` — component system handles composition
+- `{# comment #}` syntax — HTML comments already supported
+
+## Impact
+
+- **New element**: `FragmentElement(DynamicElement)` in `webcompy/elements/types/_fragment.py`
+- **Type-alias dependency**: Relies on `refactor-element-foundations` which widens `ChildNode` to `ElementAbstract`, making `FragmentElement` automatically valid as a `ChildNode` without a per-element addition
+- **Modified files**: `template/_parser.py` (text splitting for `{% %}`), `template/_ast.py` (IfNode, ForNode), `template/_binder.py` (bind_if, bind_for), `elements/types/_switch.py` (`SwitchCasesSignal` type alias widened from `list[tuple[SignalBase[Any], NodeGenerator]]` to `list[tuple[Any, NodeGenerator]]` — type-only, no behavioral change)
+- **Minimal element system change**: FragmentElement is a simple ~10 line DynamicElement subclass
+- **No breaking changes**: Pure addition
+
+## Dependencies
+
+- **Depends on**: Change 1 (template interpolation — parser, binder, and AST infrastructure); `refactor-element-foundations` (FragmentElement relies on `ChildNode` being `ElementAbstract`-based)
+- **Required by**: Change 3 (component tags — FragmentElement for multi-child slot wrapping), Change 6 (markdown — `{% if %}`/`{% for %}` blocks in Markdown templates), Change 7 (markdown for-expansion — `FragmentElement` for multi-child wrapping, for-loop AST structure)
+- **Recommended implementation order**: Second template-engine change (0 → 1 → **2** → 3 → 4 → 5 → 6 → 7)

--- a/openspec/changes/feat-template-control-flow/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-control-flow/specs/template-engine/spec.md
@@ -1,0 +1,118 @@
+## ADDED Requirements
+
+### Requirement: FragmentElement shall render multiple children transparently without a DOM wrapper
+
+`FragmentElement` SHALL be a `DynamicElement` subclass that has no DOM node of its own and renders its children sequentially in the parent element. After `refactor-element-foundations` (which widens `ChildNode` to `ElementAbstract`), `FragmentElement` is automatically valid as a `ChildNode` without a separate type-alias addition.
+
+#### Scenario: Fragment renders children in parent
+- **WHEN** a `FragmentElement([Element("p", {}, []), Element("span", {}, [])])` is rendered inside a `<div>`
+- **THEN** the `<p>` and `<span>` SHALL be rendered as direct children of the `<div>`
+- **AND** no wrapper DOM node SHALL be created
+
+#### Scenario: Fragment with single child
+- **WHEN** a `FragmentElement` contains exactly one child
+- **THEN** that child SHALL be rendered normally in the parent
+
+#### Scenario: Fragment with zero children
+- **WHEN** a `FragmentElement` contains no children
+- **THEN** nothing SHALL be rendered (no DOM nodes created)
+
+#### Scenario: Fragment with zero children during hydration
+- **WHEN** a `FragmentElement` contains no children and the page is being hydrated
+- **THEN** `_hydrate_node()` SHALL return without creating any DOM nodes
+- **AND** no error SHALL be raised
+
+#### Scenario: Fragment children hydrate via DynamicElement._hydrate_node
+- **WHEN** a `FragmentElement` with children is hydrated
+- **THEN** each child SHALL be hydrated via the standard `DynamicElement._hydrate_node()` path
+- **AND** unmounted children SHALL be scheduled via `AsyncSchedulerPort`
+
+### Requirement: Template engine shall support conditional rendering via {% if %} blocks
+
+`{% if var %}`, `{% elif var %}`, `{% else %}`, `{% endif %}` SHALL provide conditional rendering. Signal conditions SHALL use `switch()` for reactive updates. Non-Signal conditions SHALL be evaluated at bind time.
+
+#### Scenario: Reactive if with Signal condition
+- **WHEN** `{% if show %}...{% endif %}` is used and `show` is a `Signal` in the context
+- **THEN** `switch()` SHALL be generated with the Signal as the case condition
+- **AND** the branch content SHALL update reactively when the Signal changes
+
+#### Scenario: Static if with plain bool
+- **WHEN** `{% if flag %}...{% endif %}` is used and `flag` is `True` (plain bool)
+- **THEN** the branch content SHALL be included in the Element tree
+- **AND** no `switch()` SHALL be generated (non-reactive)
+
+#### Scenario: Static if with falsy value
+- **WHEN** `{% if flag %}...{% endif %}` is used and `flag` is `False`
+- **THEN** no children SHALL be produced for that branch
+
+#### Scenario: If-elif-else chain
+- **WHEN** `{% if a %}A{% elif b %}B{% else %}C{% endif %}` is used
+- **THEN** the first truthy branch SHALL be rendered
+- **AND** if no branch is truthy, the `{% else %}` branch SHALL be rendered
+
+#### Scenario: Multiple elements in branch
+- **WHEN** an `{% if %}` branch contains multiple HTML elements
+- **THEN** the elements SHALL be wrapped in a `FragmentElement` for the `switch()` generator
+
+#### Scenario: Dot notation in condition
+- **WHEN** `{% if item.visible %}` is used
+- **THEN** `resolve_var("item.visible", ctx)` SHALL be called to evaluate the condition
+
+#### Scenario: Mixed Signal and static conditions in if-elif chain
+- **WHEN** an if-elif chain contains both Signal and plain value conditions (e.g., `{% if signal_a %}A{% elif plain_bool %}B{% endif %}`)
+- **THEN** the reactive path (`switch()`) SHALL be used
+- **AND** `SwitchCasesSignal` (`_switch.py:23`) SHALL be widened from `list[tuple[SignalBase[Any], NodeGenerator]]` to `list[tuple[Any, NodeGenerator]]` so that mixed-type conditions can be passed to `SwitchElement.__init__` without a cast
+- **AND** plain value conditions SHALL be evaluated with `truth()` at evaluation time (not wrapped in a Signal)
+
+#### Scenario: Malformed if block (missing endif)
+- **WHEN** `{% if x %}...` has no matching `{% endif %}`
+- **THEN** a `WebComPyException` SHALL be raised
+
+### Requirement: Template engine shall support list iteration via {% for %} blocks
+
+`{% for item in items %}`, `{% endfor %}` SHALL provide iteration. `ReactiveList`/`ReactiveDict` iterables SHALL use `repeat()` for reactive updates. Plain `list`/`dict` SHALL use list comprehension.
+
+#### Scenario: Reactive for with ReactiveList
+- **WHEN** `{% for item in items %}...{% endfor %}` is used and `items` is a `ReactiveList`
+- **THEN** `repeat()` SHALL be generated with the ReactiveList
+- **AND** the list content SHALL update reactively when items are added/removed
+
+#### Scenario: Reactive for with ReactiveDict
+- **WHEN** `{% for value in my_dict %}...{% endfor %}` is used and `my_dict` is a `ReactiveDict`
+- **THEN** `repeat()` SHALL be generated with the ReactiveDict
+
+#### Scenario: Static for with plain list
+- **WHEN** `{% for item in plain_list %}...{% endfor %}` is used and `plain_list` is a `list`
+- **THEN** children SHALL be generated via list comprehension (non-reactive)
+- **AND** no `repeat()` SHALL be used
+
+#### Scenario: Multiple elements per iteration (reactive)
+- **WHEN** the `{% for %}` body contains multiple elements and the iterable is reactive
+- **THEN** each iteration's children SHALL be wrapped in a `FragmentElement` within the `repeat()` template
+
+#### Scenario: Multiple elements per iteration (static)
+- **WHEN** the `{% for %}` body contains multiple elements and the iterable is static
+- **THEN** all elements SHALL be appended directly to the parent's children list
+
+#### Scenario: Loop variable available in body
+- **WHEN** `{% for item in items %}<p>{{ item.name }}</p>{% endfor %}` is used
+- **THEN** `item` SHALL be added to the binding context for the body
+- **AND** `{{ item.name }}` SHALL resolve within the loop body
+
+#### Scenario: Dot notation in iterable reference
+- **WHEN** `{% for post in user.posts %}` is used
+- **THEN** `resolve_var("user.posts", ctx)` SHALL resolve the iterable
+
+#### Scenario: Nested control flow
+- **WHEN** `{% for item in items %}{% if item.visible %}<li>{{ item.name }}</li>{% endif %}{% endfor %}` is used
+- **THEN** the `{% if %}` SHALL be correctly nested inside the `{% for %}` body and evaluated per iteration
+
+#### Scenario: Malformed for block (missing endfor)
+- **WHEN** `{% for item in items %}...` has no matching `{% endfor %}`
+- **THEN** a `WebComPyException` SHALL be raised
+
+#### Scenario: Dict key-value unpacking
+- **WHEN** `{% for key, value in my_dict %}<p>{{ key }}: {{ value }}</p>{% endfor %}` is used with `my_dict` being a `ReactiveDict`
+- **THEN** `repeat()` SHALL be generated using the `Callable[[V, K], ChildNode]` overload
+- **AND** both `key` and `value` SHALL be available as loop variables in the body context
+- **AND** the body SHALL update reactively when dict entries change

--- a/openspec/changes/feat-template-control-flow/tasks.md
+++ b/openspec/changes/feat-template-control-flow/tasks.md
@@ -1,0 +1,66 @@
+## 1. FragmentElement
+
+- [ ] 1.1 Implement `FragmentElement(DynamicElement)` in `packages/webcompy/src/webcompy/elements/types/_fragment.py` (constructor accepts `list[ElementAbstract]`, `_on_set_parent` is no-op). After `refactor-element-foundations`, `FragmentElement` (an `ElementAbstract` subclass) is automatically a valid `ChildNode`; no separate type-alias edit is needed.
+- [ ] 1.2 Test FragmentElement rendering (single child, multiple children, zero children, nested in repeat, nested in switch)
+- [ ] 1.3 Test FragmentElement hydration: zero children (no-op), single child (child hydrated), multiple children (all hydrated in parent)
+
+## 2. Template AST — Control Flow Nodes
+
+- [ ] 2.1 Add `IfNode(branches: list[tuple[str|None, list[TemplateNode]]])` and `ForNode(loop_vars: list[str], iterable_path: str, body: list[TemplateNode])` to `_ast.py` (`loop_vars` is a list to support single variable `["item"]` and tuple unpacking `["key", "value"]`)
+- [ ] 2.2 Add `DIRECTIVE_PATTERN` regex to match `{% if %}`, `{% elif %}`, `{% else %}`, `{% endif %}`, `{% for %}`, `{% endfor %}` with variable path extraction
+- [ ] 2.3 Add `DirectiveToken` types (IfDirective, ElseDirective, EndIfDirective, ForDirective, EndForDirective) for the bracket-matching phase
+
+## 3. Parser — {% %} Block Extraction and Bracket Matching
+
+- [ ] 3.1 Implement text node post-processing: scan `TemplateText` children for `{% %}` patterns, split into `LiteralText` and `DirectiveToken` sequences
+- [ ] 3.2 Implement bracket-matching algorithm: walk children list, match `{% if %}`→`{% endif %}`, `{% for %}`→`{% endfor %}`, group intermediate children into IfNode/ForNode. For `{% for %}`, split the left-hand side on `,` → list of loop variable names (supporting both `"item"` and `"key, value"` tuples)
+- [ ] 3.3 Handle `{% elif %}` and `{% else %}` within `{% if %}` blocks
+- [ ] 3.4 Handle nested control flow (if inside for, for inside if) via recursive application of bracket matching
+- [ ] 3.5 Raise error on malformed blocks (missing endif, missing endfor, mismatched nesting)
+
+## 4. Binder — Control Flow Binding
+
+- [ ] 4.1 Implement `bind_if(node: IfNode, ctx) -> ElementChildren` with Signal detection → `switch()` path vs static truthiness evaluation path
+- [ ] 4.2 Implement `bind_for(node: ForNode, ctx) -> ElementChildren` with Signal detection → `repeat()` + FragmentElement path vs list comprehension path
+- [ ] 4.3 Implement branch/iteration body binding with context extension (loop variable added to context)
+- [ ] 4.4 Implement FragmentElement wrapping for multi-child branches/iterations
+- [ ] 4.5 Implement dict key-value mapping for `{% for key, value in dict %}`: select `repeat()` `Callable[[V, K], ChildNode]` overload, map callback args `(value=args[0], key=args[1])` to loop variable names by position
+- [ ] 4.6 Widen `SwitchCasesSignal` type alias in `packages/webcompy/src/webcompy/elements/types/_switch.py:23` from `list[tuple[SignalBase[Any], NodeGenerator]]` to `list[tuple[Any, NodeGenerator]]` — aligns with runtime behavior in `_select_generator()` and with `SwitchCasesSignalList` which already uses `Any`; pure type-level change
+
+## 5. Unit Tests — Parser Control Flow
+
+- [ ] 5.1 Test `{% if %}` / `{% endif %}` parsing into IfNode (single branch, with elif/else)
+- [ ] 5.2 Test `{% for %}` / `{% endfor %}` parsing into ForNode
+- [ ] 5.3 Test nested control flow parsing (if in for, for in if)
+- [ ] 5.4 Test malformed block error cases
+
+## 6. Unit Tests — Binder Control Flow
+
+- [ ] 6.1 Test reactive if binding (Signal condition → switch generation)
+- [ ] 6.2 Test static if binding (bool/None condition → conditional inclusion)
+- [ ] 6.3 Test if-elif-else chain binding
+- [ ] 6.4 Test reactive for binding (ReactiveList → repeat generation, single child)
+- [ ] 6.5 Test reactive for binding with multiple children (FragmentElement wrapping)
+- [ ] 6.6 Test static for binding (plain list → list comprehension)
+- [ ] 6.7 Test for binding with ReactiveDict
+- [ ] 6.8 Test dict key-value unpacking (`{% for k, v in d %}`) with ReactiveDict — both `k` and `v` available in body
+- [ ] 6.9 Test loop variable scoping (item available in body)
+- [ ] 6.10 Test dot notation in conditions and iterables
+
+## 7. Integration Tests
+
+- [ ] 7.1 Test `render_template` with `{% if %}` and `{% for %}` end-to-end (component setup context)
+- [ ] 7.2 Test nested control flow integration (for containing if)
+- [ ] 7.3 Test multi-element scenarios with FragmentElement in switch and repeat contexts
+- [ ] 7.4 Test switch() truthiness evaluation semantics with Signal conditions
+
+## 8. SSR & Hydration
+
+- [ ] 8.1 Test `render_app_html_sync(app)` with a template component using `{% if %}` / `{% for %}` — verify SSR HTML contains correct branch / repeated elements
+- [ ] 8.2 Test `TestRenderer.render(component)` — verify prerendered nodes from conditional and loop branches have `__webcompy_prerendered_node__` flag
+- [ ] 8.3 E2E: add a template-based demo page under `e2e/core/` with control flow using `static_site` fixture — verify (a) pre-rendered HTML matches conditional branch output, (b) hydration correctly reuses existing DOM nodes, (c) Signal change triggers `switch()` branch switch with correct DOM update
+
+## 9. CI Review Update
+
+- [ ] 9.1 Update `.opencode/agents/ci-review.md`: add `FragmentElement` as a new `DynamicElement` subclass (no DOM node, transparent child rendering, `_is_patchable` returns False, follows `SwitchElement` lifecycle for re-render / deferred `on_after_rendering`)
+- [ ] 9.2 Update `AGENTS.md` File→Spec Mapping: `webcompy/elements/types/_fragment.py` → `elements` spec

--- a/openspec/changes/feat-template-css-text/.openspec.yaml
+++ b/openspec/changes/feat-template-css-text/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-css-text/design.md
+++ b/openspec/changes/feat-template-css-text/design.md
@@ -1,0 +1,85 @@
+## Context
+
+WebComPy's scoped_style system processes CSS as nested Python dicts (`StyleDict`). The `ComponentGenerator.scoped_style` setter and `ReactiveScopedStyle` both use `_process_style_declaration`, `_classify_nested_key`, `_scope_combinator_selector`, and `_generate_css_recursive` helpers (defined in `_generator.py`) to produce scoped CSS strings. The dict structure maps CSS constructs as follows:
+
+- Property declarations: `"property": "value"` (str value)
+- Pseudo-classes/elements: `":hover": { nested }` (dict value, `:` prefix)
+- At-rules: `"@media (...)": { nested }` (dict value, `@` prefix)
+- Combinator selectors: `"sub-selector": { nested }` (dict value, other prefix)
+- At-rule detection: `key.startswith("@")` → `_classify_nested_key` returns `"at-rule"`
+- Pseudo detection: `key.startswith(":")` → returns `"pseudo"`
+- Other nested keys → `"combinator"` (including `@keyframes` percentage selectors like `0%`)
+
+This change introduces a CSS text parser that produces identical `StyleDict` structures from CSS text strings, enabling developers to write CSS in its natural form while reusing all existing scoping logic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse CSS text strings into `StyleDict` structures matching the existing dict format
+- Support all CSS constructs handled by WebComPy's scoped_style system
+- Support `{{ varname }}` interpolation in reactive CSS via `css_text_template`
+- Support file-based CSS loading via `Path`
+- All scoped_style assignment goes through explicit `css_text()` / `css_text_template()` calls
+
+**Non-Goals:**
+- Direct string/Path assignment to `scoped_style` setter (must use `css_text()`)
+- Modification of `ReactiveScopedStyle` or `ComponentGenerator` internals
+- CSS validation/linting
+- Sass/Less/CSS-in-JS
+- `{{ }}` support in static scoped_style (no component context available at module level)
+
+## Decisions
+
+### D1: CSS text → StyleDict conversion, not direct CSS scoping
+
+The CSS parser produces `StyleDict` (nested dict) rather than applying scoping directly to CSS text. This reuses all existing `_process_style_declaration`, `_classify_nested_key`, `_scope_combinator_selector`, and `_generate_css_recursive` logic without duplication.
+
+**Rationale**: The existing dict-based scoping logic is tested and handles all edge cases (combinator splitting, pseudo-scoping, at-rule scoping, `@keyframes` special-casing). Producing `StyleDict` means the parser only needs to handle CSS structural parsing, not scoping semantics.
+
+**Alternatives considered**: Directly inserting `[webcompy-cid-{id}]` into CSS text would require reimplementing the combinator split logic and would duplicate at-rule/pseudo/combinator classification.
+
+### D2: Parenthesis-aware tokenizer for at-rule arguments
+
+The CSS parser uses parenthesis-depth tracking when scanning for delimiters (`:`, `{`, `;`). This prevents `:` inside `@media (max-width: 768px)` from being misidentified as a property declaration.
+
+**Rationale**: Without depth tracking, `max-width: 768px` would split at `:`, breaking the at-rule key. The parser tracks `(`/`)` depth and only considers delimiters at depth 0.
+
+### D3: `{{ }}` resolution before CSS parsing
+
+`css_text_template` resolves `{{ }}` holes in CSS text BEFORE parsing. The resolution uses `resolve_holes` from the shared `_holes.py` module (Change 1).
+
+**Rationale**: CSS `{` and `}` are single braces, while `{{ }}` uses double braces. Resolving `{{ }}` first means the CSS parser never sees double braces — it only sees single braces in their structural role. This mirrors Jinja2's approach to CSS templating.
+
+**Reactive integration path**: The factory function returned by `css_text_template(source, context)` SHALL be a `Callable[[], dict[str, StyleDict]]`. When called, it:
+1. Reads the current values of all Signal dependencies (via `resolve_holes` — which reads Signal `.value` at call time).
+2. Outputs the fully-resolved CSS text string.
+3. Parses the string via the CSS parser and returns the resulting `StyleDict` dict.
+
+This factory SHALL be passed as the argument to `reactive_scoped_style(factory)`. The existing `ReactiveScopedStyle` mechanism wraps the factory in a `Computed(lambda: factory())`. When `_render_css()` evaluates this `Computed`, the factory is called, `resolve_holes` reads Signal `.value` inside the `Computed` closure, and dependency tracking is automatically established. Signal changes dirty the `Computed`, which triggers `_render_css()` re-evaluation through the existing `on_after_updating` callback registered by `ReactiveScopedStyle`.
+
+**Important**: The factory SHALL NOT internally create a `Computed`. All reactivity is achieved through `ReactiveScopedStyle`'s existing `Computed` wrapping of the passed factory.
+
+### D4: Minimal type-level core modification
+
+`css_text()` returns `dict[str, StyleDict]` which matches the existing `scoped_style` setter parameter type (`_generator.py:253`). `css_text_template()` returns `Callable[[], dict[str, StyleDict]]`, which SHALL be directly assignable to `reactive_scoped_style`'s `ReactiveScopedStyleFunc`.
+
+To make this work, the existing `ReactiveScopedStyleFunc` type alias (`_reactive_scoped_style.py:61`) SHALL be corrected from `Callable[[], StyleDict]` to `Callable[[], dict[str, StyleDict]]`. The runtime contract of `render_css()` / `_apply_scope()` iterates `.items()` over the factory return value (`_reactive_scoped_style.py:174,214`), expecting a selector-keyed top-level dict (`dict[str, StyleDict]`), not a bare `StyleDict`. The current alias is a pre-existing type imprecision. No behavioral change — `render_css` and `_apply_scope` are unchanged.
+
+**Rationale**: The user requires explicit `css_text()`/`css_text_template()` calls. Fixing the type alias ensures `css_text_template`'s return type is directly assignable to `ReactiveScopedStyleFunc`, avoiding casts at usage sites. This is a type-only change (one line, no behavioral impact).
+
+### D5: Reuse `_holes.py` for `{{ }}` resolution
+
+The `resolve_holes`, `split_text`, `HOLE_PATTERN`, and `resolve_var` utilities are defined in Change 1's `webcompy/template/_holes.py` shared module. `css_text_template` imports from this module. File loading (`Path` arguments) delegates to Change 4's `_load_file` from `webcompy/template/_files.py`.
+
+**Rationale**: Avoids duplicating the `{{ }}` resolution logic. Change 1's design is updated to include `_holes.py` extraction.
+
+## Risks / Trade-offs
+
+- **[Risk] CSS parser misses edge cases (CSS variables, vendor prefixes, complex selectors)** → Mitigation: Parser returns dict structure; properties and selectors are stored as raw strings. The existing `_process_style_declaration` handles value cleanup. Unknown constructs are preserved as-is.
+- **[Risk] Performance of parsing CSS text on every reactive evaluation** → Mitigation: For static CSS, parsing happens once (module level). For reactive CSS, the `Computed` only re-evaluates on Signal change. The parser operates on small CSS blocks (typical component styles are <50 lines).
+- **[Risk] File-based CSS loading in browser** → Mitigation: `css_text(Path(...))` / `css_text_template(Path(...))` delegates file reading to Change 4's `_load_file` in `_files.py`, which raises `WebComPyException` when `ENVIRONMENT == "pyscript"`. The same rejection applies to CSS file paths in the browser as to HTML template file paths.
+- **[Trade-off] No validation/error reporting on CSS syntax** → Acceptable — the parser is lenient (like HTMLParser). Invalid CSS produces incorrect dicts which produce incorrect scoped CSS. Developers can validate with external tools.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-css-text/proposal.md
+++ b/openspec/changes/feat-template-css-text/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+WebComPy currently requires developers to define scoped CSS as Python nested dictionaries (`".btn": {"color": "red"}`). This is verbose, unnatural for web developers who expect to write regular CSS, and prevents the use of standard CSS tooling. Adding CSS text support lets developers write CSS in its natural form, with Jinja2-style `{{ }}` interpolation for reactive styles that leverage WebComPy's existing scoped_style infrastructure.
+
+## What Changes
+
+- Add a CSS text parser (`css_text`) that converts CSS text strings into the `StyleDict` format used by WebComPy's scoped_style system
+- Add `css_text_template(source, context)` that returns a factory function supporting `{{ varname }}` interpolation with reactive Signal tracking
+- Support all CSS constructs handled by WebComPy's scoped_style: selectors, combinators, pseudo-classes/elements, at-rules (`@media`, `@supports`, `@container`, `@keyframes`), and nested rules
+- Support file-based CSS loading via `Path`
+- `css_text()` and `css_text_template()` provide an alternative CSS-text-based API for creating scoped styles from natural CSS syntax; the existing dict-based `scoped_style` API remains unchanged and fully supported
+- Imports `resolve_holes` / `HOLE_PATTERN` from Change 1's shared `_holes.py` module
+- No existing API changes — purely additive
+
+## Capabilities
+
+### New Capabilities
+_None — extends `template-engine` and `reactive-scoped-style`_
+
+### Modified Capabilities
+- `template-engine`: CSS text parsing and `{{ }}` interpolation for scoped styles
+- `reactive-scoped-style`: `reactive_scoped_style` can be used with `css_text_template` for reactive CSS text
+
+## Known Issues Addressed
+_None_
+
+## Non-goals
+- Direct string/Path assignment to `scoped_style` setter (must use `css_text()`)
+- Modification of `ReactiveScopedStyle` or `ComponentGenerator` internals
+- CSS validation/linting
+- Sass/Less/CSS-in-JS
+- `{{ }}` support in static scoped_style (no component context available at module level)
+
+## Impact
+
+- **New file**: `webcompy/template/_css_parser.py` — CSS text → StyleDict parser (~150 lines)
+- **New file**: `webcompy/template/_css_template.py` — `css_text`, `css_text_template` functions
+- **Shared dependency**: `webcompy/template/_holes.py` (created by Change 1 — `resolve_holes`, `HOLE_PATTERN`)
+- **Type-level core correction (independent of CSS text)**: `_reactive_scoped_style.py` `ReactiveScopedStyleFunc` alias corrected from `Callable[[], StyleDict]` to `Callable[[], dict[str, StyleDict]]` — this is a pre-existing type imprecision fix that aligns the alias with the runtime contract of `render_css()` / `_apply_scope()`; included here because `css_text_template`'s return type becomes directly assignable to `ReactiveScopedStyleFunc` after this correction
+- **No breaking changes**: Existing dict-based scoped_style API unchanged
+
+## Dependencies
+
+- **Depends on**: Change 1 (template interpolation — `_holes.py` shared module with `resolve_holes` / `HOLE_PATTERN`)
+- **Depends on**: Change 4 (file loading — `_load_file` for `Path` support)
+- **Required by**: None
+- **Recommended implementation order**: Fifth template-engine change (0 → 1 → 2 → 3 → 4 → **5** → 6 → 7)

--- a/openspec/changes/feat-template-css-text/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-css-text/specs/template-engine/spec.md
@@ -1,0 +1,77 @@
+## ADDED Requirements
+
+### Requirement: CSS text shall be parsed into scoped style dict structure
+
+The framework SHALL provide a `css_text(source: str | Path) -> dict[str, StyleDict]` function that parses CSS text strings into the existing `StyleDict` (nested dict) format. The parser SHALL handle all CSS constructs supported by WebComPy's scoped_style system, including selectors, combinator selectors, pseudo-classes/elements, at-rules (`@media`, `@supports`, `@container`, `@keyframes`), and nested rules. `textwrap.dedent` SHALL be applied to the source before parsing. The return type `dict[str, StyleDict]` matches the `scoped_style` setter type (`_generator.py:253`).
+
+#### Scenario: Basic selectors and properties
+- **WHEN** `css_text(".btn { color: red; }")` is called
+- **THEN** it SHALL return `{".btn": {"color": "red"}}`
+
+#### Scenario: Pseudo-class nesting
+- **WHEN** `css_text(".btn:hover { background: blue; }")` is called
+- **THEN** it SHALL return `{".btn:hover": {"background": "blue"}}`
+
+#### Scenario: Nested pseudo-class (implicit nesting)
+- **WHEN** `css_text(".btn { color: red; :hover { background: blue; } }")` is called
+- **THEN** it SHALL return `{".btn": {"color": "red", ":hover": {"background": "blue"}}}`
+
+#### Scenario: At-rule
+- **WHEN** `css_text("@media (max-width: 768px) { .btn { font-size: 12px; } }")` is called
+- **THEN** it SHALL return `{"@media (max-width: 768px)": {".btn": {"font-size": "12px"}}}`
+
+#### Scenario: @keyframes
+- **WHEN** `css_text("@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }")` is called
+- **THEN** it SHALL return `{"@keyframes spin": {"0%": {"transform": "rotate(0deg)"}, "100%": {"transform": "rotate(360deg)"}}}`
+
+#### Scenario: Nested at-rules
+- **WHEN** `css_text("@media (max-width: 768px) { @supports (display: grid) { .btn { display: grid; } } }")` is called
+- **THEN** nested at-rules SHALL be parsed into nested dict structure
+
+#### Scenario: Combinator selectors
+- **WHEN** `css_text(".a > .b { color: red; }")` is called
+- **THEN** it SHALL return `{".a > .b": {"color": "red"}}`
+
+#### Scenario: CSS comments stripped
+- **WHEN** `css_text("/* comment */ .btn { color: red; }")` is called
+- **THEN** comments SHALL be stripped and the result SHALL be `{".btn": {"color": "red"}}`
+
+#### Scenario: At-rule with paren-contained colon
+- **WHEN** `@media (max-width: 768px)` contains `:` inside parentheses
+- **THEN** the parser SHALL NOT treat the internal `:` as a property separator
+
+#### Scenario: File loading
+- **WHEN** `css_text(Path("styles/button.css"))` is called in a server environment
+- **THEN** the file SHALL be read and its content parsed as CSS text
+
+#### Scenario: File loading rejected in browser
+- **WHEN** `css_text(Path("styles/button.css"))` is called in a PyScript browser environment
+- **THEN** `WebComPyException` SHALL be raised with a message recommending inline CSS strings (inherited from Change 4's `_load_file`)
+
+### Requirement: CSS text templates shall support {{ }} variable interpolation
+
+The framework SHALL provide a `css_text_template(source: str | Path, context: dict) -> Callable[[], dict[str, StyleDict]]` function. The returned factory SHALL resolve `{{ varname }}` holes from the context using `resolve_holes` (from `_holes.py`), parse the resolved CSS text to `dict[str, StyleDict]`, and be suitable for use with `reactive_scoped_style`. `ReactiveScopedStyleFunc` (`_reactive_scoped_style.py:61`) SHALL be corrected from `Callable[[], StyleDict]` to `Callable[[], dict[str, StyleDict]]` so that `css_text_template`'s return type is directly assignable. This aligns the alias with the runtime contract of `render_css()` / `_apply_scope()` which iterate `.items()` over the factory return value (selector-keyed top-level dict).
+
+#### Scenario: Factory resolves {{ }} before parsing
+- **WHEN** `css_text_template(".btn { color: {{ color }}; }", {"color": Signal("blue")})` returns a factory
+- **AND** the factory is called
+- **THEN** `{{ color }}` SHALL be resolved to `"blue"` by reading `color.value`
+- **AND** the result SHALL be `{".btn": {"color": "blue"}}`
+
+#### Scenario: Signal dependency tracking in factory
+- **WHEN** the returned factory is wrapped in `reactive_scoped_style` (creating a `Computed`)
+- **AND** a referenced Signal changes
+- **THEN** the `Computed` SHALL re-evaluate the factory, re-resolve `{{ }}`, and re-parse CSS
+- **AND** the `<style>` element SHALL update reactively
+
+#### Scenario: Factory with file source
+- **WHEN** `css_text_template(Path("styles/dynamic.css"), context)` returns a factory
+- **THEN** each factory call SHALL read the file, resolve `{{ }}`, and parse CSS
+
+### Requirement: css_text and css_text_template shall be exported from webcompy.template
+
+Both `css_text` and `css_text_template` SHALL be importable from `webcompy.template`.
+
+#### Scenario: Import
+- **WHEN** a developer writes `from webcompy.template import css_text, css_text_template`
+- **THEN** both functions SHALL be available

--- a/openspec/changes/feat-template-css-text/tasks.md
+++ b/openspec/changes/feat-template-css-text/tasks.md
@@ -1,0 +1,58 @@
+## 1. CSS Parser Implementation
+
+- [ ] 1.1 Implement `parse_css(text: str) -> StyleDict` in `webcompy/template/_css_parser.py`
+- [ ] 1.2 Implement comment stripping: `re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)`
+- [ ] 1.3 Implement `read_key` with parenthesis-depth tracking for `(`, `)` to handle at-rule arguments
+- [ ] 1.4 Implement `read_braced` with brace-depth matching for `{`, `}` to extract nested blocks
+- [ ] 1.5 Implement `parse_block_content` distinguishing properties (delimited by `;`) from nested rules (delimited by `{}`)
+- [ ] 1.6 Implement `textwrap.dedent` application before parsing
+
+## 2. CSS Template Functions
+
+- [ ] 2.1 Implement `css_text(source: str | Path) -> dict[str, StyleDict]` in `webcompy/template/_css_template.py`
+- [ ] 2.2 Implement `css_text_template(source: str | Path, context: dict) -> Callable[[], dict[str, StyleDict]]`
+- [ ] 2.3 Import `resolve_holes` from `webcompy.template._holes` (shared module created by Change 1)
+- [ ] 2.4 Import `_load_file` from `webcompy.template._files` (shared module created by Change 4); resolve `Path` arguments to strings via `_load_file(source)` before parsing
+- [ ] 2.5 Correct `ReactiveScopedStyleFunc` type alias in `packages/webcompy/src/webcompy/components/_reactive_scoped_style.py:61` from `Callable[[], "StyleDict"]` to `Callable[[], "dict[str, StyleDict]"]` — matches the runtime contract of `render_css()` / `_apply_scope()` which iterate `.items()` over the factory return value; type-only change (no behavioral effect)
+
+## 3. Public API
+
+- [ ] 3.1 Export `css_text`, `css_text_template` from `webcompy.template.__init__`
+
+## 4. Unit Tests — CSS Parser
+
+- [ ] 4.1 Basic selectors (`.class`, `#id`, `element`, `*`)
+- [ ] 4.2 Combinator selectors (`.a > .b`, `.a + .b`, `.a ~ .b`, `.a .b`)
+- [ ] 4.3 Pseudo-classes (`:hover`, `:focus`, `:nth-child(n)`, `:not(sel)`)
+- [ ] 4.4 Pseudo-elements (`::before`, `::after`, `::placeholder`)
+- [ ] 4.5 At-rules (`@media`, `@supports`, `@container`)
+- [ ] 4.6 `@keyframes` with percentage selectors (`0%`, `100%`, `from`, `to`)
+- [ ] 4.7 Nested at-rules (at-rule inside at-rule)
+- [ ] 4.8 Mixed properties and nested rules in one block
+- [ ] 4.9 Comments (`/* ... */`) stripped correctly
+- [ ] 4.10 Multi-value properties (`font-family: a, b, c`)
+- [ ] 4.11 CSS variables (`--custom: value`) preserved as raw strings
+
+## 5. Unit Tests — Template Functions
+
+- [ ] 5.1 `css_text` with plain CSS string returns correct `dict[str, StyleDict]`
+- [ ] 5.2 `css_text` with `Path` loads and parses file content
+- [ ] 5.3 `css_text` with `Path` in PyScript browser environment raises `WebComPyException` (inherited from Change 4)
+- [ ] 5.4 `css_text_template` resolves `{{ }}` in CSS text
+- [ ] 5.5 `css_text_template` factory tracks Signal dependencies (Signal change → new `dict[str, StyleDict]`)
+- [ ] 5.6 `css_text_template` returns `Callable[[], dict[str, StyleDict]]` type compatible with `reactive_scoped_style`
+- [ ] 5.7 `textwrap.dedent` applied to CSS text
+
+## 6. Integration Tests
+
+- [ ] 6.1 Component with `css_text()` static scoped_style
+- [ ] 6.2 Component with reactive CSS text (`css_text_template` + `reactive_scoped_style`)
+- [ ] 6.3 Reactive style updates `<style>` element on Signal change
+- [ ] 6.4 File-based CSS loading (server environment)
+- [ ] 6.5 Backward compat: dict `scoped_style` unchanged
+- [ ] 6.6 Backward compat: dict factory in `reactive_scoped_style` unchanged
+
+## 7. CI Review Update
+
+- [ ] 7.1 Update `.opencode/agents/ci-review.md`: add CSS text template patterns
+- [ ] 7.2 Update `AGENTS.md` File→Spec Mapping: `webcompy/template/_css_parser.py` and `_css_template.py` → `template-engine` spec

--- a/openspec/changes/feat-template-file-loading/.openspec.yaml
+++ b/openspec/changes/feat-template-file-loading/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-file-loading/design.md
+++ b/openspec/changes/feat-template-file-loading/design.md
@@ -1,0 +1,79 @@
+## Context
+
+Change 1's `render_template` accepts `source: str`. Developers must embed templates as Python strings. For production applications with complex templates, separate `.html` files are preferred — they enable HTML tooling, designer collaboration, and cleaner separation of concerns.
+
+The main constraint is dual-environment support: server (standard Python with filesystem access) vs browser (PyScript without filesystem). The browser environment cannot use `Path.read_text()`, so file-based templates are server-only for MVP with a future build-time inlining option.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Accept `pathlib.Path` as source argument to `render_template`
+- Load files synchronously on server (standard Python)
+- Reject file paths in browser with helpful error message
+- Resolve relative paths against caller module directory
+- Skip file read caching for dev server responsiveness
+
+**Non-Goals:**
+- Browser file loading (future: build-time inlining)
+- Template file watching/auto-reload
+- Binary/encoded template loading (UTF-8 only)
+- Asynchronous file loading
+
+## Decisions
+
+### D1: `str | Path` union type for source parameter
+
+`render_template` accepts `source: str | Path`. String sources go through existing path; Path sources trigger file loading.
+
+**Rationale**: Clean API. Single function with type-based dispatch. No need for separate `render_template_from_file` function.
+
+### D2: `_load_file` as shared module in `_files.py`
+
+`_load_file(path: Path) -> str` and `_find_caller_dir() -> str | None` SHALL be defined in `webcompy/template/_files.py`. This module has no imports from other template submodules (only `inspect`, `os`, `pathlib`, `webcompy`, and `webcompy.utils._environment`), making it a clean leaf module importable from `__init__.py`, `_css_template.py`, and anywhere else that needs file loading.
+
+**Rationale**: Change 5's `_css_template.py` needs `_load_file` for `css_text(Path(...))`. If `_load_file` were in `__init__.py`, importing it from `_css_template.py` would create a circular import (`__init__.py` → `_css_template.py` → `__init__.py`). Extracting to `_files.py` (a leaf with no template-internal imports) resolves this cleanly. Change 6's `render_markdown` (also in `__init__.py`) benefits from the same extraction.
+
+### D3: Caller-module-relative path resolution
+
+Relative paths are resolved against the directory of the calling Python module, using `inspect.stack()` to find the caller's `__file__`.
+
+**Frame-skipping strategy**: `inspect.stack()` returns frames starting from the innermost call. Framework-internal frames (`_load_file`, `render_template`, `render_markdown`) whose filenames are within the `webcompy` package directory SHALL be skipped. The first frame whose filename is outside the `webcompy` package SHALL be treated as the caller.
+
+```python
+import inspect
+import os
+import webcompy
+
+_webcompy_root = os.path.dirname(webcompy.__file__)
+
+def _find_caller_dir() -> str | None:
+    for frame_info in inspect.stack()[2:]:  # skip _find_caller_dir itself + _load_file
+        if _webcompy_root not in frame_info.filename:
+            return os.path.dirname(frame_info.filename)
+    return None
+```
+
+**Rationale**: Natural convention — templates placed next to their component module files. Moving the module and its templates together preserves relative paths. The frame-skipping loop handles the variable-depth indirection (e.g., `render_markdown` → `_load_file` has more frames than `render_template` → `_load_file`).
+
+**Fallback**: If `inspect.stack()` fails or all frames belong to the framework (possible in PyScript or tooling contexts), treat the path as relative to the current working directory (`os.getcwd()`).
+
+### D4: No file read caching
+
+Template file contents are read on every `render_template` call. Only the parsed Template AST is cached (by content string, as in Change 1).
+
+**Rationale**: During development, template files change frequently. Re-reading ensures dev server picks up changes without restart. In production, only one read per component setup occurs (AST cache handles subsequent calls).
+
+### D5: Browser rejection with helpful error
+
+When `ENVIRONMENT == "pyscript"`, file path arguments raise `WebComPyException` with a message suggesting inline strings.
+
+**Rationale**: Clear, actionable error. Future: build-time inlining converts file references to string constants before browser deployment.
+
+## Risks / Trade-offs
+
+- **[Risk] `inspect.stack()` PyScript compatibility** → Mitigation: Wrapped in try/except with `os.getcwd()` fallback (see D2 frame-skipping strategy). Spike to verify before implementation.
+- **[Risk] File I/O per component setup could be slow in SSG** → Mitigation: SSG renders each page once; file reads are negligible compared to network/JS loading. For large SSG sites, AST caching (by content) still applies.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-file-loading/proposal.md
+++ b/openspec/changes/feat-template-file-loading/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+Change 1 requires template strings to be inline in Python source. For larger templates or team workflows where designers work with HTML files directly, it's essential to support loading templates from separate `.html` files. Separating templates from Python also improves readability and enables standard HTML tooling (syntax highlighting, validation) without Jinja2-specific editor extensions.
+
+## What Changes
+
+- Extend `render_template` to accept `pathlib.Path` as the first argument
+- Load file content synchronously on the server using `Path.read_text(encoding="utf-8")`
+- Reject file paths in the browser (PyScript) environment with a helpful error message pointing to inline strings
+- Resolve relative paths against the calling Python module's directory
+- Do NOT cache file reads (dev server should pick up template changes without restart)
+
+## Capabilities
+
+### New Capabilities
+_None — extends `template-engine`_
+
+### Modified Capabilities
+- `template-engine`: `render_template` source argument extended to accept `str | Path`
+
+## Known Issues Addressed
+_None_
+
+## Non-goals
+- Browser file loading (future: build-time inlining)
+- Template file watching/auto-reload
+- Binary/encoded template loading (UTF-8 only)
+- Asynchronous file loading
+
+## Impact
+
+- **New file**: `template/_files.py` — `_load_file` helper and `_find_caller_dir` utility (extracted to shared module to avoid circular imports with `_css_template.py` in Change 5)
+- **Modified file**: `template/__init__.py` — `render_template` signature change, delegates to `_load_file` from `_files.py`
+- **New behavior**: Path resolution via `inspect.stack()` for server, feature detection for browser
+- **No new dependencies**: Uses stdlib `pathlib` and `inspect`
+- **No breaking changes**: String-based usage unchanged
+
+## Dependencies
+
+- **Depends on**: Change 1 (template interpolation — `render_template` API)
+- **Required by**: Change 5 (css-text — `css_text(Path)` uses `_load_file`), Change 6 (markdown — `render_markdown(Path)` uses `_load_file`)
+- **Recommended implementation order**: Fourth template-engine change (0 → 1 → 2 → 3 → **4** → 5 → 6 → 7) — can be implemented at any time after Change 1

--- a/openspec/changes/feat-template-file-loading/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-file-loading/specs/template-engine/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Template engine shall accept file paths as template source
+
+`render_template(source: str | Path, context: dict[str, Any])` SHALL accept `pathlib.Path` objects as the source argument. The file SHALL be read and its content used as the template string.
+
+#### Scenario: File loading on server
+- **WHEN** `render_template(Path("templates/card.html"), ctx)` is called in a standard Python environment
+- **THEN** the file SHALL be read using `Path.read_text(encoding="utf-8")`
+- **AND** the file content SHALL be parsed as a template string
+
+#### Scenario: File loading in browser
+- **WHEN** `render_template(Path("templates/card.html"), ctx)` is called in a PyScript browser environment
+- **THEN** `WebComPyException` SHALL be raised with a message recommending inline string templates
+
+#### Scenario: Inline string unchanged
+- **WHEN** `render_template("<div>{{ x }}</div>", ctx)` is called with a string source
+- **THEN** behavior SHALL be identical to Change 1 (no regression)
+
+### Requirement: File paths shall be resolved relative to the calling module
+
+Relative `Path` arguments SHALL be resolved against the directory of the calling Python module.
+
+#### Scenario: Relative path resolution
+- **WHEN** `render_template(Path("templates/card.html"), ctx)` is called from `/app/components/page.py`
+- **THEN** the file SHALL be searched at `/app/components/templates/card.html`
+
+### Requirement: File reads shall not be cached
+
+Template file content SHALL be read fresh on each `render_template` call. Only the parsed Template AST SHALL be cached by content string.
+
+#### Scenario: File change during development
+- **WHEN** a template file is modified between two `render_template` calls
+- **THEN** the second call SHALL read the updated file content

--- a/openspec/changes/feat-template-file-loading/tasks.md
+++ b/openspec/changes/feat-template-file-loading/tasks.md
@@ -1,0 +1,24 @@
+## 1. File Loading Module (_files.py)
+
+- [ ] 1.1 Create `webcompy/template/_files.py` — leaf module with no imports from other template submodules
+- [ ] 1.2 Implement `_find_caller_dir() -> str | None`: use `inspect.stack()` with frame-skipping (skip frames inside `webcompy` package), return first non-framework caller's directory
+- [ ] 1.3 Implement `_load_file(path: Path) -> str`: check `ENVIRONMENT`, raise `WebComPyException` for PyScript with helpful message, resolve relative path via `_find_caller_dir()`, read with `Path.read_text(encoding="utf-8")`
+- [ ] 1.4 Add fallback path resolution when `inspect.stack()` fails (use `os.getcwd()`)
+
+## 2. Public API Integration
+
+- [ ] 2.1 Update `render_template` signature in `template/__init__.py` to `source: str | Path`; import `_load_file` from `_files.py` and dispatch based on `isinstance(source, Path)`
+- [ ] 2.2 Ensure string-based usage unchanged (no regression)
+
+## 3. Unit Tests
+
+- [ ] 3.1 Test file loading with valid Path (server environment, tempfile)
+- [ ] 3.2 Test file loading with relative Path → caller-module resolution
+- [ ] 3.3 Test file loading with absolute Path
+- [ ] 3.4 Test browser environment rejection (mock `ENVIRONMENT == "pyscript"`)
+- [ ] 3.5 Test inline string source still works (no regression)
+- [ ] 3.6 Test file content change between calls (non-cached reads)
+
+## 4. Spike
+
+- [ ] 4.1 Verify `inspect.stack()` functionality in PyScript environment; document fallback behavior

--- a/openspec/changes/feat-template-interpolation/.openspec.yaml
+++ b/openspec/changes/feat-template-interpolation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-interpolation/design.md
+++ b/openspec/changes/feat-template-interpolation/design.md
@@ -1,0 +1,102 @@
+## Context
+
+WebComPy currently requires developers to define component templates via Python API calls (`html.DIV({...}, ...)`). This is verbose for simple structures and unfamiliar to web developers who expect to write HTML. The framework has no HTML parsing or template engine infrastructure.
+
+The existing element system handles reactivity through direct type-based dispatch: `TextElement` accepts `SignalBase` for reactive text, `ElementBase._init_new_node` registers `on_after_updating` callbacks for Signal-valued attributes, and `_create_child_element` wraps `str`/`SignalBase` children into `TextElement`. A template engine can leverage these existing mechanisms by producing Element trees with the same type semantics.
+
+Key constraints:
+- No external dependencies (stdlib only) — must use `html.parser.HTMLParser`
+- Must work in both server (standard Python) and browser (PyScript/Emscripten) environments
+- Must produce `Element` instances (not strings), preserving Signal reactivity
+- Root template must be a single `Element` (enforced by `Component.__init_component`)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse HTML template strings into WebComPy Element trees using stdlib `html.parser.HTMLParser`
+- Support `{{ varname }}` interpolation in text content — Signal values passed through for reactive updates
+- Support `{{ varname }}` interpolation in attribute values — Signals produce reactive `Computed` values, non-Signals produce static strings
+- Support dot notation `{{ a.b.c }}` for dict/attribute access
+- Support `@event="handler_var"` for event handler binding
+- Support `:ref="ref_var"` for DomNodeRef binding
+- Accept `locals()` or explicit dict as variable context
+- Cache compiled Template ASTs per template string
+- Reject `<script>`, `<style>`, and other CDATA elements for security
+- Handle void elements (`<br>`, `<img>`, `<input>`, etc.), boolean attributes, and HTML comments
+- Enforce single root element with whitespace trimming
+
+**Non-Goals:**
+- Control flow blocks (`{% if %}`, `{% for %}`) — deferred to Change 2
+- File-based template loading (`Path` argument) — deferred to Change 4
+- Component tag resolution (`<my-component>`) — deferred to Change 3
+- Expression evaluation (`{{ x + y }}`, filters, etc.) — variable name reference only
+- Template inheritance or includes
+
+## Decisions
+
+### D1: Use `html.parser.HTMLParser` with `convert_charrefs=True`
+
+**Rationale**: `HTMLParser` is the only stdlib HTML parser with real-world HTML tolerance. `xml.etree.ElementTree` and `xml.dom.minidom` require well-formed XML and reject common HTML patterns (unclosed `<br>`, boolean attributes, etc.). `convert_charrefs=True` (default since Python 3.5) pre-resolves HTML entities, simplifying downstream processing.
+
+**Alternatives considered**: `string.Template` and `string.Formatter` cannot parse HTML structure (flat text only). External libraries (Jinja2, lxml, BeautifulSoup) violate the no-dependency constraint.
+
+### D2: Two-phase processing: Compile (parse → AST) then Bind (AST + context → Element tree)
+
+**Rationale**: Separating parsing from binding enables caching of Template ASTs. The AST is immutable per template string and can be reused across multiple component renderings. The bind phase is context-dependent and runs per component setup.
+
+**Shared pipeline**: A `_render_nodes(source, context) -> list[ElementAbstract]` function SHALL be exposed for internal reuse. Both `_render_nodes` and `render_template` SHALL reside in `template/__init__.py`. This function performs dedent → cache → parse → bind without single-root validation, returning all root nodes as a list. `render_template` wraps `_render_nodes` with the single-root `Element` assertion. This enables `render_markdown` (Change 6) to reuse the parser and binder while handling multi-root Markdown documents.
+
+**Shared `_holes.py` module**: The interpolation utilities — `HOLE_PATTERN` regex, `LiteralText`/`Hole` dataclasses, `split_text()`, `resolve_var()`, and `resolve_holes()` — SHALL reside in `webcompy/template/_holes.py`. This module has no imports from other template modules (avoids circular dependencies) and is shared by `_ast.py` (text splitting), `_binder.py` (variable resolution), and Change 5's CSS text pipeline (`css_text_template`). `_ast.py` imports `LiteralText` and `Hole` from `_holes.py` to define `TemplateText`.
+
+### D3: Signal objects passed through directly to `TextElement` for text interpolation
+
+**Rationale**: `TextElement.__init__` already handles `SignalBase` by registering an `on_after_updating` callback. Passing the Signal object directly (rather than extracting `.value`) preserves reactivity. Non-Signal values (str, int, Element instances) are handled by `_create_child_element`'s existing type-based dispatch.
+
+### D4: Reactive attribute evaluation via `Computed` for Signal-valued attributes
+
+When one or more `{{ }}` holes in an attribute value reference a `SignalBase`, a `Computed` SHALL be generated that produces the full attribute string reactively. The `Computed` closure captures the resolved variable references from the context at bind time, and the `Computed`'s dependency tracking automatically picks up Signal references. The `Computed` is passed as the attribute value to `Element`, leveraging the existing `_init_new_node` / `_generate_attr_updater` mechanism for reactive DOM attribute updates.
+
+When no Signal is referenced in the attribute holes, static string evaluation SHALL be used (no `Computed` created).
+
+**Rationale**: The existing element system already supports reactive attributes: `ElementBase._init_new_node` checks `isinstance(value, SignalBase)` and registers `on_after_updating` callbacks. By returning a `Computed` signal instead of a plain string, the template engine leverages this built-in mechanism without any element system changes.
+
+**API choice**: The template engine SHALL use `Computed(fn)` from `webcompy.signal` (Tier 2 — Internal constructor API) rather than `use_computed()` from `webcompy` top-level (Tier 1 — Public composable API). This follows the two-tier API defined in `composables/spec.md:64-81`: the template engine is framework infrastructure, not user-facing component setup code. `Computed()` does not emit warnings, does not participate in SSR transfer (derived values recompute on the browser), and is the correct API for framework-internal signal creation.
+
+**Signal detection**: Before creating a `Computed`, all `{{ }}` holes are checked: if any resolved variable is a `SignalBase`, the `Computed` path is taken. If none are Signals, the static path is used. This avoids unnecessary `Computed` object creation for purely static attributes (common case).
+
+### D5: Reject `<script>`, `<style>`, and CDATA elements
+
+**Rationale**: HTMLParser treats these as CDATA content elements, delivering their entire content as a single `handle_data` blob. This bypasses the template engine's interpolation scanning. Additionally, `<script>` poses XSS risks and `<style>` poses CSS injection risks. WebComPy provides `scoped_style` for component CSS and `raw_html()` for controlled raw HTML insertion.
+
+### D6: Void element tracking and `<br>` special-casing
+
+**Rationale**: `HTMLParser` does NOT auto-close void elements — it calls `handle_starttag` without a matching `handle_endtag`. The tree builder must maintain a `VOID_ELEMENTS` set to avoid pushing void elements onto the element stack. `<br>` receives special treatment (`NewLine()` instead of `Element("br")`) because `"br"` is not a valid `HtmlTags` literal in WebComPy.
+
+**Tag name type casting**: Since `Element.__init__` and `create_element` accept `tag_name: HtmlTags` (a `Literal[...]`), the binder SHALL cast parsed tag names via `cast("HtmlTags", tag_name)` for all element creation. This is consistent with `Element.__init__`'s own internal cast (`cast("HtmlTags", tag_name.lower())` at `_element.py:164`). The cast is safe: the HTML parser produces syntactically valid tag names, and `Element.__init__` already accepts arbitrary strings at runtime.
+
+### Regex: HOLE_PATTERN
+
+Variable interpolation holes SHALL be matched by:
+
+```python
+HOLE_PATTERN = re.compile(r"\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}")
+```
+
+Each path segment MUST start with a letter or underscore (`[a-zA-Z_]`) followed by zero or more word characters (`\w*`), matching Python identifier rules. This rejects `{{123}}` (digit-first), `{{}}` (empty), and `{{` without closing `}}` as literal text — they will not be captured by the pattern. The group captures the full dot-notation path (e.g., `"user.name"` from `{{ user.name }}`) for resolution via `resolve_var`.
+
+### D7: `textwrap.dedent` for indented triple-quoted strings
+
+**Rationale**: Triple-quoted template strings from Python source have common leading whitespace. `textwrap.dedent` removes this without affecting template structure. Leading/trailing whitespace-only text nodes around the root element are stripped.
+
+## Risks / Trade-offs
+
+- **[Risk] HTMLParser may behave differently in PyScript** → Mitigation: Spike to verify HTMLParser functionality in PyScript before implementation. Fallback: all stdlib modules are available in Pyodide.
+- **[Risk] Template parse errors produce confusing messages** → Mitigation: Catch `HTMLParser` exceptions and re-raise with template-source context (line numbers if available).
+- **[Risk] Large templates with many `{{ }}` holes may have performance impact** → Mitigation: `_create_child_element` and `TextElement` construction are O(1). The compile cache eliminates re-parsing cost. No virtual DOM diffing — direct updates only.
+- **[Risk] Computed lifecycle management for reactive attributes** → Mitigation: The `Computed` is passed as an attribute value to an `Element`, which registers an `on_after_updating` consumer callback. When the Element is destroyed (`_remove_element` → `consumer_destroy` on callback nodes), the downstream consumer edge is cleaned up. The `Computed` itself becomes garbage-collectable when the Element is GC'd. This is the same lifecycle path as any user-provided `SignalBase`-valued attribute; no new cleanup mechanism is needed.
+- **[Note] `locals()` captures `ctx` (ComponentContext) and all local variables** → When `locals()` is used as the context, the component's `ctx` parameter and any framework-injected locals become accessible from the template (e.g., `{{ ctx }}`). This is not dangerous — `TextElement` safely converts to string — but developers should be aware that the entire local scope is exposed. Explicit dicts can be used instead for tighter control.
+- **[Note] Module-level `_template_cache` is unbounded** → The cache (`_cache.py`) stores compiled ASTs keyed by source string. No eviction policy (size limit, LRU) is implemented in MVP. Distinct template strings are bounded in typical applications (each is a compile-time constant), so unbounded growth is unlikely. A future enhancement could add `functools.lru_cache` semantics or a size cap.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-interpolation/proposal.md
+++ b/openspec/changes/feat-template-interpolation/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+WebComPy currently requires developers to define component templates using only the Python element API (`html.DIV({...}, ...)`). Compared to other frontend frameworks that allow defining templates in HTML, this is a clear weakness — it makes simple UI structures verbose, reduces accessibility for non-Python web developers, and prevents the use of standard HTML tooling. Adding an HTML template engine that parses template strings into WebComPy's reactive Element tree bridges this gap while preserving the framework's reactivity model.
+
+## What Changes
+
+- Add a new `webcompy/template/` module with a public `render_template` API
+- Implement HTML-to-Element-tree parsing using `html.parser.HTMLParser` (stdlib only, no external dependencies)
+- Support `{{ varname }}` and `{{ a.b.c }}` variable interpolation in text content — Signal objects are passed through directly to `TextElement` for reactive updates
+- Support `{{ varname }}` variable interpolation in attribute values — Signals produce reactive `Computed` values (auto-dependency-tracking), non-Signals produce static strings
+- Support `@event="handler_var"` event handler binding from template context
+- Support `:ref="ref_var"` DomNodeRef binding from template context
+- Support `locals()` and explicit dict as variable context
+- Reject `<script>`, `<style>`, and other CDATA content elements in templates for security
+- Handle void elements (`<br>`, `<img>`, `<input>`, etc.), boolean attributes, and HTML comments correctly
+- Apply `textwrap.dedent` to template strings for clean indented source
+- Extract a shared `_holes.py` module for interpolation utilities (`HOLE_PATTERN`, `LiteralText`/`Hole` dataclasses, `split_text()`, `resolve_var()`, `resolve_holes()`) used by the parser, binder, and CSS text pipeline (Change 5)
+- Cache compiled Template ASTs per template string
+
+## Capabilities
+
+### New Capabilities
+- `template-engine`: HTML template parsing and variable interpolation that produces reactive WebComPy Element trees
+
+### Modified Capabilities
+_None — new capability, no existing spec changes_
+
+## Known Issues Addressed
+_None_
+
+## Non-goals
+- Control flow blocks (`{% if %}`, `{% for %}`) — deferred to Change 2
+- File-based template loading (`Path` argument) — deferred to Change 4
+- Component tag resolution (`<my-component>`) — deferred to Change 3
+- Expression evaluation (`{{ x + y }}`, filters, etc.) — variable name reference only
+- Template inheritance or includes
+- Template cache eviction policy (size limit, LRU) — unbounded cache is acceptable for compile-time constant templates; `functools.lru_cache` integration deferred to future enhancement
+
+## Impact
+
+- **New package**: `packages/webcompy/src/webcompy/template/` (core package, no external dependency)
+- **New files**: `__init__.py`, `_holes.py`, `_parser.py`, `_ast.py`, `_binder.py`, `_cache.py`
+- **Related specs**: `elements/spec.md` (TextElement, Element, create_element — leveraged, not modified)
+- **Both environments**: Works in server (SSR/SSG) and browser (PyScript) — HTMLParser is stdlib
+- **No breaking changes**: Pure addition, existing Python API unchanged
+
+## Dependencies
+
+- **Depends on**: `refactor-element-foundations` (resolved before implementation; no direct technical dependency)
+- **Required by**: Change 2 (control flow), Change 4 (file loading), Change 3 (component tags — `resolve_attr` with Computed generation for component props), Change 5 (css-text — `_holes.py` shared module), Change 6 (markdown — `render_template` / `_render_nodes` pipeline), Change 7 (markdown for-expansion — `_render_nodes` shared pipeline, `_holes.resolve_var`)
+- **Recommended implementation order**: First template-engine change (0 → **1** → 2 → 3 → 4 → 5 → 6 → 7)

--- a/openspec/changes/feat-template-interpolation/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-interpolation/specs/template-engine/spec.md
@@ -1,0 +1,188 @@
+## ADDED Requirements
+
+### Requirement: Template engine shall parse HTML strings into Element trees
+
+`render_template(source: str, context: dict[str, Any]) -> Element` SHALL parse HTML template strings and return WebComPy `Element` trees using `html.parser.HTMLParser`. The returned value SHALL be a single `Element` instance suitable as a component root.
+
+#### Scenario: Basic HTML structure
+- **WHEN** `render_template("<div><p>Hello</p></div>", {})` is called
+- **THEN** it SHALL return `Element("div", {}, children=[Element("p", {}, [TextElement("Hello")])])`
+
+#### Scenario: Single root element only
+- **WHEN** the template has multiple top-level elements (`<div></div><div></div>`)
+- **THEN** `WebComPyException` SHALL be raised with message "Template must have exactly one root element"
+
+#### Scenario: Whitespace around root element
+- **WHEN** the template has whitespace-only text nodes before or after the root element
+- **THEN** those whitespace nodes SHALL be skipped and the root element SHALL be returned
+
+#### Scenario: Leading/trailing non-whitespace text
+- **WHEN** the template has non-whitespace text before or after the root element (e.g., `"text<div></div>text"`)
+- **THEN** `WebComPyException` SHALL be raised
+
+### Requirement: Template engine shall handle void elements and self-closing tags
+
+The template engine SHALL correctly handle void HTML elements (which have no end tag) and self-closing tag syntax.
+
+#### Scenario: Void elements without closing slash
+- **WHEN** the template contains `<br>`, `<img src="x">`, `<input type="text">`
+- **THEN** the tree builder SHALL NOT push void elements onto the element stack
+- **AND** `<br>` SHALL produce `NewLine()` not `Element("br")`
+- **AND** `<img>`, `<input>` SHALL produce `Element` instances with their attributes
+
+#### Scenario: Self-closing tags
+- **WHEN** the template contains `<img src="x" />` with trailing slash
+- **THEN** the element SHALL be created via `handle_startendtag` and SHALL NOT be pushed onto the stack
+
+### Requirement: Template engine shall handle boolean attributes
+
+Boolean HTML attributes (e.g., `disabled`, `checked`) that have no value SHALL be converted to `True` for the attribute dict.
+
+#### Scenario: Boolean attribute conversion
+- **WHEN** the template contains `<input disabled>`
+- **THEN** the attribute SHALL be `{"disabled": True}` (which `_proc_attr` converts to `""` in the DOM)
+
+#### Scenario: Boolean attribute with explicit value
+- **WHEN** the template contains `<input disabled="disabled">`
+- **THEN** the attribute SHALL be `{"disabled": "disabled"}` (string value preserved)
+
+### Requirement: Template engine shall skip HTML comments
+
+HTML comments (`<!-- ... -->`) SHALL be ignored and SHALL NOT produce any nodes in the Element tree.
+
+#### Scenario: Comment skipping
+- **WHEN** the template contains `<!-- this is a comment -->`
+- **THEN** no node SHALL be created for the comment
+
+### Requirement: Template engine shall reject CDATA content elements
+
+`<script>`, `<style>`, `<iframe>`, `<noembed>`, `<noframes>`, and `<xmp>` tags SHALL be rejected with a `WebComPyException`.
+
+#### Scenario: Script tag rejection
+- **WHEN** the template contains `<script>alert(1)</script>`
+- **THEN** `WebComPyException` SHALL be raised with a message recommending `scoped_style` or `raw_html` as alternatives
+
+#### Scenario: Style tag rejection
+- **WHEN** the template contains `<style>body{color:red}</style>`
+- **THEN** `WebComPyException` SHALL be raised
+
+### Requirement: Template engine shall support variable interpolation in text content
+
+`{{ varname }}` and `{{ a.b.c }}` (dot notation) SHALL interpolate variables from the context into text content. Signal values SHALL be passed directly to `TextElement` for reactive updates.
+
+#### Scenario: Signal in text content
+- **WHEN** `render_template("<p>{{ count }}</p>", {"count": Signal(5)})` is called
+- **THEN** `TextElement(Signal(5))` SHALL be created, preserving reactive binding
+
+#### Scenario: String in text content
+- **WHEN** `render_template("<p>{{ name }}</p>", {"name": "Alice"})` is called
+- **THEN** `TextElement("Alice")` SHALL be created
+
+#### Scenario: Element as variable
+- **WHEN** `render_template("<div>{{ card }}</div>", {"card": Element("span", {}, [TextElement("x")])})` is called
+- **THEN** the `Element("span")` SHALL be placed as a direct child of the `<div>`
+
+#### Scenario: Component as variable
+- **WHEN** a context variable contains a `Component` instance
+- **THEN** the Component SHALL be placed as a direct child in the Element tree
+
+#### Scenario: Missing variable
+- **WHEN** a template references `{{ undefined_var }}` that is not in the context
+- **THEN** `KeyError` SHALL be raised with a message listing the available variable names
+
+#### Scenario: None variable
+- **WHEN** a context variable is `None`
+- **THEN** nothing SHALL be inserted at that position
+
+#### Scenario: Dot notation with dict
+- **WHEN** `{{ user.name }}` is used with `user` being `{"name": "Alice"}`
+- **THEN** dict key access SHALL resolve `user["name"]` → `"Alice"`
+
+#### Scenario: Dot notation with object attribute
+- **WHEN** `{{ user.name }}` is used with `user` being a dataclass/NamedTuple
+- **THEN** `getattr(user, "name")` SHALL be used
+
+### Requirement: Template engine shall support variable interpolation in attribute values
+
+`{{ varname }}` in attribute values SHALL produce reactive `Computed` signals when the referenced variable is a `SignalBase`. When no Signal is referenced, static string evaluation SHALL be used.
+
+#### Scenario: Single Signal in attribute
+- **WHEN** `class="{{ cls }}"` is used with `cls` being `Signal("active")`
+- **THEN** a `Computed` SHALL be generated that evaluates to `str(cls.value)`
+- **AND** the `Computed` SHALL be passed as the attribute value
+- **AND** the DOM attribute SHALL update reactively when `cls` changes
+
+#### Scenario: Mixed literal and Signal
+- **WHEN** `class="card {{ cls }}"` is used with `cls` being `Signal("active")`
+- **THEN** a `Computed` SHALL be generated that evaluates to `f"card {cls.value}"`
+- **AND** the attribute SHALL update reactively when `cls` changes
+
+#### Scenario: Multiple Signals in one attribute
+- **WHEN** `data-label="{{ a }} {{ b }}"` is used with both `a` and `b` being Signals
+- **THEN** a single `Computed` SHALL be generated that depends on both Signals
+- **AND** the attribute SHALL update when either Signal changes
+
+#### Scenario: No Signal in attribute (static)
+- **WHEN** `class="{{ cls }}"` is used with `cls` being `"static-string"` (plain str)
+- **THEN** static string evaluation SHALL be used (no `Computed` created)
+- **AND** the attribute value SHALL be `"static-string"`
+
+#### Scenario: Integer in attribute (static)
+- **WHEN** `data-index="{{ idx }}"` is used with `idx` being `42`
+- **THEN** the resolved attribute SHALL be `"42"` (static, no Computed)
+
+#### Scenario: Mixed literal and non-Signal variable
+- **WHEN** `class="card {{ cls }}"` is used with `cls` being `"active"` (plain str)
+- **THEN** the resolved attribute value SHALL be `"card active"` (static)
+
+### Requirement: Template engine shall support event handler binding
+
+`@event_name="handler_var"` attributes SHALL resolve the named callable from the context and set it as a DOM event handler.
+
+#### Scenario: Click handler
+- **WHEN** `render_template('<button @click="on_click">Btn</button>', {"on_click": handler})` is called
+- **THEN** the resulting `Element` SHALL have `events={"click": handler}`
+
+#### Scenario: Missing event handler
+- **WHEN** `@click="missing_handler"` references a name not in the context
+- **THEN** `KeyError` SHALL be raised
+
+### Requirement: Template engine shall support DomNodeRef binding
+
+`:ref="ref_var"` attributes SHALL resolve the named `DomNodeRef` from the context and set it as the element's ref.
+
+#### Scenario: Ref binding
+- **WHEN** `render_template('<input :ref="my_ref">', {"my_ref": DomNodeRef()})` is called
+- **THEN** the resulting `Element` SHALL have `ref=my_ref`
+
+### Requirement: Template engine shall accept locals() as context
+
+The `context` dict argument SHALL accept the result of `locals()` called within a component setup function, enabling implicit variable capture.
+
+#### Scenario: locals() usage
+- **WHEN** `render_template("<p>{{ count }}</p>", locals())` is called from a component setup where `count = use_state(lambda: 0)` exists
+- **THEN** `count` SHALL be accessible from the template
+
+### Requirement: Template engine shall cache compiled Template ASTs
+
+Template strings SHALL be parsed into Template ASTs and cached by source string. Subsequent calls with the same source SHALL reuse the cached AST.
+
+#### Scenario: Cache hit
+- **WHEN** `render_template` is called twice with the same template string
+- **THEN** parsing SHALL occur only on the first call; the second call SHALL reuse the cached AST
+
+### Requirement: Template engine shall apply textwrap.dedent
+
+Template strings SHALL have `textwrap.dedent` applied before parsing to normalize indentation from triple-quoted Python strings.
+
+#### Scenario: Dedent application
+- **WHEN** a template string has leading whitespace from Python indentation
+- **THEN** `textwrap.dedent` SHALL remove common leading whitespace before parsing
+
+### Requirement: Template engine shall treat unknown tags leniently
+
+Tags not in the HtmlTags literal SHALL be treated as regular HTML elements. No error SHALL be raised for unknown tag names.
+
+#### Scenario: Unknown tag
+- **WHEN** the template contains `<widget>text</widget>` and "widget" is not in HtmlTags
+- **THEN** `Element("widget", {}, [TextElement("text")])` SHALL be created

--- a/openspec/changes/feat-template-interpolation/tasks.md
+++ b/openspec/changes/feat-template-interpolation/tasks.md
@@ -1,0 +1,113 @@
+## 1. Module Setup
+
+- [ ] 1.1 Create `packages/webcompy/src/webcompy/template/` package directory structure with `__init__.py`
+
+## 2. Shared Holes Module (_holes.py)
+
+- [ ] 2.1 Create `_holes.py` module — no imports from other template modules (avoids circular dependencies)
+- [ ] 2.2 Implement `HOLE_PATTERN` regex: `\{\{\s*([a-zA-Z_]\w*(?:\.[a-zA-Z_]\w*)*)\s*\}\}` — first segment MUST start with letter/underscore (rejects `{{123}}` digit-first patterns as literal text)
+- [ ] 2.3 Implement `LiteralText(text: str)` and `Hole(var_path: str)` dataclasses
+- [ ] 2.4 Implement `split_text(text: str) -> list[LiteralText | Hole]` for `{{ }}` extraction from text and attribute values
+- [ ] 2.5 Implement `resolve_var(path: str, ctx: dict) -> Any` with dot-notation support (dict key access with `isinstance` check, fallback to `getattr`)
+- [ ] 2.6 Implement `resolve_holes(text: str, ctx: dict) -> str` that resolves all `{{ }}` patterns to string values (extracts `.value` from Signals, `str()` for others, `""` for `None`; used by Change 5 `css_text_template`)
+
+## 3. Template AST
+
+- [ ] 3.1 Implement `_ast.py` with TemplateNode, TemplateElement, TemplateText, AttrSpec dataclasses (imports `LiteralText`, `Hole`, `split_text` from `_holes.py`)
+
+## 4. HTML Parser (Tree Builder)
+
+- [ ] 4.1 Implement `TemplateTreeBuilder(HTMLParser)` with `VOID_ELEMENTS` set and `handle_starttag` (element creation, stack push, void element exclusion)
+- [ ] 4.2 Implement `handle_startendtag` for self-closing tag syntax (`<tag />`)
+- [ ] 4.3 Implement `handle_endtag` with stack matching
+- [ ] 4.4 Implement `handle_data` with `{{ }}` scanning and `split_text` integration
+- [ ] 4.5 Implement `handle_comment` to skip comments
+- [ ] 4.6 Implement `<br>` → `NewLine` special-casing and boolean attribute (`None` → `True`) handling
+- [ ] 4.7 Implement `REJECTED_TAGS` check (`script`, `style`, `iframe`, `noembed`, `noframes`, `xmp`) raising `WebComPyException`
+
+## 5. Compilation Cache
+
+- [ ] 5.1 Implement `_cache.py` with module-level `_template_cache` dict and `get_or_compile()` function (dedent → strip → cache lookup/miss → parse → store → return)
+
+## 6. Event Handler and Ref Binding
+
+- [ ] 6.1 Implement `classify_attrs()` that partitions attribute specs into: `@event` → events dict, `:ref` → ref lookup, boolean → attr True, regular → attr string
+- [ ] 6.2 Implement event handler resolution: `@click="on_click"` → `events["click"] = resolve_var("on_click", ctx)`
+- [ ] 6.3 Implement DomNodeRef resolution: `:ref="my_ref"` → `ref = resolve_var("my_ref", ctx)`
+
+## 7. Attribute Evaluation (Reactive + Static)
+
+- [ ] 7.1 Implement `resolve_attr(parts, ctx) -> AttrValue` with Signal detection: check all Hole references for `isinstance(resolve_var(...), SignalBase)`
+- [ ] 7.2 Implement `Computed` generation branch: when Signals are detected, create a `Computed(lambda: ...)` closure that concatenates literal parts and current Signal `.value`s (using `Computed(fn)` from `webcompy.signal` — Tier 2 internal constructor API)
+- [ ] 7.3 Ensure static path preserves original behavior: when no Signals are referenced, resolve to plain string via concatenation
+- [ ] 7.4 Test `Computed` lifecycle: component destroy cleans up attribute `Computed` consumer nodes (verified via `on_after_updating` callback node cleanup on `Element` destruction)
+
+## 8. Element Tree Binding
+
+- [ ] 8.1 Implement `bind_element(node: TemplateElement, ctx) -> Element` that creates `Element` instances with resolved attrs, events, ref, and recursively bound children
+- [ ] 8.2 Implement `bind_children(nodes, ctx) -> list` that dispatches TemplateText → text parts binding, TemplateElement → bind_element
+- [ ] 8.3 Implement `bind_text_part(part, ctx) -> ElementChildren` that returns `LiteralText.text` or `resolve_var(Hole.var_path, ctx)`
+
+## 9. Shared Pipeline + Public API
+
+- [ ] 9.1 Implement `_render_nodes(source: str, context: dict) -> list[ElementAbstract]` in `template/__init__.py` as the shared internal pipeline: dedent → cache → parse → bind all root nodes without single-root validation (enables reuse by Change 6's `render_markdown`)
+- [ ] 9.2 Implement `render_template(source: str, context: dict[str, Any]) -> Element` in `__init__.py` that calls `_render_nodes` and asserts exactly one root Element
+
+## 10. Unit Tests — Holes Module
+
+- [ ] 10.1 Test HOLE_PATTERN matches `{{ varname }}`, `{{ a.b.c }}` with optional whitespace
+- [ ] 10.2 Test HOLE_PATTERN rejects `{{123}}` (digit-first), `{{}}` (empty), `{{` (unclosed) — all treated as literal text
+- [ ] 10.3 Test `split_text` with literal-only text, hole-only text, mixed content, multiple holes
+- [ ] 10.4 Test `resolve_var` dict key access, object attribute access, chained paths, missing key → KeyError
+- [ ] 10.5 Test `resolve_holes` with plain strings (passthrough), Signal values (`.value` extraction), `None` → `""`
+- [ ] 10.6 Test `resolve_holes` with mixed literal and holes in CSS-style text (validates Change 5 compatibility)
+
+## 11. Unit Tests — Parser
+
+- [ ] 11.1 Test basic HTML structure parsing (nested elements, attributes, text content)
+- [ ] 11.2 Test void elements (`<br>`, `<img>`, `<input>`, `<hr>`, `<source>`, etc.) and self-closing syntax
+- [ ] 11.3 Test boolean attributes (bare `disabled`, `disabled=""`, `disabled="disabled"`)
+- [ ] 11.4 Test HTML comments (skipping, nested content)
+- [ ] 11.5 Test REJECTED_TAGS rejection (`<script>`, `<style>`, etc.)
+- [ ] 11.6 Test `{{ }}` splitting in text and attribute values (literal/hole parts)
+
+## 12. Unit Tests — Binding
+
+- [ ] 12.1 Test text interpolation with Signal, str, int, None, Element, Component values
+- [ ] 12.2 Test dot notation resolution (dict access, object attribute access, chained)
+- [ ] 12.3 Test attribute evaluation: single Signal in attribute (Computed + DOM reactive update), mixed literal+Signal, multiple Signals, no-Signal static path, integer/bool static
+- [ ] 12.4 Test event handler binding (`@click`, multiple handlers)
+- [ ] 12.5 Test DomNodeRef binding (`:ref`)
+- [ ] 12.6 Test missing variable error (KeyError with available names)
+
+## 13. Unit Tests — Integration
+
+- [ ] 13.1 Test `render_template` end-to-end with real component setup
+- [ ] 13.2 Test `locals()` usage pattern
+- [ ] 13.3 Test compile cache (same string → cache hit, different → cache miss)
+- [ ] 13.4 Test `textwrap.dedent` behavior with indented triple-quoted strings
+- [ ] 13.5 Test root element validation (single root OK, multiple roots error, whitespace trimming)
+- [ ] 13.6 Test lenient unknown tag handling (`<widget>` → `Element("widget", ...)`)
+
+## 14. Spike
+
+- [ ] 14.1 Verify `html.parser.HTMLParser` functionality in PyScript/Emscripten environment
+
+## 15. SSR & Hydration
+
+- [ ] 15.1 Test `render_app_html_sync(app)` with a template-based component — verify SSR HTML output contains expected text and element structure from `{{ }}` interpolation
+- [ ] 15.2 Test `TestRenderer.render(component)` — verify prerendered `__webcompy_prerendered_node__` flag is set on text nodes from Signal interpolation
+- [ ] 15.3 E2E: add a template-based demo page under `e2e/core/` using `static_site` fixture — verify (a) pre-rendered HTML matches the template structure, (b) hydration payload includes transferred Signal values, (c) after browser load, changing a Signal value updates the corresponding DOM text node
+
+## 16. CI Review Update
+
+- [ ] 16.1 Update `.opencode/agents/ci-review.md`: add template engine patterns (HTMLParser-based AST compilation, `HOLE_PATTERN`, `resolve_var`, `render_template` / `_render_nodes`)
+- [ ] 16.2 Update `AGENTS.md` File->Spec Mapping: `webcompy/template/` -> `template-engine` spec
+
+## 17. Future Enhancement — Cache Eviction
+
+- [ ] 17.1 Add eviction policy (`functools.lru_cache` or size cap) to `_template_cache` in `_cache.py` for long-running dynamic-template workloads
+
+## 18. Main Spec Generation (Archive Time)
+
+- [ ] 18.1 After all 8 changes are implemented and before the final archive, generate `openspec/specs/template-engine/spec.md` by merging the delta specs from all changes (feat-template-interpolation, feat-template-control-flow, feat-template-component-tags, feat-template-css-text, feat-template-file-loading, feat-template-markdown, feat-template-markdown-for-expansion). The main spec SHALL include all ADDED requirements from Changes 1–6, with Change 7's MODIFIED requirements superseding the corresponding Change 6 baseline requirements.

--- a/openspec/changes/feat-template-markdown-for-expansion/.openspec.yaml
+++ b/openspec/changes/feat-template-markdown-for-expansion/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/feat-template-markdown-for-expansion/design.md
+++ b/openspec/changes/feat-template-markdown-for-expansion/design.md
@@ -1,0 +1,117 @@
+## Context
+
+Change 6's `render_markdown` pipeline converts Markdown to HTML via `MarkdownPort`, strips `<p>` wrappers around `{% %}` directives, then feeds the HTML to `_render_nodes` for template binding. `{% for %}` blocks in the HTML use standard `repeat()` — which renders the for-body per item independently. For Markdown-native list items (`- {{ item }}`), the Markdown parser generates a complete `<ul><li>{{ item }}</li></ul>` per list block, and `repeat()` stacks one `<ul>` per iteration instead of merging list items into a single `<ul>`.
+
+The key insight: **merging Markdown list items across iterations requires rendering all items' markdown text together in one MarkdownPort pass.** Separately rendered subtrees cannot share a `<ul>` wrapper. A `DynamicElement` that concatenates per-item markdown, renders once, and re-renders on collection change solves this while preserving field-level reactivity.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Merge `{% for %}` over Markdown native list bodies into a single `<ul>` (or `<ol>`) with all `<li>` children
+- Preserve field-level reactivity: `{{ item.field }}` where `item.field` is a Signal SHALL update fine-grained via `TextElement`, without triggering block re-render
+- Support collection reactivity: when the iterable (e.g., `ReactiveList`) changes, re-render the merged block wholesale
+- Detect list-body vs non-list-body for-loops and route accordingly: list → `MarkdownForElement`; non-list → repeat() (unchanged, fully reactive)
+- Support nested `{% for %}`, tuple unpacking (`{% for k, v in d %}`), and per-item `{% if %}` (static evaluation)
+- Follow `SwitchElement` lifecycle patterns for callback node management and async `_refresh`
+
+**Non-Goals:**
+- Reactive `{% if %}` inside a merging list-body `{% for %}` — the `{% if %}` is statically evaluated per item (fundamental constraint; use `<ul>{% for %}{% if %}<li>...</li>{% endif %}{% endfor %}</ul>` for reactive list-item conditionals).
+- Incremental (O(1)) patching — block re-render on collection change is O(N), acceptable for content pages
+- `{% else %}` within `{% for %}`
+- General-purpose reactive-markdown primitive
+
+## Decisions
+
+### D1: `MarkdownForElement(DynamicElement)` — reactive block-rendering for loops
+
+`MarkdownForElement` SHALL be a `DynamicElement` subclass in `webcompy/template/_markdown_for.py`. It holds the iterable, the body markdown template (string), the loop variable names (list of str), and the binding context. On render:
+
+1. Read current items from the iterable (if `ReactiveList`/`ReactiveDict`, reading `.value`/iterating establishes reactive dependency).
+2. For each item N, apply expression-scoped renaming to the body markdown: within `{{ }}`/`{% %}` spans, replace the loop variable name(s) with `__wmdf_{N}_{varname}`. Inject `__wmdf_N_varname = items[N]` into the context.
+3. Concatenate all per-item markdown text into a single string.
+4. `MarkdownPort.render(concatenated)` → HTML.
+5. `_strip_directive_paragraphs(html)` (handles any nested lone `{% %}` directives).
+6. `_render_nodes(html, augmented_context)` → children (a single `<ul>` with all `<li>`s).
+7. Set as `_children`.
+
+On collection change (iterable is `ReactiveList`/`ReactiveDict`): `_refresh()` repeats steps 1-7 and patches children.
+
+**Reactive separation** (critical):
+- **Field change** (e.g., `item.name` Signal changes): the per-field `TextElement(Signal)` handles updates fine-grained via `on_after_updating`. **No block re-render.**
+- **Collection change** (add/remove/replace items): `on_after_updating` on the iterable triggers `_refresh()` → full block re-render (O(N)). **Block re-render occurs.**
+- **`{% if %}` inside for** (e.g., `{% if item.active %}`): evaluated **statically per item** during steps 2-3. If `item.active` is a Signal and changes, the `{% if %}` does NOT re-evaluate (only collection change or `<p>`-content change triggers re-evaluation of the if). For reactive list-item conditionals, use the HTML-block escape hatch.
+
+**Rationale**: This is the only architecture that delivers single `<ul>` + field-level reactivity. The O(N) collection re-render is acceptable for content pages (where collection changes are rare). The static-if limitation for merging loops is a documented trade-off with a well-defined escape hatch.
+
+**Alternatives considered during planning**:
+
+| Approach | Description | Outcome |
+|---|---|---|
+| A — Static pre-pass | Pre-expand `{% for %}` at text level without reactive wrapper; no collection reactivity | Rejected (snapshot-only) |
+| B — Per-item DynamicElement | Each item as a standalone DynamicElement with its own reactive subtree | Rejected (no shared `<ul>`) |
+| C — Post-hoc DOM merge | Render via `repeat()` then merge adjacent `<ul>` elements in DOM | Rejected (brittle DOM surgery) |
+| D — Markdown dialect extension | Extend Markdown syntax to express loop-within-list natively | Rejected (non-standard) |
+| **E — MarkdownForElement** | Reactive `DynamicElement` that concatenates per-item markdown text and renders via single `MarkdownPort` pass | **Selected** |
+| F — Source-level rewrite | Rewrite `{% for %}` + `- ` lines to `<ul>{% for %}<li>` at source level; full incremental reactivity | Rejected (fragile, breaks on complex bodies) |
+
+The MarkdownForElement approach is the sweet spot: correct merging for any body + field reactivity + collection reactivity (wholesale).
+
+### D2: Expression-scoped loop-variable renaming
+
+Loop variable renaming MUST be scoped to `{{ }}` and `{% %}` template expressions only. A naive global `\b{item}\b` replace would corrupt Markdown prose containing the loop variable name.
+
+**Implementation**: For each item N, walk the body markdown text and identify `{{ }}` / `{% %}` spans. Within each span, replace occurrences of the loop variable name(s) with `__wmdf_{N}_{varname}`. For tuple unpacking (`{% for k, v in d %}`), both `k` and `v` are renamed per iteration (`__wmdf_N_k`, `__wmdf_N_v`).
+
+**Rationale**: The renaming scope is limited to template expressions; prose remains intact. The `__wmdf_` prefix is reserved for framework-generated synthetic keys. The HOLE_PATTERN from Change 1 (`[a-zA-Z_]\w*(\.[a-zA-Z_]\w*)*`) validates the renamed paths.
+
+### D3: Reserved prefix `__wmdf_`
+
+All synthetic context keys generated by the for-expansion SHALL use the `__wmdf_` prefix (e.g., `__wmdf_0_item`, `__wmdf_1_item`). User-supplied context keys with this prefix MAY collide and cause unexpected behavior. The prefix SHALL be documented as a framework-reserved namespace.
+
+**Rationale**: The prefix makes origin clear and reduces collision probability. A full collision-detection mechanism (UserWarning on collision) can be added in a follow-up.
+
+### D4: Body-type detection — list vs non-list routing
+
+`render_markdown`'s pipeline SHALL detect whether a `{% for %}` body, when rendered independently per item via `repeat()`, would produce list blocks that SHOULD be merged:
+
+- **List body**: body lines (after stripping `{% if %}`/`{% endif %}` directives) start with `-`, `*`, `+`, or a digit followed by `.` or `)` (i.e., unordered/ordered list markers). Route to `MarkdownForElement`.
+- **Non-list body**: headings (`#`), paragraphs (plain text), HTML blocks (lines starting with `<`), blockquotes (`>`), etc. Route to standard `repeat()` (unchanged from Change 6, fully reactive with reactive `{% if %}`).
+
+**Rationale**: Lists have a natural merge expectation (multiple `- ` items → one `<ul>`). Headings, paragraphs, and other blocks do not — independent per-item rendering via `repeat()` produces the expected output. This heuristic maximizes reactivity (non-list for-loops stay on the fully-reactive `repeat()` path with reactive `{% if %}`) while fixing the list-use case.
+
+### D5: Lifecycle — mirroring SwitchElement with shared `_run_refresh_sync`
+
+`MarkdownForElement._render()` SHALL register `on_after_updating` callback nodes on the iterable (if reactive) during the initial render. The callback nodes SHALL be stored in `_callback_nodes` and destroyed on element cleanup (`_remove_element` → `consumer_destroy`).
+
+`_refresh()` SHALL be `async def` and follow the `SwitchElement._refresh` pattern:
+- Determine new children via re-expansion + re-render.
+- Patch old children via `_patch_children`.
+- Defer `on_after_rendering` lifecycle hooks via `start_defer_after_rendering` / `end_defer_after_rendering` when `_signal_activated` is True.
+
+For sync invocation of the async `_refresh` from `on_after_updating` callbacks, `MarkdownForElement` SHALL use the shared `_run_refresh_sync(self._refresh, *args)` helper from `webcompy.elements.types._dynamic` (extracted in `refactor-element-foundations`), rather than duplicating the sync-wrapper logic.
+
+### D6: Nested for and tuple unpacking
+
+- **Nested `{% for %}`**: If a `MarkdownForElement` body contains another `{% for %}`, the inner for SHALL be recursively expanded during steps 2-3 (created as another `MarkdownForElement`, or routed to repeat() if non-list). Per-item renaming composite paths: `__wmdf_{outer}_{inner}_varname`.
+- **Tuple unpacking**: `{% for k, v in dict %}` SHALL rename both loop variables to `__wmdf_N_k` and `__wmdf_N_v`, and inject both into context.
+- **`{% if %}` inside `{% for %}`**: statically evaluated per item during step 2. The if condition is resolved against the per-item renamed context. Body content for truthy branches is emitted; falsy branches are omitted. This means `{% if %}` inside list-body `{% for %}` is NOT reactive to field changes (only re-evaluates on collection change).
+
+**Rationale**: Nested for recursion follows the same merge logic. Tuple unpacking mirrors Change 2's `for`-binding design (D6). Static-if evaluation during expansion is the only way to achieve list merging — reactive if would require the `{% if %}` directive to appear at list-item line-start, which Markdown would not recognize as a list.
+
+### D7: HTML-block escape hatch for fully-reactive list loops
+
+For developers who need fully-reactive list loops (incremental O(1) patching + reactive `{% if %}`), the pattern `<ul>{% for item in items %}<li>{{ item }}</li>{% endfor %}</ul>` (HTML block) SHALL be documented. This uses `repeat()` + `switch()` from Changes 2-3 and is the preferred path for reactive collections in list contexts.
+
+**Rationale**: HTML blocks pass through Markdown unchanged, so the template engine processes them with the HTML-first reactive pipeline. This escape hatch provides full reactivity for those who need it, without complicating the MarkdownForElement design.
+
+## Risks / Trade-offs
+
+- **[Risk] O(N) block re-render on collection change may be slow for large lists** → Mitigation: Content pages rarely have large frequently-changing lists. For large dynamic lists, use the HTML-block escape hatch (`<ul>{% for %}<li>...</li>{% endfor %}</ul>`). A future enhancement could add incremental (O(1)) patching for simple-list `MarkdownForElement`.
+- **[Risk] `__wmdf_` prefix collision with user context keys** → Mitigation: The `__wmdf_` prefix is unlikely to be used by user code (double-underscore convention). Documented as reserved.
+- **[Risk] List-body detection heuristic false positives/negatives** → Mitigation: The heuristic is conservative: list markers at line start after stripping if-directives. Edge cases (mixed list+other blocks) are rare. False negatives (list not detected) → falls back to repeat() (safe, just no merging). False positives (non-list routed to MarkdownForElement) → still produces correct output, just with re-render semantics instead of incremental.
+- **[Trade-off] `{% if %}` inside merging for-loops is non-reactive to field changes** → Mitigation: Re-evaluates on collection change. HTML-block escape hatch for fully-reactive list-item conditionals. Documented prominently.
+- **[Trade-off] Generates a new DynamicElement (~100 lines)** → Mitigation: follows established patterns (SwitchElement/RepeatElement). Minimal new surface area. Lives in `webcompy/template/` (not `elements/types/`) since it's Markdown-pipeline-specific.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-markdown-for-expansion/proposal.md
+++ b/openspec/changes/feat-template-markdown-for-expansion/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Change 6's Markdown pipeline renders `{% for %}` blocks via the standard HTML-first repeat() path. This means a loop wrapping Markdown native list items such as `{% for item in items %}\n- {{ item }}\n{% endfor %}` produces one `<ul>` per iteration — because the Markdown parser generates a complete `<ul>` block per item, and repeat() stacks them as independent subtrees. For documentation and content pages, developers expect list items to merge into a single `<ul>`.
+
+This change introduces `MarkdownForElement` — a reactive `DynamicElement` that expands `{% for %}` loops at the markdown-text level, concatenates per-item markdown into one string, renders the merged markdown as **one** `<ul>` with all `<li>` children, and preserves field-level reactivity. Collection changes trigger a wholesale re-render of the merged block.
+
+## What Changes
+
+- Add `MarkdownForElement(DynamicElement)` in `webcompy/template/_markdown_for.py` — reactive block-rendering for `{% for %}` in Markdown templates
+- Integrate body-type detection into the `render_markdown` pipeline: list-body `{% for %}` → `MarkdownForElement` (merged `<ul>` + reactive); non-list-body `{% for %}` → repeat() (unchanged, fully reactive)
+- Implement expression-scoped loop-variable renaming (`{{ item.x }}` → `{{ __wmdf_N_item.x }}`) within per-item markdown body text, with `__wmdf_N_item = items[N]` injected into context
+- Support nested `{% for %}`, tuple unpacking (`{% for k, v in d %}`), and nested `{% if %}` (static per item)
+- Document the `__wmdf_` reserved prefix for synthetic context keys
+- `{% for %}` over non-list bodies (headings, paragraphs, HTML blocks) continues to use repeat() from Change 6 — fully reactive with reactive `{% if %}`
+- Provide an HTML-block escape hatch: `<ul>{% for item in items %}<li>{{ item }}</li>{% endfor %}</ul>` for fully-incremental reactive list loops
+
+## Capabilities
+
+### New Capabilities
+_None — extends `template-engine`_
+
+### Modified Capabilities
+- `template-engine`: `{% for %}` over Markdown list bodies produces a single `<ul>` with merged `<li>` children and collection-level reactivity via `MarkdownForElement`
+
+## Known Issues Addressed
+- Markdown `{% for %}` over native list syntax now produces a single `<ul>` instead of one per iteration (addressed via `MarkdownForElement`)
+
+## Non-goals
+- Reactive `{% if %}` inside a merging `{% for %}` list body — the `{% if %}` is statically evaluated per item (fundamental constraint of Markdown block rendering; use HTML-block escape hatch for reactive list-item conditionals)
+- `{% else %}` within `{% for %}` (empty-iterable fallback)
+- Incremental (O(1)) DOM patching for list-body `{% for %}` — `MarkdownForElement` does O(N) block re-render on collection change, which is acceptable for content pages
+- General-purpose reactive-markdown primitive (`reactive_markdown(computed_source)`) — out of scope; `MarkdownForElement` is focused on the for-loop use case
+
+## Impact
+
+- **New file**: `webcompy/template/_markdown_for.py` — `MarkdownForElement(DynamicElement)` (~100 lines)
+- **Modified file**: `webcompy/template/__init__.py` — body-type detection in `render_markdown` pipeline; route list-body `{% for %}` to `MarkdownForElement`
+- **Leverages existing**: `DynamicElement._render` / `_refresh` infrastructure (mirrors `SwitchElement` lifecycle, using shared `_run_refresh_sync` helper from `refactor-element-foundations`), `inject(MARKDOWN_PORT_KEY)` from Change 6, `_render_nodes` from Change 1, `FragmentElement` from Change 2, `_holes.resolve_var` for variable resolution
+- **No breaking changes**: Non-list `{% for %}` behavior unchanged (repeat()); `<ul>` single-block output is the correct behavior users expect
+
+## Dependencies
+
+- **Depends on**: Change 1 (template interpolation — `_render_nodes` shared pipeline, `_holes.resolve_var`)
+- **Depends on**: Change 2 (control flow — `FragmentElement` for multi-child wrapping, for-loop AST structure)
+- **Depends on**: Change 6 (Markdown — `MarkdownPort`, `DefaultMarkdownParser`, `render_markdown` pipeline, `<p>` stripping) — MUST be archived after Change 6
+- **Required by**: None
+- **Recommended implementation order**: Seventh template-engine change (0 → 1 → 2 → 3 → 4 → 5 → 6 → **7**)

--- a/openspec/changes/feat-template-markdown-for-expansion/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-markdown-for-expansion/specs/template-engine/spec.md
@@ -1,0 +1,146 @@
+## MODIFIED Requirements
+
+### Requirement: render_markdown shall produce reactive Element trees from Markdown
+
+`render_markdown(source: str | Path, context: dict) -> ElementAbstract` SHALL render Markdown templates into reactive Element trees. The pipeline SHALL be: Markdown → HTML (via MarkdownPort) → strip directive paragraphs → parse HTML with multi-root support → bind → FragmentElement wrapping for multi-root. When Markdown produces a single top-level element, an `Element` SHALL be returned directly. When Markdown produces multiple top-level elements, a `FragmentElement` SHALL be returned containing all root elements.
+
+`{% for %}` blocks whose body is a Markdown list (lines starting with `-`, `*`, `+`, or digit`.`/`)`) SHALL be routed to `MarkdownForElement` for merged single-`<ul>` output with collection-level reactivity (superseding the Change 6 baseline of one `<ul>` per iteration via `repeat()`). All other `{% for %}` blocks (headings, paragraphs, HTML blocks) SHALL continue to use the standard `repeat()` path (unchanged from Change 6).
+
+#### Scenario: Basic Markdown rendering (single element)
+- **WHEN** `render_markdown("# Hello {{ name }}", {"name": "World"})` is called
+- **THEN** an `Element("h1", ..., [TextElement("Hello World")])` SHALL be returned
+
+#### Scenario: Basic Markdown rendering (multiple elements)
+- **WHEN** `render_markdown("# Title\n\nText.", ctx)` is called
+- **THEN** a `FragmentElement([Element("h1", ...), Element("p", ...)])` SHALL be returned
+
+#### Scenario: Component root usage with wrapper
+- **WHEN** a developer returns `html.ARTICLE({}, render_markdown("..", ctx))` from a component setup
+- **THEN** the FragmentElement SHALL render transparently inside `<article>`
+- **AND** no extra `<div>` wrapper SHALL appear in the DOM
+
+#### Scenario: Multi-root Markdown requires explicit wrapper as component root
+- **WHEN** a developer returns `render_markdown("# Title\n\nText.", ctx)` directly from a component setup (producing multiple top-level elements → `FragmentElement`)
+- **THEN** `Component.__init_component` SHALL raise `WebComPyException("Root Node of Component must be instance of 'Element'")` because the root is a `FragmentElement`, not an `Element`
+- **AND** the developer SHALL wrap the result in an explicit root element (e.g., `html.ARTICLE({}, render_markdown(...))`)
+
+#### Scenario: {{ }} interpolation in Markdown
+- **WHEN** `render_markdown("## {{ title }}", {"title": Signal("Home")})` is called
+- **THEN** a reactive `TextElement(Signal("Home"))` SHALL be produced inside `<h2>`
+
+#### Scenario: {% for %} over Markdown list body produces a single <ul> (supersedes Change 6 baseline of one `<ul>` per iteration via `repeat()`)
+- **WHEN** source contains `{% for item in items %}\n- {{ item }}\n{% endfor %}`
+- **THEN** the for-body SHALL be detected as a list body and routed to `MarkdownForElement`
+- **AND** the rendered children SHALL contain a **single** `<ul>` element with N `<li>` children (merged)
+- **AND** `<li>` content SHALL be reactive (fine-grained `TextElement` updates on field changes)
+- **AND** appending/removing items to/from the iterable SHALL trigger a block re-render via `_refresh()`
+
+#### Scenario: Component tags in Markdown HTML blocks
+- **WHEN** source contains `<user-card title="Hello" />`
+- **THEN** the component tag SHALL be preserved through Markdown parsing
+- **AND** `render_template` SHALL resolve it via ComponentStore (Change 3)
+
+#### Scenario: File loading
+- **WHEN** `render_markdown(Path("page.md"), ctx)` is called in a server environment
+- **THEN** the file SHALL be read, parsed as Markdown, and rendered
+
+## ADDED Requirements
+
+### Requirement: MarkdownForElement shall merge for-loop list bodies into a single block element
+
+`MarkdownForElement` SHALL be a `DynamicElement` subclass in `webcompy/template/_markdown_for.py` that renders `{% for %}` blocks over Markdown list bodies as a single `<ul>` (or `<ol>`) with merged `<li>` children. It SHALL concatenate per-item Markdown text, render the merged text via `MarkdownPort`, bind the result via `_render_nodes`, and set the bound children as its child elements. The element SHALL follow `SwitchElement` lifecycle patterns for callback node management and async `_refresh`.
+
+#### Scenario: Ordered list merging via MarkdownForElement
+- **WHEN** `render_markdown("{% for item in items %}\n1. {{ item }}\n{% endfor %}", ctx)` is called
+- **THEN** a single `<ol>` with merged `<li>` children SHALL be produced
+
+#### Scenario: Field-level reactivity (no block re-render)
+- **WHEN** a `{% for %}` list body contains `{{ item.name }}` where `item.name` is a `Signal`
+- **THEN** changing `item.name.value` SHALL update the corresponding `TextElement` in the DOM fine-grained
+- **AND** `MarkdownForElement._refresh` SHALL NOT be triggered (no collection change)
+
+#### Scenario: Collection reactivity (block re-render)
+- **WHEN** the iterable is a `ReactiveList` and a new item is appended
+- **THEN** the `MarkdownForElement` SHALL re-render the entire merged block
+- **AND** the `<ul>` SHALL contain the new item in its `<li>` children
+
+### Requirement: Markdown for-expansion shall use expression-scoped loop-variable renaming
+
+Per-item loop variable references in `{{ }}` SHALL be renamed with a per-iteration prefix (`__wmdf_{N}_{varname}`) scoped to template expressions only. The synthetic keys SHALL be injected into the binding context.
+
+#### Scenario: Loop variable renamed per iteration
+- **WHEN** `{% for item in items %}- {{ item.name }}{% endfor %}` is expanded with items=[obj0, obj1]
+- **THEN** the per-item body SHALL emit `- {{ __wmdf_0_item.name }}` and `- {{ __wmdf_1_item.name }}`
+- **AND** context SHALL contain `__wmdf_0_item = obj0` and `__wmdf_1_item = obj1`
+
+#### Scenario: Renaming scoped to template expressions only
+- **WHEN** the body Markdown prose contains the word "item" outside `{{ }}`
+- **THEN** the prose SHALL NOT be renamed (only `{{ }}` / `{% %}` spans are renamed)
+
+#### Scenario: Tuple unpacking
+- **WHEN** `{% for k, v in my_dict %}- {{ k }}: {{ v }}{% endfor %}` is used
+- **THEN** both `k` and `v` SHALL be renamed per iteration (`__wmdf_N_k`, `__wmdf_N_v`)
+- **AND** both SHALL be available in the body context
+
+### Requirement: List-body detection shall route for-loops to MarkdownForElement or repeat()
+
+The `render_markdown` pipeline SHALL detect whether a `{% for %}` body is a list body (lines start with `-`, `*`, `+`, or digit+`.`/`)`) and route accordingly: list bodies → `MarkdownForElement`; non-list bodies → standard `repeat()`.
+
+#### Scenario: List body detected and routed to MarkdownForElement
+- **WHEN** a `{% for %}` body consists of lines starting with `-` or `*` or digit`.`/`)`
+- **THEN** a `MarkdownForElement` SHALL be created
+
+#### Scenario: Non-list body routed to repeat()
+- **WHEN** a `{% for %}` body consists of heading lines (`#`), paragraphs (plain text), or HTML blocks (`<div>`)
+- **THEN** the standard `repeat()` path from Change 6 SHALL be used (fully reactive with reactive `{% if %}`)
+
+#### Scenario: Non-list for preserves reactive if
+- **WHEN** a non-list `{% for %}` body contains `{% if item.show %}...{% endif %}`
+- **THEN** the `{% if %}` SHALL be bound via `switch()` and SHALL reactively update on `item.show` change
+
+### Requirement: Nested for-loops and if-in-for shall be handled in list-body for
+
+Nested `{% for %}` inside a list-body `{% for %}` SHALL be recursively expanded. `{% if %}` inside a list-body `{% for %}` SHALL be statically evaluated per item during expansion.
+
+#### Scenario: Nested for in list body
+- **WHEN** a list-body `{% for %}` body contains another `{% for %}`
+- **THEN** the inner `{% for %}` SHALL be recursively expanded as a nested `MarkdownForElement`
+- **AND** naming SHALL be composite (`__wmdf_{outer}_{inner}_varname`)
+
+#### Scenario: If-in-for static evaluation
+- **WHEN** a list-body `{% for %}` body contains `{% if item.active %}- {{ item.name }}{% endif %}`
+- **THEN** the `{% if %}` SHALL be evaluated statically per item during expansion
+- **AND** if `item.active` is falsy for iteration N, that iteration's `- {{ item.name }}` SHALL NOT be emitted
+- **AND** the if SHALL re-evaluate on collection change (block re-render)
+
+#### Scenario: HTML-block escape hatch for reactive list-item conditional
+- **WHEN** a developer needs reactive list-item conditionals
+- **THEN** they SHALL use `<ul>{% for item in items %}{% if item.active %}<li>{{ item.name }}</li>{% endif %}{% endfor %}</ul>` (HTML block)
+- **AND** this SHALL use `repeat()` + `switch()` for full reactivity
+
+### Requirement: __wmdf_ prefix shall be reserved for framework-generated context keys
+
+All synthetic context keys generated by Markdown for-expansion SHALL use the `__wmdf_` prefix. User-supplied context keys with this prefix MAY collide with framework-generated keys.
+
+#### Scenario: Reserved prefix documented
+- **WHEN** a developer reviews the template engine documentation
+- **THEN** `__wmdf_` SHALL be listed as a reserved prefix for framework-generated context keys
+
+### Requirement: MarkdownForElement shall re-render on collection change with lifecycle hooks deferred
+
+When the iterable is reactive (`ReactiveList`/`ReactiveDict`), `MarkdownForElement` SHALL register an `on_after_updating` callback that triggers `_refresh()`. The `_refresh` SHALL defer `on_after_rendering` lifecycle hooks during reactivation (matching `SwitchElement` behavior). For synchronous invocation of `_refresh` from `on_after_updating` callbacks, `MarkdownForElement` SHALL use the shared `_run_refresh_sync` helper from `webcompy.elements.types._dynamic`, rather than duplicating the async-to-sync wrapper logic.
+
+#### Scenario: Callback registered on reactive iterable
+- **WHEN** `MarkdownForElement` renders with a `ReactiveList` iterable
+- **THEN** an `on_after_updating` callback SHALL be registered on the `ReactiveList`
+- **AND** the callback SHALL invoke `_refresh()`
+- **AND** the callback node SHALL be stored in `_callback_nodes` and destroyed on element cleanup
+
+#### Scenario: Static iterable skips callback registration
+- **WHEN** `MarkdownForElement` renders with a plain `list` iterable
+- **THEN** no `on_after_updating` callback SHALL be registered
+- **AND** `_refresh` SHALL NOT be called on iterable change (block is static snapshot)
+
+#### Scenario: on_after_rendering deferred during refresh
+- **WHEN** `_refresh()` is triggered by a collection change (not initial render)
+- **THEN** `on_after_rendering` lifecycle hooks SHALL be deferred via `start_defer_after_rendering` / `end_defer_after_rendering`

--- a/openspec/changes/feat-template-markdown-for-expansion/tasks.md
+++ b/openspec/changes/feat-template-markdown-for-expansion/tasks.md
@@ -1,0 +1,91 @@
+## 1. MarkdownForElement Implementation
+
+- [ ] 1.1 Implement `MarkdownForElement(DynamicElement)` in `webcompy/template/_markdown_for.py` (constructor accepts iterable, body_markdown str, loop_vars list[str], context dict)
+- [ ] 1.2 Implement `_render()`: read iterable items, per-item rename loop vars in expression spans with `__wmdf_{N}_{varname}` prefix, inject synthetic keys into per-item context, concatenate markdown, `MarkdownPort.render()`, `<p>` strip, `_render_nodes()`, set children
+- [ ] 1.3 Implement `_refresh()` following `SwitchElement._refresh` pattern (re-expand, patch children, defer `on_after_rendering`); use shared `_run_refresh_sync(self._refresh, *args)` from `webcompy.elements.types._dynamic` for the callback registration path
+- [ ] 1.4 Register `on_after_updating` on reactive iterable during `_render()` if not `_signal_activated`; store callback node in `_callback_nodes`
+- [ ] 1.5 Handle static iterable (plain list/dict): no callback registration, one-shot render
+
+## 2. Expression-Scoped Renaming
+
+Span boundaries for `{{ }}` and `{% %}` SHALL use the same brace delimiters as Changes 1 and 2. Renamed variable paths SHALL be validated against `HOLE_PATTERN` from `webcompy.template._holes` (Change 1). `{% %}` span boundaries SHALL match the same delimiter structure as `DIRECTIVE_PATTERN` from `webcompy.template._ast` (Change 2). Variable name replacement within spans SHALL use simple string substitution (no regex needed).
+
+- [ ] 2.1 Implement `_rename_in_expressions(text: str, var_name: str, replacement: str) -> str` that renames `var_name` → `replacement` only within `{{ }}` / `{% %}` spans
+- [ ] 2.2 Handle tuple unpacking: rename all loop variable names in expression spans (`{% for k, v in d %}` → `__wmdf_N_k`, `__wmdf_N_v`)
+- [ ] 2.3 Ensure prose (non-expression text) is NOT affected by renaming
+
+## 3. Nested and Inline Directive Handling
+
+- [ ] 3.1 Implement nested `{% for %}` detection and routing: if body contains `{% for %}` → recursively create `MarkdownForElement` (or repeat if non-list body) with composite naming prefix
+- [ ] 3.2 Statically evaluate `{% if %}` inside list-body for: resolve condition per item using `resolve_var` against per-item context; omit body for falsy iterations
+- [ ] 3.3 Handle `{% elif %}` / `{% else %}` within static per-item if evaluation
+
+## 4. Body-Type Detection in render_markdown Pipeline
+
+- [ ] 4.1 Implement `_is_list_body(body_text: str) -> bool` heuristic: strip if-directive lines, check remaining non-empty lines start with `-`, `*`, `+`, or digit+`.`/`)`
+- [ ] 4.2 Integrate detection into `render_markdown`: for-each `{% for %}` block, if list body → create `MarkdownForElement`; else → use standard repeat() path
+- [ ] 4.3 Ensure non-list for-loops continue to work with reactive `{% if %}` (unchanged from Change 6 baseline)
+
+## 5. Reserved Prefix Documentation
+
+- [ ] 5.1 Document `__wmdf_` as framework-reserved prefix for synthetic context keys in the template engine module docstring and README
+
+## 6. Unit Tests — MarkdownForElement
+
+- [ ] 6.1 Single list-body for produces one `<ul>` with N `<li>` children (static list)
+- [ ] 6.2 Ordered list body produces one `<ol>` with N `<li>` children
+- [ ] 6.3 Field-level reactivity: `{{ item.field }}` with Signal → DOM text updates on field change without block re-render
+- [ ] 6.4 Collection reactivity: `ReactiveList` append → `_refresh` called → `<ul>` updated with new `<li>`
+- [ ] 6.5 Collection reactivity: `ReactiveList` remove → `_refresh` → `<ul>` updated
+- [ ] 6.6 Collection reactivity: `ReactiveDict` change → `_refresh` → `<ul>` updated
+- [ ] 6.7 Static iterable (plain list): no on_after_updating registered, `_refresh` not called on change
+- [ ] 6.8 Loop variable renaming correctness (item → `__wmdf_N_item`)
+- [ ] 6.9 Renaming scoped to expressions only (prose "item" preserved)
+- [ ] 6.10 Tuple unpacking (`{% for k, v in d %}`) — both vars renamed and bound correctly
+- [ ] 6.11 Nested `{% for %}` in list body (inner for merged recursively)
+
+## 7. Unit Tests — If-in-For Static Evaluation
+
+- [ ] 7.1 `{% if item.active %}` in list-body for: static evaluation, truthy branch emitted, falsy omitted
+- [ ] 7.2 `{% if %}` re-evaluates on collection change (block re-render)
+- [ ] 7.3 `{% elif %}` / `{% else %}` within static per-item if
+- [ ] 7.4 Non-list for with `{% if %}`: reactive via switch() (unchanged from Change 6)
+
+## 8. Unit Tests — Body-Type Detection
+
+- [ ] 8.1 List body (`- ` lines) → routed to MarkdownForElement
+- [ ] 8.2 Unordered list (`* ` marker) → MarkdownForElement
+- [ ] 8.3 Ordered list (`1. ` marker) → MarkdownForElement
+- [ ] 8.4 Non-list body (heading `# `) → routed to repeat()
+- [ ] 8.5 Non-list body (plain text paragraphs) → routed to repeat()
+- [ ] 8.6 Non-list body (HTML blocks `<div>`) → routed to repeat()
+- [ ] 8.7 Non-list body preserves reactive `{% if %}` (repeat + switch)
+
+## 9. Unit Tests — HTML-Block Escape Hatch
+
+- [ ] 9.1 `<ul>{% for %}{% if %}<li>...</li>{% endif %}{% endfor %}</ul>` produces single `<ul>` with reactive if (repeat + switch path)
+- [ ] 9.2 Incremental (O(1)) patching: adding one item to list does not re-render all items
+
+## 10. Unit Tests — Lifecycle
+
+- [ ] 10.1 Callback node stored in `_callback_nodes` on reactive iterable
+- [ ] 10.2 Callback node destroyed on element cleanup
+- [ ] 10.3 `on_after_rendering` deferred during `_refresh()` (signal_activated)
+- [ ] 10.4 Zero children case (empty iterable): no DOM nodes created, no error
+
+## 11. Integration Tests
+
+- [ ] 11.1 End-to-end: `render_markdown` with `{% for %}` over list body and `locals()` context
+- [ ] 11.2 Mixed for: list-body for + non-list for in same Markdown document
+
+## 12. SSR & Hydration
+
+- [ ] 12.1 `render_app_html_sync(app)` with Markdown template using list-body `{% for %}` — verify SSR HTML contains single `<ul>` with correct `<li>` elements
+- [ ] 12.2 `TestRenderer.render()` — verify `__webcompy_prerendered_node__` flags on children of MarkdownForElement
+- [ ] 12.3 E2E: test that after hydration, field-level Signal changes update individual `<li>` text nodes
+- [ ] 12.4 E2E: test that after hydration, ReactiveList append triggers re-render of the merged `<ul>` block
+
+## 13. CI Review Update
+
+- [ ] 13.1 Update `.opencode/agents/ci-review.md`: add `MarkdownForElement` pattern (reactive block-rendering DynamicElement, expression-scoped renaming, list-body detection heuristic, lifecycle mirroring SwitchElement, `__wmdf_` reserved prefix)
+- [ ] 13.2 Update `AGENTS.md` File→Spec Mapping: `webcompy/template/_markdown_for.py` → `template-engine` spec

--- a/openspec/changes/feat-template-markdown/.openspec.yaml
+++ b/openspec/changes/feat-template-markdown/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-13

--- a/openspec/changes/feat-template-markdown/design.md
+++ b/openspec/changes/feat-template-markdown/design.md
@@ -1,0 +1,95 @@
+## Context
+
+WebComPy's template engine (Changes 1-5) processes HTML template strings with `{{ }}` interpolation, `{% if %}`/`{% for %}` control flow, and component tag resolution. This change adds Markdown as an alternative template syntax by converting Markdown to HTML and feeding it through the existing HTML template engine pipeline.
+
+The key challenge is the interaction between Markdown's block-level parsing and Jinja2's `{% %}` block directives. Markdown parsers wrap freestanding text lines in `<p>` tags, which would incorrectly wrap `{% for %}` and `{% endif %}` directives. A post-processing step removes these `<p>` wrappers.
+
+For the Markdown parser itself, Python's stdlib provides no built-in solution. A DI-injectable `MarkdownPort` allows the framework to ship a minimal built-in parser while enabling users to inject a full-featured third-party parser (mistletoe, markdown, etc.) for complete CommonMark compatibility.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define `MarkdownPort` ABC with DI injection
+- Implement built-in `DefaultMarkdownParser` supporting common Markdown features
+- Implement `render_markdown` pipeline: Markdown → HTML → directive cleanup → `render_template`
+- Support nested lists via indent-based parsing
+- Support HTML block passthrough (including component tags)
+- Support file-based Markdown via `Path`
+- Support all template engine features in Markdown: `{{ }}`, `{% if %}`/`{% for %}`, component tags
+
+**Non-Goals:**
+- Tables, footnotes, definition lists in DefaultMarkdownParser (available via third-party injection)
+- Full CommonMark compliance in DefaultMarkdownParser
+- Markdown-to-Markdown transformations
+- Inline-only Markdown (always full document)
+
+## Decisions
+
+### D1: `MarkdownPort` ABC with DI injection
+
+Follows the existing port abstraction pattern (`DOMPort`, `FetchPort`, etc.). `MarkdownPort` defines a single `render(source: str) -> str` method. `MARKDOWN_PORT_KEY` is an `InjectKey[MarkdownPort]`. Both `BrowserRenderContext` and `ServerRenderContext` provide `DefaultMarkdownParser()` as the default.
+
+**Rationale**: The built-in parser handles 90% of use cases (documentation pages, blogs, simple content). Users needing tables, footnotes, or strict CommonMark compliance can inject a third-party parser. This follows WebComPy's established port pattern and avoids mandating an external dependency.
+
+**Alternatives considered**: Requiring an external Markdown dependency would violate the stdlib-only constraint. A full CommonMark parser from scratch would be ~1000+ lines and is not a good use of framework development time.
+
+### D2: Post-processing to strip `<p>` wrappers from `{% %}` directives
+
+Markdown parsers wrap freestanding text lines in `<p>` tags. This produces `<p>{% for item in items %}</p>` which the template engine's bracket matcher (Change 2) would treat as a single-element body rather than a multi-element block. A regex post-process removes `<p>` tags wrapping lone `{% %}` directives.
+
+```python
+re.sub(r'<p>\s*(\{%[^<]*?%\})\s*</p>', r'\1', html)
+```
+
+**Rationale**: Simple, targeted fix. Only removes `<p>` around lines that are purely `{% %}` directives. Lines containing both text AND directives (e.g., `<p>Text {% if x %}</p>`) are left intact. The regex uses non-greedy matching and excludes `<` from the directive body to prevent matching across HTML elements.
+
+### D3: HTML block detection for preserving component tags
+
+Lines starting with `<` are detected as HTML blocks and passed through unchanged by the Markdown parser. This preserves component tags (`<user-card>`) and other raw HTML in Markdown content.
+
+**Rationale**: Standard Markdown behavior — most parsers pass HTML through unchanged. Component tags from Change 3 resolve during the `render_template` step of the pipeline.
+
+### D4: Indent-based nested list parsing
+
+List items are grouped by indent level. When indent increases, a nested sub-list begins (recursive parsing). Tabs are normalized to 2 spaces for consistent indent calculation.
+
+**Rationale**: Nested lists are essential for documentation and content. The indent-based approach maps naturally to Markdown's visual structure. Tab normalization avoids platform-specific indent issues.
+
+### D5: Inline formatting order (images before links)
+
+Inline parsing applies transformations in a specific order: images (`![alt](url)`) before links (`[text](url)`), then bold, italic, strikethrough, and inline code. This prevents `![alt](url)` from being partially consumed by the link regex.
+
+**Rationale**: Images start with `!` and contain `[...](...)` which overlaps with the link pattern. Processing images first ensures `!` is consumed before the link regex sees the bracket structure.
+
+### D6: FragmentElement for multi-root Markdown documents
+
+`render_markdown` does NOT call `render_template` directly. Instead, it uses the lower-level parser and binder from Change 1 (exposed as `_render_nodes` function) which returns ALL root nodes without single-root validation. The nodes are then wrapped:
+
+- Single root node → returned as-is (`Element`)
+- Multiple root nodes → wrapped in `FragmentElement` (no DOM wrapper)
+
+This works because Markdown naturally produces multiple top-level HTML elements (`<h1>`, `<p>`, `<ul>`, etc.). FragmentElement (from Change 2) is transparent — its children render directly in the parent DOM. When `render_markdown` is used as a child of an HTML element, no extra wrapper `<div>` appears in the DOM. When used as a component root, the developer explicitly chooses the wrapper element:
+
+```python
+return html.ARTICLE({}, render_markdown("# Title\n\nText", locals()))
+```
+
+**Rationale**: Adding a default `<div>` wrapper to every Markdown document would pollute the DOM with semantically meaningless elements. FragmentElement avoids this entirely. The developer retains control: for component roots, they wrap in a semantic element (`<article>`, `<section>`, `<div>`); for child content, FragmentElement is transparent.
+
+**Component root constraint**: When `render_markdown` returns a `FragmentElement` (multiple top-level elements), it is NOT a valid component root. `Component.__init_component` (`_component.py:188-189`) requires `isinstance(node, Element)`, and `FragmentElement` is a `DynamicElement`, not an `Element`. Developers MUST wrap multi-root Markdown in an explicit `Element` wrapper when used as a component root.
+
+**Change 7 refinement**: In Change 7, `{% for %}` over Markdown list bodies is routed to `MarkdownForElement` which merges list items into a single `<ul>` (instead of the baseline one-`<ul>`-per-iteration). Non-list for-loops stay on the fully-reactive `repeat()` path.
+
+**Implementation**: Change 1 is updated to expose `_render_nodes(source, context) -> list[ElementAbstract]` via the internal pipeline `_cache.py` → `_bind.py` → `_render_nodes`. This shared function parses + binds without single-root validation. `render_template` wraps `_render_nodes` with root validation. `render_markdown` uses `_render_nodes` directly.
+
+## Risks / Trade-offs
+
+- **[Risk] DefaultMarkdownParser edge cases in real-world Markdown** → Mitigation: DI injection allows users to replace with a battle-tested parser. The built-in parser is documented as "minimal but practical."
+- **[Risk] `<p>` stripping regex too aggressive** → Mitigation: The regex is targeted: only matches `<p>` wrapping a single `{% %}` directive with optional whitespace. Nested or compound cases are not stripped (safe default).
+- **[Risk] Markdown block-level state machine complexity** → Mitigation: Line-by-line parser with simple state transitions (para, list, code, html, blank). No lookahead beyond 1 line in most cases.
+- **[Trade-off] No CommonMark compliance in built-in parser** → Acceptable — the DI injection mechanism provides the upgrade path if needed.
+- **[Trade-off] DefaultMarkdownParser (~300 lines) adds to browser wheel bundle size** → Acceptable. The parser is part of the `webcompy` core package and always included in the browser wheel. ~300 lines of Python compresses to ~10KB, which is negligible compared to the PyScript/Emscripten WASM runtime (several MB). If bundle size becomes a concern in the future, `DefaultMarkdownParser` can be lazy-imported at first `inject(MARKDOWN_PORT_KEY)` time, avoiding the overhead for apps that do not use Markdown.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/feat-template-markdown/proposal.md
+++ b/openspec/changes/feat-template-markdown/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+After the HTML template engine (Changes 1-5), the next frontier is Markdown — the lingua franca of documentation, blogs, and content-heavy pages. Allowing developers to write templates in Markdown with the same `{{ }}` interpolation, `{% if %}`/`{% for %}` control flow, and component tags (`<user-card>`) as HTML templates dramatically reduces boilerplate for content-heavy components. A DI-injectable Markdown parser port allows users to start with the built-in minimal parser (stdlib-only) and upgrade to a full CommonMark-compliant parser by injecting a third-party library.
+
+## What Changes
+
+- Define `MarkdownPort` ABC in `webcompy/ports` with DI key `MARKDOWN_PORT_KEY`
+- Implement `DefaultMarkdownParser` — a minimal but practical Markdown-to-HTML converter (~300 lines) supporting headings, paragraphs, ordered/unordered/nested lists, code blocks, inline formatting, links, images, blockquotes, horizontal rules, and HTML block passthrough
+- Implement `render_markdown(source, context)` — a pipeline that converts Markdown to HTML, strips `<p>` wrappers around `{% %}` directives, and feeds the result to `render_template`
+- Register `DefaultMarkdownParser` in both `BrowserRenderContext` and `ServerRenderContext`
+- Support file-based Markdown loading via `Path`
+- Support all HTML template engine features: `{{ }}`, `{% if %}`, component tags in HTML blocks
+- Support `{% for %}` via standard `repeat()` path (baseline): Markdown-native list bodies produce one list block per iteration; full list-merging with `MarkdownForElement` is added in Change 7
+
+## Capabilities
+
+### New Capabilities
+_None — extends `template-engine` and `port-abstraction`_
+
+### Modified Capabilities
+- `template-engine`: Markdown template rendering via `render_markdown`
+- `port-abstraction`: New `MarkdownPort` ABC and `MARKDOWN_PORT_KEY` DI key
+
+## Known Issues Addressed
+_None — this is a new capability layered on Changes 1, 2, 4, 5_
+
+## Non-goals
+- Tables, footnotes, definition lists in DefaultMarkdownParser (available via third-party DI injection)
+- Full CommonMark compliance in DefaultMarkdownParser
+- Markdown-to-Markdown transformations
+- Inline-only Markdown (always full document)
+- `{% for %}` list-body merging into single `<ul>` — deferred to Change 7 (`MarkdownForElement`)
+
+## Impact
+
+- **New file**: `webcompy/ports/_markdown.py` — `MarkdownPort` ABC
+- **New file**: `webcompy/template/_markdown_default.py` — `DefaultMarkdownParser`
+- **Modified file**: `webcompy/ports/_keys.py` — add `MARKDOWN_PORT_KEY`
+- **Modified file**: `webcompy/app/_render_context.py` — `BrowserRenderContext._register_ports()`
+- **Modified file**: `webcompy-server/src/webcompy_server/_context.py` — `ServerRenderContext._register_ports()`
+- **Modified file**: `webcompy/template/__init__.py` — export `render_markdown`
+- **No breaking changes**
+
+## Dependencies
+
+- **Depends on**: Change 1 (template interpolation — `render_template` API)
+- **Depends on**: Change 2 (control flow — `{% if %}`/`{% for %}` in Markdown)
+- **Depends on**: Change 3 (component tags — `<user-card>` in Markdown HTML blocks)
+- **Depends on**: Change 4 (file loading — `_load_file` for Path support)
+- **Required by**: Change 7 (markdown for-expansion — `MarkdownForElement` list-body merging)
+- **Recommended implementation order**: Sixth template-engine change (0 → 1 → 2 → 3 → 4 → 5 → **6** → 7)

--- a/openspec/changes/feat-template-markdown/specs/port-abstraction/spec.md
+++ b/openspec/changes/feat-template-markdown/specs/port-abstraction/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: MarkdownPort ABC shall exist
+
+The system SHALL provide a `MarkdownPort` abstract base class in `webcompy.ports` with a single abstract method `render(source: str) -> str` that converts Markdown text to HTML.
+
+#### Scenario: MarkdownPort is importable
+- **WHEN** a developer imports `webcompy.ports`
+- **THEN** `MarkdownPort` SHALL be accessible
+
+#### Scenario: MarkdownPort cannot be instantiated directly
+- **WHEN** a developer attempts to instantiate `MarkdownPort` directly
+- **THEN** Python SHALL raise `TypeError` due to abstract method `render`
+
+#### Scenario: BrowserRenderContext provides default MarkdownPort
+- **WHEN** a `BrowserRenderContext` is created
+- **THEN** `MARKDOWN_PORT_KEY` SHALL be provided with a `DefaultMarkdownParser` instance
+
+#### Scenario: ServerRenderContext provides default MarkdownPort
+- **WHEN** a `ServerRenderContext` is created
+- **THEN** `MARKDOWN_PORT_KEY` SHALL be provided with a `DefaultMarkdownParser` instance
+
+#### Scenario: Custom parser injection
+- **WHEN** a user calls `app.provide(MARKDOWN_PORT_KEY, CustomParser())`
+- **THEN** `inject(MARKDOWN_PORT_KEY)` SHALL return the custom parser instance

--- a/openspec/changes/feat-template-markdown/specs/template-engine/spec.md
+++ b/openspec/changes/feat-template-markdown/specs/template-engine/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: DefaultMarkdownParser shall convert Markdown to HTML
+
+`DefaultMarkdownParser.render(source)` SHALL convert Markdown text to HTML strings. `textwrap.dedent` SHALL be applied to the source before parsing.
+
+#### Scenario: Headings
+- **WHEN** source contains `# Title`, `## Section`, ... `###### Sub`
+- **THEN** the output SHALL be `<h1>Title</h1>`, `<h2>Section</h2>`, ... `<h6>Sub</h6>`
+
+#### Scenario: Paragraphs
+- **WHEN** source contains consecutive non-blank lines
+- **THEN** they SHALL be joined into `<p>text</p>` with inline formatting applied
+
+#### Scenario: Unordered lists
+- **WHEN** source contains `- item1` and `- item2`
+- **THEN** the output SHALL be `<ul><li>item1</li><li>item2</li></ul>`
+
+#### Scenario: Ordered lists
+- **WHEN** source contains `1. first` and `2. second`
+- **THEN** the output SHALL be `<ol><li>first</li><li>second</li></ol>`
+
+#### Scenario: Nested lists
+- **WHEN** source contains an indented list item under a parent item
+- **THEN** a nested `<ul>` or `<ol>` SHALL be produced inside the parent `<li>`
+- **AND** tabs SHALL be normalized to 2 spaces for indent calculation
+
+#### Scenario: Fenced code blocks
+- **WHEN** source contains lines between ```` ``` ```` fences
+- **THEN** the output SHALL be `<pre><code>content</code></pre>`
+
+#### Scenario: Inline formatting
+- **WHEN** source contains `**bold**`, `*italic*`, `` `code` ``, `[link](url)`, `![img](url)`, `~~strike~~`
+- **THEN** they SHALL be converted to `<strong>`, `<em>`, `<code>`, `<a href>`, `<img>`, `<del>` respectively
+
+#### Scenario: Blockquotes
+- **WHEN** source contains `> quoted text`
+- **THEN** the output SHALL be `<blockquote>quoted text</blockquote>`
+
+#### Scenario: Horizontal rules
+- **WHEN** source contains `---`, `***`, or `___` on its own line
+- **THEN** the output SHALL be `<hr>`
+
+#### Scenario: HTML block passthrough
+- **WHEN** lines start with `<` (HTML blocks)
+- **THEN** they SHALL be preserved as-is in the output without Markdown processing
+- **AND** component tags (`<user-card>`) SHALL pass through unchanged
+
+### Requirement: render_markdown shall produce reactive Element trees from Markdown
+
+`render_markdown(source: str | Path, context: dict) -> ElementAbstract` SHALL render Markdown templates into reactive Element trees. The pipeline SHALL be: Markdown → HTML (via MarkdownPort) → strip directive paragraphs → parse HTML with multi-root support → bind → FragmentElement wrapping for multi-root. When Markdown produces a single top-level element, an `Element` SHALL be returned directly. When Markdown produces multiple top-level elements, a `FragmentElement` SHALL be returned containing all root elements.
+
+#### Scenario: Basic Markdown rendering (single element)
+- **WHEN** `render_markdown("# Hello {{ name }}", {"name": "World"})` is called
+- **THEN** an `Element("h1", ..., [TextElement("Hello World")])` SHALL be returned
+
+#### Scenario: Basic Markdown rendering (multiple elements)
+- **WHEN** `render_markdown("# Title\n\nText.", ctx)` is called
+- **THEN** a `FragmentElement([Element("h1", ...), Element("p", ...)])` SHALL be returned
+
+#### Scenario: Component root usage with wrapper
+- **WHEN** a developer returns `html.ARTICLE({}, render_markdown("..", ctx))` from a component setup
+- **THEN** the FragmentElement SHALL render transparently inside `<article>`
+- **AND** no extra `<div>` wrapper SHALL appear in the DOM
+
+#### Scenario: Multi-root Markdown requires explicit wrapper as component root
+- **WHEN** a developer returns `render_markdown("# Title\n\nText.", ctx)` directly from a component setup (producing multiple top-level elements → `FragmentElement`)
+- **THEN** `Component.__init_component` SHALL raise `WebComPyException("Root Node of Component must be instance of 'Element'")` because the root is a `FragmentElement`, not an `Element`
+- **AND** the developer SHALL wrap the result in an explicit root element (e.g., `html.ARTICLE({}, render_markdown(...))`)
+
+#### Scenario: {{ }} interpolation in Markdown
+- **WHEN** `render_markdown("## {{ title }}", {"title": Signal("Home")})` is called
+- **THEN** a reactive `TextElement(Signal("Home"))` SHALL be produced inside `<h2>`
+
+#### Scenario: {% for %} over Markdown list (baseline — one <ul> per iteration)
+- **WHEN** source contains `{% for item in items %}\n- {{ item }}\n{% endfor %}`
+- **THEN** the `{% for %}` and `{% endfor %}` SHALL NOT be wrapped in `<p>` tags
+- **AND** the for-body `<ul><li>{{ item }}</li></ul>` SHALL be repeated via `repeat()`, producing one `<ul>` per iteration (baseline behavior)
+- **AND** `{{ item }}` SHALL be reactive within each iteration
+- **NOTE**: Merging into a single `<ul>` is deferred to Change 7 (`MarkdownForElement`)
+
+#### Scenario: Component tags in Markdown HTML blocks
+- **WHEN** source contains `<user-card title="Hello" />`
+- **THEN** the component tag SHALL be preserved through Markdown parsing
+- **AND** `render_template` SHALL resolve it via ComponentStore (Change 3)
+
+#### Scenario: File loading
+- **WHEN** `render_markdown(Path("page.md"), ctx)` is called in a server environment
+- **THEN** the file SHALL be read, parsed as Markdown, and rendered
+
+### Requirement: {% %} directives shall not be wrapped in paragraph tags
+
+Line-by-line `{% %}` directives (e.g., `{% for item in items %}`) that would be wrapped in `<p>` tags by the Markdown parser SHALL have those `<p>` wrappers removed before passing to `render_template`.
+
+#### Scenario: {% for %} directive unwrapped
+- **WHEN** Markdown processing produces `<p>{% for item in items %}</p>`
+- **THEN** the `<p>` wrapper SHALL be stripped to `{% for item in items %}`
+
+#### Scenario: {% if %} with text preserved
+- **WHEN** Markdown produces `<p>{% if x %}visible text{% endif %}</p>`
+- **THEN** the `<p>` SHALL NOT be stripped (directive has sibling text content)

--- a/openspec/changes/feat-template-markdown/tasks.md
+++ b/openspec/changes/feat-template-markdown/tasks.md
@@ -1,0 +1,90 @@
+## 1. MarkdownPort ABC + DI Key
+
+- [ ] 1.1 Define `MarkdownPort` ABC in `webcompy/ports/_markdown.py` with abstract `render(source: str) -> str` method
+- [ ] 1.2 Add `MARKDOWN_PORT_KEY = InjectKey[MarkdownPort]("webcompy-port-markdown")` to `webcompy/ports/_keys.py`
+- [ ] 1.3 Add `MarkdownPort` and `MARKDOWN_PORT_KEY` to `webcompy/ports/__init__.py` (import + `__all__`), following the existing port export pattern
+
+## 2. DefaultMarkdownParser
+
+- [ ] 2.1 Implement `DefaultMarkdownParser(MarkdownPort)` in `webcompy/template/_markdown_default.py`
+- [ ] 2.2 Implement block-level parser: headings (`#`~`######`), paragraphs (consecutive non-blank lines), blank line handling
+- [ ] 2.3 Implement list parser with nested list support (indent-based nesting, tab→2space normalization, ul/ol mixed nesting)
+- [ ] 2.4 Implement fenced code block parser (```` ``` ```` fences, optional language hint ignored)
+- [ ] 2.5 Implement blockquote parser (`>` prefix, multi-line joins)
+- [ ] 2.6 Implement horizontal rule parser (`---`, `***`, `___` on own line)
+- [ ] 2.7 Implement HTML block detection: lines starting with `<` output as-is (passthrough)
+- [ ] 2.8 Implement inline parser: bold (`**`), italic (`*`), strikethrough (`~~`), inline code (`` ` ``), links (`[]()`), images (`![]()`)
+- [ ] 2.9 Ensure inline formatting order: images before links, bold before italic
+- [ ] 2.10 Apply `textwrap.dedent` to source before parsing
+
+## 3. Port Registration
+
+- [ ] 3.1 Import `DefaultMarkdownParser` and `MARKDOWN_PORT_KEY` in `BrowserRenderContext._register_ports()`
+- [ ] 3.2 Provide `DefaultMarkdownParser()` via `self._di_scope.provide(MARKDOWN_PORT_KEY, DefaultMarkdownParser())`
+- [ ] 3.3 Do the same in `ServerRenderContext._register_ports()`
+
+## 4. render_markdown Pipeline
+
+- [ ] 4.1 Implement `render_markdown(source: str | Path, context: dict) -> ElementAbstract` in `webcompy/template/__init__.py`
+- [ ] 4.2 Implement source loading: `str` → use directly; `Path` → `_load_file` from `webcompy.template._files` (created by Change 4)
+- [ ] 4.3 Implement `inject(MARKDOWN_PORT_KEY).render(text)` to convert Markdown to HTML
+- [ ] 4.4 Implement `_strip_directive_paragraphs(html) -> str` using regex to remove `<p>` wrappers around lone `{% %}` directives
+- [ ] 4.5 Call `_render_nodes(html, context)` (shared function from Change 1) to parse + bind without single-root validation
+- [ ] 4.6 If result has 1 node → return it directly; if multiple nodes → wrap in `FragmentElement` and return
+- [ ] 4.7 Export `render_markdown` from `webcompy.template.__init__`
+
+## 5. Unit Tests — DefaultMarkdownParser
+
+- [ ] 5.1 Headings (h1-h6, with/without space after `#`)
+- [ ] 5.2 Paragraphs (single line, multi-line joined, with inline formatting)
+- [ ] 5.3 Unordered lists (`-` and `*` markers)
+- [ ] 5.4 Ordered lists (`1.` and `1)` markers)
+- [ ] 5.5 Nested lists (indent-based, ul/ol mixed, 3+ levels)
+- [ ] 5.6 Deeply nested lists (3+ levels, alternate markers)
+- [ ] 5.7 Code blocks (```` ``` ```` fenced, with language hint ignored)
+- [ ] 5.8 Inline code (backtick)
+- [ ] 5.9 Bold (`**text**`) and italic (`*text*`)
+- [ ] 5.10 Strikethrough (`~~text~~`)
+- [ ] 5.11 Links (`[text](url)`)
+- [ ] 5.12 Images (`![alt](url)`)
+- [ ] 5.13 Horizontal rules (`---`, `***`, `___`)
+- [ ] 5.14 Blockquotes (`> text`, multi-line join)
+- [ ] 5.15 HTML block passthrough (div, span, component tags like `<user-card>`)
+- [ ] 5.16 `{{ }}` and `{% %}` preserved as plain text in output
+- [ ] 5.17 Mixed content (heading + paragraph + nested list + blockquote + code)
+
+## 6. Unit Tests — render_markdown Pipeline
+
+- [ ] 6.1 Basic `render_markdown` single-root → returns Element
+- [ ] 6.2 Basic `render_markdown` multi-root → returns FragmentElement
+- [ ] 6.3 `{{ }}` interpolation in Markdown text (str and Signal values)
+- [ ] 6.4 `{% if %}` / `{% elif %}` / `{% else %}` blocks in Markdown
+- [ ] 6.5 `{% for %}` blocks wrapping multiple Markdown elements
+- [ ] 6.6 `{% for %}` and `{% endfor %}` `<p>` wrapper stripping
+- [ ] 6.7 `{% for %}` with nested `{% if %}` in body
+- [ ] 6.8 Component tags in Markdown HTML blocks
+- [ ] 6.9 File-based Markdown loading (`Path`)
+- [ ] 6.10 `textwrap.dedent` applied to Markdown source
+- [ ] 6.11 FragmentElement renders transparently inside parent element
+- [ ] 6.12 render_markdown as component root with explicit wrapper
+
+## 7. Unit Tests — DI
+
+- [ ] 7.1 DefaultMarkdownParser provided by default in BrowserRenderContext
+- [ ] 7.2 DefaultMarkdownParser provided by default in ServerRenderContext
+- [ ] 7.3 Custom parser injection via `app.provide(MARKDOWN_PORT_KEY, ...)`
+- [ ] 7.4 `inject(MARKDOWN_PORT_KEY)` returns correct instance after injection
+
+## 8. Integration Tests
+
+- [ ] 8.1 Component using `render_markdown` with `locals()`
+- [ ] 8.2 Reactive Markdown: Signal value change → DOM text update
+- [ ] 8.3 Markdown with `{% for %}` containing Markdown-formatted items (Signal preservation)
+- [ ] 8.4 Markdown with component tags and dynamic props (`<card :count="signal">`)
+- [ ] 8.5 SSR/SSG with Markdown template
+- [ ] 8.6 Custom Markdown parser via DI (e.g., mistletoe adapter)
+
+## 9. CI Review Update
+
+- [ ] 9.1 Update `.opencode/agents/ci-review.md`: add MarkdownPort and DefaultMarkdownParser patterns
+- [ ] 9.2 Update `AGENTS.md` File→Spec Mapping: `webcompy/ports/_markdown.py` → `port-abstraction` spec; `webcompy/template/_markdown_default.py` → `template-engine` spec

--- a/openspec/changes/refactor-element-foundations/.openspec.yaml
+++ b/openspec/changes/refactor-element-foundations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-14

--- a/openspec/changes/refactor-element-foundations/design.md
+++ b/openspec/changes/refactor-element-foundations/design.md
@@ -1,0 +1,87 @@
+## Context
+
+`ChildNode` (`generators.py:66`) annotates the return type of `NodeGenerator` and the `repeat()` template callbacks. Its current union explicitly lists `ElementBase`, `TextElement`, `MultiLineTextElement`, and `NewLine`. The class hierarchy is:
+
+```
+ElementAbstract (root)
+├── ElementWithChildren
+│   ├── ElementBase -> Element, Component
+│   └── DynamicElement -> SwitchElement, RepeatElement -> MultiLineTextElement
+├── TextElement
+└── NewLine
+```
+
+`TextElement`, `NewLine`, and `MultiLineTextElement` are all `ElementAbstract` descendants. `ElementBase` is also an `ElementAbstract` descendant. The only members NOT covered by `ElementBase` are the `DynamicElement` subclasses. The alias explicitly added `MultiLineTextElement` (a DynamicElement) but omitted `SwitchElement` / `RepeatElement` — an inconsistency rooted in the fact that `DynamicElement` extends `ElementWithChildren` directly, not `ElementBase`, making it a sibling of `ElementBase` rather than a subclass.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `ChildNode` structurally correct by basing it on `ElementAbstract`
+- Eliminate per-element patching of the alias for future `DynamicElement` types (e.g., `FragmentElement`)
+- Extract a shared `_run_refresh_sync` helper from the duplicated code in `SwitchElement` and `RepeatElement`
+- Keep all changes behavior-preserving (no runtime effect)
+
+**Non-Goals:**
+- Merging `ChildNode` and `ElementChildren` into a single alias
+- Public export of `ChildNode`
+
+## Decisions
+
+### D1: `ElementAbstract | SignalBase | str | None`
+
+Replace the current union with `ElementAbstract | SignalBase[Any] | str | None`. All text / newline / dynamic element types are `ElementAbstract` subclasses and are subsumed by the root.
+
+**Rationale**: `ElementAbstract` is the common root of every renderable node (`Element`, `Component`, `TextElement`, `NewLine`, `SwitchElement`, `RepeatElement`, `MultiLineTextElement`, and future `FragmentElement`). Basing `ChildNode` on it removes the inconsistency and is future-proof — no additional type-alias edits are needed when new element types are introduced.
+
+**Alternatives considered**: Adding `DynamicElement` to the existing union would fix `SwitchElement` / `RepeatElement` / `FragmentElement` but perpetuate the pattern of per-element patching. Widening to `ElementAbstract` is the cleanest single change.
+
+### D2: Type widening is safe (backward compatible)
+
+`ElementBase` is a subclass of `ElementAbstract`, so widening from `ElementBase` to `ElementAbstract` only ADDS accepted types. Every value previously valid under `ChildNode` remains valid. No call site narrows on `ChildNode` being `ElementBase`-bounded: `ChildNode` is consumed only as a return-type annotation in `NodeGenerator` and `repeat()` callbacks. Runtime dispatch uses `_create_child_element` (which is typed over `ElementChildren` = `ElementAbstract | ...`), not `ChildNode`.
+
+### D3: Shared `_run_refresh_sync` helper in `_dynamic.py`
+
+`_switch.py:76-92` and `_repeat.py:144-160` contain an identical sync-wrapper pattern: the `_refresh_sync` method that imports `asyncio`, detects the running event loop, handles the `ENVIRONMENT != "pyscript"` / `nest_asyncio` branch, and calls `loop.run_until_complete(self._refresh(*args))`. The only variable part is `self._refresh` (the bound async method).
+
+Extract a module-level helper:
+
+```python
+# _dynamic.py (new)
+from typing import Any, Awaitable, Callable
+
+def _run_refresh_sync(refresh: Callable[..., Awaitable[None]], *args: Any) -> None:
+    import asyncio
+    from webcompy.utils._environment import ENVIRONMENT
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(refresh(*args))
+    else:
+        if ENVIRONMENT != "pyscript":
+            import nest_asyncio
+            if not getattr(loop, "_nest_asyncio_patched", False):
+                nest_asyncio.apply(loop)
+                loop._nest_asyncio_patched = True  # type: ignore[attr-defined]
+        loop.run_until_complete(refresh(*args))
+```
+
+Switch and Repeat become:
+
+```python
+def _refresh_sync(self, *args: Any):
+    _run_refresh_sync(self._refresh, *args)
+```
+
+**Rationale**: The sync wrapper is a non-trivial async pattern (imports `nest_asyncio`, handles loop state, guards against `pyscript` environment). Three copies (including the upcoming `MarkdownForElement`) create maintenance risk — a fix to this pattern would need to be propagated to all three. `_dynamic.py` is the natural home: it already imports `asyncio` and hosts module-level helpers (`_subtree_has_async_setup`, `_patch_children`, `_position_element_nodes`). The extraction is behavior-preserving (pure refactor).
+
+**Alternatives considered**: Keeping the duplication and documenting it as known debt. This is acceptable short-term but the async pattern is exactly the kind of code that benefits from single-point maintenance. Since `MarkdownForElement` is about to add a third copy, now is the right time to consolidate.
+
+## Risks / Trade-offs
+
+- **[Risk] Hidden narrowing on `ElementBase`** -> Mitigation: Grep confirmed no consumer narrows `ChildNode` to `ElementBase`. `pyright` will catch any regression.
+- **[Note] `ChildNode` and `ElementChildren` become structurally identical** -> Acceptable; unification is a separate, optional cleanup.
+- **[Risk] `_run_refresh_sync` extraction changes behavior** -> Mitigation: The extracted function is a verbatim copy of the existing sync-wrapper body; the only change is from method call (`self._refresh(*args)`) to delegate call (`refresh(*args)`). `pytest tests/ --tb=short` confirms no regressions.
+
+## Open Questions
+
+None — all design decisions resolved during planning phase.

--- a/openspec/changes/refactor-element-foundations/proposal.md
+++ b/openspec/changes/refactor-element-foundations/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+Two element-system refactors needed before the template engine:
+
+**`ChildNode` type widening**: The `ChildNode` type alias in `webcompy/elements/generators.py` is declared as `ElementBase | TextElement | MultiLineTextElement | NewLine | SignalBase | str | None`. However, `DynamicElement` subclasses (`SwitchElement`, `RepeatElement`) extend `ElementWithChildren -> ElementAbstract`, NOT `ElementBase`. This creates a latent type gap: the return values of `switch()` and `repeat()` (both `DynamicElement`) are technically not valid `ChildNode` members under strict type checking. The alias only appears to work because `MultiLineTextElement` (a `RepeatElement` subclass) was added explicitly while its parent `RepeatElement` and sibling `SwitchElement` were omitted — an inconsistency.
+
+**`_refresh_sync` common helper**: `_switch.py:76-92` and `_repeat.py:144-160` contain virtually identical `_refresh_sync` implementations (the nest_asyncio + loop.run_until_complete sync wrapper). The upcoming `MarkdownForElement` (template engine) would create a third copy. Extracting a shared `_run_refresh_sync` helper in `_dynamic.py` and reducing Switch/Repeat to one-line delegations eliminates duplication and keeps the async-invariant pattern in one place.
+
+The upcoming template engine introduces `FragmentElement` (another `DynamicElement`) and `MarkdownForElement`. Rather than patching the `ChildNode` alias per-element and duplicating the `_refresh_sync` pattern, this change addresses both proactively.
+
+## What Changes
+
+### Part 1: ChildNode type widening
+- Consolidate `ChildNode` from `ElementBase | TextElement | MultiLineTextElement | NewLine | SignalBase[Any] | str | None` to `ElementAbstract | SignalBase[Any] | str | None`
+- `TextElement`, `MultiLineTextElement`, and `NewLine` are removed from the explicit union because they are all `ElementAbstract` subclasses (subsumed)
+- This is a type widening (`ElementBase` is a subset of `ElementAbstract`); all previously accepted values remain valid, and `SwitchElement` / `RepeatElement` / future `FragmentElement` become correctly typed
+
+### Part 2: `_refresh_sync` common helper
+- Extract a `_run_refresh_sync(refresh: Callable[..., Awaitable[None]], *args: Any) -> None` helper in `webcompy/elements/types/_dynamic.py`
+- The helper encapsulates the nest_asyncio + loop.run_until_complete sync wrapper (currently duplicated verbatim in `_switch.py:76-92` and `_repeat.py:144-160`)
+- Reduce `SwitchElement._refresh_sync` and `RepeatElement._refresh_sync` to one-line delegations: `_run_refresh_sync(self._refresh, *args)`
+- `MarkdownForElement` (template engine Change 6) will use the same helper instead of creating a third copy
+
+## Capabilities
+
+### New Capabilities
+_None_
+
+### Modified Capabilities
+- `elements`: `ChildNode` type alias widened to `ElementAbstract` base, subsuming text/newline element types and covering all `DynamicElement` subclasses
+
+## Known Issues Addressed
+_None — proactively resolves a latent type gap surfaced during the template-engine proposal review_
+
+## Non-goals
+- Unifying `ChildNode` and `ElementChildren` into a single alias (they are structurally identical after this change; consolidation deferred to avoid churn)
+- Changing runtime behavior of `_create_child_element` or `_is_patchable` (purely a type-alias change)
+- Adding `ChildNode` to the public `webcompy.elements` export surface
+
+## Impact
+
+- **Modified files**: 
+  - `packages/webcompy/src/webcompy/elements/generators.py` — `ChildNode` alias (line 66); adjust imports (add `ElementAbstract`, drop `ElementBase` if no other usage)
+  - `packages/webcompy/src/webcompy/elements/types/_dynamic.py` — add `_run_refresh_sync` helper function
+  - `packages/webcompy/src/webcompy/elements/types/_switch.py` — `_refresh_sync` reduced to one-line delegation
+  - `packages/webcompy/src/webcompy/elements/types/_repeat.py` — `_refresh_sync` reduced to one-line delegation
+- **Type-only change** (Part 1): No runtime behavior change. `pyright` is the verification gate.
+- **Pure refactor** (Part 2): Behavior-preserving extraction. `pytest` confirms no regressions.
+- **No breaking changes**: Type widening is backward-compatible.
+
+## Dependencies
+
+- **Depends on**: None
+- **Required by**: `feat-template-control-flow` (FragmentElement relies on `ChildNode` accepting `DynamicElement`), `feat-template-markdown-for-expansion` (MarkdownForElement uses `_run_refresh_sync` helper)
+- **Recommended implementation order**: First (0 -> 1 -> 2 -> 3 -> 4 -> 5 -> 6 -> 7)

--- a/openspec/changes/refactor-element-foundations/specs/elements/spec.md
+++ b/openspec/changes/refactor-element-foundations/specs/elements/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: ChildNode type alias shall accept all renderable node types
+
+`ChildNode` SHALL be defined as `ElementAbstract | SignalBase[Any] | str | None`. Because `ElementAbstract` is the common root of `Element`, `Component`, `TextElement`, `NewLine`, and all `DynamicElement` subclasses (`SwitchElement`, `RepeatElement`, `MultiLineTextElement`, and future `FragmentElement`), the alias SHALL accept any renderable element node without per-type enumeration.
+
+#### Scenario: switch() result is a valid ChildNode
+- **WHEN** a `NodeGenerator` returns a `SwitchElement` (from `switch()`)
+- **THEN** the return value SHALL be a valid `ChildNode` under static type checking
+
+#### Scenario: repeat() result is a valid ChildNode
+- **WHEN** a `NodeGenerator` returns a `RepeatElement` or `MultiLineTextElement`
+- **THEN** the return value SHALL be a valid `ChildNode` under static type checking
+
+#### Scenario: Future DynamicElement types are automatically covered
+- **WHEN** a new `DynamicElement` subclass (e.g., `FragmentElement`) is introduced
+- **THEN** it SHALL be automatically valid as a `ChildNode` without requiring an edit to the type alias
+
+### Requirement: DynamicElement `_refresh_sync` pattern shall use a shared helper
+
+A `_run_refresh_sync(refresh: Callable[..., Awaitable[None]], *args: Any) -> None` helper SHALL be defined in `webcompy/elements/types/_dynamic.py`. The helper SHALL encapsulate the nest_asyncio + loop.run_until_complete sync-wrapping logic. `SwitchElement._refresh_sync` and `RepeatElement._refresh_sync` SHALL delegate to `_run_refresh_sync` instead of containing their own copies of the sync-wrapper logic.
+
+#### Scenario: SwitchElement uses shared helper
+- **WHEN** `SwitchElement._refresh_sync` is called
+- **THEN** it SHALL delegate to `_run_refresh_sync(self._refresh, *args)`
+- **AND** the runtime behavior SHALL be identical to the pre-extraction implementation
+
+#### Scenario: RepeatElement uses shared helper
+- **WHEN** `RepeatElement._refresh_sync` is called
+- **THEN** it SHALL delegate to `_run_refresh_sync(self._refresh, *args)`
+- **AND** the runtime behavior SHALL be identical to the pre-extraction implementation
+
+#### Scenario: New DynamicElement subclasses use shared helper
+- **WHEN** a new `DynamicElement` subclass (e.g., `MarkdownForElement`) requires `_refresh_sync` semantics
+- **THEN** it SHALL use `_run_refresh_sync(self._refresh, *args)` without duplicating the sync-wrapper logic

--- a/openspec/changes/refactor-element-foundations/tasks.md
+++ b/openspec/changes/refactor-element-foundations/tasks.md
@@ -1,0 +1,17 @@
+## 1. Type Alias Consolidation
+
+- [ ] 1.1 Change `ChildNode` in `packages/webcompy/src/webcompy/elements/generators.py` from `ElementBase | TextElement | MultiLineTextElement | NewLine | SignalBase[Any] | str | None` to `ElementAbstract | SignalBase[Any] | str | None`
+- [ ] 1.2 Update imports in `generators.py`: add `from webcompy.elements.types._abstract import ElementAbstract`; remove `ElementBase` from the existing `from webcompy.elements.types._element import` import if it is not referenced elsewhere in the file
+- [ ] 1.3 Verify that `TextElement`, `MultiLineTextElement`, `NewLine`, and `ElementBase` are not referenced elsewhere in `generators.py` after the `ChildNode` change (unused imports should be removed to keep lint clean)
+
+## 2. `_refresh_sync` Common Helper Extraction
+
+- [ ] 2.1 Implement `_run_refresh_sync(refresh: Callable[..., Awaitable[None]], *args: Any) -> None` in `packages/webcompy/src/webcompy/elements/types/_dynamic.py` — extracts the nest_asyncio + loop.run_until_complete sync wrapper verbatim from `_switch.py:76-92` / `_repeat.py:144-160`
+- [ ] 2.2 Import `_run_refresh_sync` from `_dynamic` in `_switch.py`; reduce `SwitchElement._refresh_sync` to `_run_refresh_sync(self._refresh, *args)`
+- [ ] 2.3 Import `_run_refresh_sync` from `_dynamic` in `_repeat.py`; reduce `RepeatElement._refresh_sync` to `_run_refresh_sync(self._refresh, *args)`
+
+## 3. Verification
+
+- [ ] 3.1 Run `uv run pyright` — confirm no new type errors; existing `switch()` / `repeat()` return-type usages should become cleaner (no latent `DynamicElement` -> `ChildNode` mismatch); `_run_refresh_sync` usages type-check
+- [ ] 3.2 Run `uv run ruff check .` and `uv run ruff format --check .`
+- [ ] 3.3 Run `uv run python -m pytest tests/ --tb=short` — confirm no runtime regressions from either refactor


### PR DESCRIPTION
## Description

This PR adds OpenSpec design artifacts for a new HTML template engine feature to WebComPy. The template engine enables developers to define component templates using HTML syntax with Jinja2-style `{{ }}` interpolation, `{% if %}`/`{% for %}` control flow, `<my-component>` component tag resolution, file-based loading, CSS text support, and Markdown rendering — all producing reactive Element trees that leverage WebComPy's existing signal and element systems.

The changes are organized as 8 interdependent OpenSpec change proposals following a dependency chain:

0. **refactor-element-foundations** — Widen `ChildNode` type alias to `ElementAbstract` and extract a shared `_run_refresh_sync` helper from duplicated code in `SwitchElement`/`RepeatElement`
1. **feat-template-interpolation** — HTML parsing via `html.parser.HTMLParser`, `{{ }}` variable interpolation with reactive Signal pass-through, reactive attribute evaluation via `Computed`, event/ref binding, template AST caching
2. **feat-template-control-flow** — `{% if %}`/`{% elif %}`/`{% else %}` conditional blocks via `switch()`, `{% for %}` loop blocks via `repeat()`, `FragmentElement` for transparent multi-child wrapping
3. **feat-template-component-tags** — `<my-component>` tag resolution via DI-based `ComponentStore` lookup, kebab→PascalCase name conversion, static/dynamic props, default slot passthrough
4. **feat-template-file-loading** — `Path` argument support for `render_template`, caller-module-relative path resolution, browser environment rejection
5. **feat-template-css-text** — CSS text→`StyleDict` parser, `css_text_template` with `{{ }}` interpolation for reactive scoped styles, `ReactiveScopedStyleFunc` type correction
6. **feat-template-markdown** — `MarkdownPort` ABC with DI injection, built-in `DefaultMarkdownParser` (~300 lines), `render_markdown` pipeline, FragmentElement multi-root wrapping
7. **feat-template-markdown-for-expansion** — `MarkdownForElement` for merging `{% for %}` list body items into a single `<ul>`, expression-scoped loop-variable renaming, list-body detection heuristic

No code changes — all 41 artifact files are in `openspec/changes/`.

## Related Resources

- OpenSpec Changes:
  - `refactor-element-foundations`
  - `feat-template-interpolation`
  - `feat-template-control-flow`
  - `feat-template-component-tags`
  - `feat-template-file-loading`
  - `feat-template-css-text`
  - `feat-template-markdown`
  - `feat-template-markdown-for-expansion`
- Specs affected:
  - `openspec/specs/template-engine/spec.md` (new — to be generated after all changes are implemented)
  - `openspec/specs/elements/spec.md` (modified — `ChildNode` type widening, `_run_refresh_sync`)
  - `openspec/specs/port-abstraction/spec.md` (modified — `MarkdownPort` ABC)

## Type of Change

- [x] docs — Documentation

## Breaking Changes?

- [x] No

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [ ] OpenSpec change is archived (if applicable) — not yet; this PR adds the artifacts
- [ ] Tests added/updated for changed code — N/A (no code changes)
- [ ] E2E tests pass (if UI-affecting change) — N/A (no code changes)
- [ ] Dual environment verified (browser + server) — design reviewed for dual-env compatibility
- [x] No new module-level globals introduced (use DI instead) — design verified
- [ ] `webcompy generate` produces correct output (if SSG-visible) — N/A (no code changes)