### PR TITLE
docs: add scope discipline section to review skill

### DIFF
--- a/.opencode/skills/webcompy-review/SKILL.md
+++ b/.opencode/skills/webcompy-review/SKILL.md
@@ -49,6 +49,22 @@ If previous review comments are reachable, look for `REVIEW_RESULT` markers. Do 
 
 Write the review following the template below. Focus ONLY on the diff (Step 1) — do not review unchanged code. Check for code quality issues, potential bugs, and logic errors that CI cannot catch.
 
+## Scope Discipline
+
+### Initial implementation vs review-fix commits
+
+When a PR has undergone multiple review cycles, distinguish the original implementation from subsequent review-fix commits in your analysis. The original implementation is the PRIMARY review target. Review-fix commits SHALL be checked only for: (a) correct resolution of the previous concern, and (b) whether they introduce regressions in the fixed area. Do NOT use review-fix commits as a springboard to expand scope into adjacent edge cases.
+
+### Pre-existing bugs
+
+Bugs in baseline code that the PR did not modify SHALL be 🔵 Note with a recommendation to file a separate change. However, if a pre-existing bug is activated or worsened by the PR's new functionality (i.e., the PR causes the bug to affect code paths it previously did not), flag it at the appropriate severity.
+
+### Severity calibration
+
+- Resource leaks confined to error paths (e.g., template compilation failure due to a missing variable) SHALL be at most 🟡 Should Improve, not 🔴 Must Fix.
+- Edge cases requiring pathological input that does not occur in realistic templates SHALL be at most 🔵 Note.
+- Missing test coverage for unlikely scenarios SHALL be at most 🟡 Should Improve.
+
 ## Critical Framework Invariants
 
 Watch for these WebComPy-specific issues that generic reviewers miss:

--- a/.opencode/skills/webcompy-review/SKILL.md
+++ b/.opencode/skills/webcompy-review/SKILL.md
@@ -53,7 +53,7 @@ Write the review following the template below. Focus ONLY on the diff (Step 1) â
 
 ### Initial implementation vs review-fix commits
 
-When a PR has undergone multiple review cycles, distinguish the original implementation from subsequent review-fix commits in your analysis. The original implementation is the PRIMARY review target. Review-fix commits SHALL be checked only for: (a) correct resolution of the previous concern, and (b) whether they introduce regressions in the fixed area. Do NOT use review-fix commits as a springboard to expand scope into adjacent edge cases.
+When a PR has undergone multiple review cycles, distinguish the original implementation from subsequent review-fix commits in your analysis. The original implementation is the PRIMARY review target. Review-fix commits SHALL be checked for: (a) correct resolution of the previous concern, and (b) whether they introduce regressions in the fixed area or any other area changed by the commit. Do NOT use review-fix commits as a springboard to expand scope into adjacent edge cases.
 
 ### Pre-existing bugs
 


### PR DESCRIPTION
## Description

Adds a "Scope Discipline" section to the `webcompy-review` skill (`SKILL.md`) to prevent review scope creep on PRs that go through multiple AI review cycles.

The section introduces three rules:

1. **Initial implementation vs review-fix commits** — The original implementation is the primary review target. Review-fix commits are checked only for correct resolution of the previous concern and regressions in the fixed area, not used as a springboard to expand into adjacent edge cases.

2. **Pre-existing bugs** — Bugs in baseline code that the PR did not modify are 🔵 Note (recommend a separate change), unless the PR's new functionality activates or worsens them.

3. **Severity calibration** — Error-path resource leaks are capped at 🟡 Should Improve; pathological-input edge cases are capped at 🔵 Note.

This was motivated by PR #223, where 12 review rounds increasingly flagged obscure edge cases in review-fix commits rather than the original implementation, creating an inefficient cycle.

## Related Resources

- OpenSpec Change: N/A (process improvement)
- Issues: none
- Specs affected: none

## Type of Change

- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [x] docs — Documentation
- [ ] chore — Maintenance, dependencies, CI
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [ ] Yes (describe migration path below)
- [x] No

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [x] OpenSpec change is archived (if applicable)
- [ ] Tests added/updated for changed code
- [ ] E2E tests pass (if UI-affecting change)
- [ ] Dual environment verified (browser + server)
- [ ] No new module-level globals introduced (use DI instead)
- [ ] `webcompy generate` produces correct output (if SSG-visible)
