### PR TITLE
docs: add server runtime roadmap change proposals

### DIFF
--- a/openspec/changes/feat-asgi-embed/.openspec.yaml
+++ b/openspec/changes/feat-asgi-embed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/feat-asgi-embed/design.md
+++ b/openspec/changes/feat-asgi-embed/design.md
@@ -1,0 +1,58 @@
+# Design: feat-asgi-embed
+
+## Context
+
+`create_asgi_app()` returns a `_ServingApp` whose `.asgi` is a plain Starlette app — embeddable in principle today. During construction, `ServerFetchPort.configure(asgi, blocked_paths, base_url=...)` binds the fetch port to that inner app (packages/webcompy-cli/src/webcompy_cli/_server.py). `configure_server_context(app, ...)` (packages/webcompy-server/src/webcompy_server/__init__.py) sets up server-side rendering including creating `app._server_fetch_port`. When WebComPy is mounted inside a host app, self-site fetches dispatched through the inner app can never reach host routes (e.g. the host's `/api/...`), because the inner Starlette instance has no knowledge of them.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Official, tested pattern: host ASGI app + `mount(prefix, serving.asgi)`.
+- Self-site fetch from embedded components reaches the host's routes via `root_app` wiring.
+- Clear `base_url` semantics under a mount prefix.
+
+**Non-Goals:**
+- SSG for embedded deployments; lifespan bridging; multi-embed guarantees.
+
+## Decisions
+
+### D1: Explicit `root_app` over implicit discovery
+`configure_server_context(app, *, root_app=None)` — when `root_app` is provided, the CLI's default `fetch_port.configure(inner_asgi, ...)` is superseded: the fetch port binds to `root_app`. Self-site URLs resolve against the host's routing table.
+
+**Why explicit**: there is no reliable way for the inner app to discover its host (ASGI has no back-reference). Alternatives considered: (b) absolute-URL fallback (fetch real network on 404 from inner app) — rejected: requires a listening socket even in-process, breaks SSG-style usage and tests, and silently changes semantics; (c) middleware that rewrites scope — fragile. Explicit wiring keeps responsibility visible at the embedding call site:
+
+```python
+serving = create_asgi_app(app, build_config)
+configure_server_context(app, root_app=host)  # fetch port targets the host
+host.mount("/admin", serving.asgi)
+```
+
+### D2: `base_url` must equal the mount prefix
+With `host.mount("/admin", ...)`, WebComPy's internal routes live under `/admin`. Setting `AppConfig.base_url="/admin/"` makes asset URLs, router links, and self-site URL resolution (`base_url`-relative resolution per `server-fetch-asgi`) align with the embedded location. The spec requires this pairing and the docs show it; a mismatch produces broken asset URLs, which is detectable in verification tests.
+
+Synergy note: `HistoryPort` now owns browser URL updates (`push_url`/`replace_url`, `port-abstraction` spec) and builds browser-visible URLs from `base_url`. With the pairing above, client-side navigation and guard-driven redirects inside the embedded app automatically produce correctly prefixed history URLs with no embed-specific code.
+
+### D3: Blocked paths are prefixed, not widened
+Page-route blocking prevents SSR fetches from recursing into HTML page routes. Under embedding, the blocked set is WebComPy's page paths prefixed by the mount prefix (e.g. `/admin/users`), because that is where the host actually serves them. Host API routes (e.g. `/api/...`) are NOT blocked — they are the intended fetch targets.
+
+### D4: Server-driven verification matrix
+Tests and an example cover: (1) SSR page render through the host mount; (2) `/_webcompy-*` asset endpoints under the prefix; (3) self-site fetch to a host API endpoint during SSR with response baked into hydration payload; (4) direct request to the host API unaffected. `run_server()` is not used in embedded mode (the host owns uvicorn); docs state that `create_asgi_app` + manual wiring replaces `run_server`.
+
+### D5: The `/_webcompy-resource` route is base_url-prefixed — embedding must compensate
+Unlike every other framework route, the resource route is registered INSIDE the serving app with the `base_url` prefix baked in (`base_url_stripped + "/_webcompy-resource/{path:path}"` in `_server.py`), and the browser-side URL builder (`ports/_browser/_resource.py`) likewise prefixes `base_url`; the `cli` spec describes the endpoint as `GET {base_url}_webcompy-resource/{path:path}`. In standalone mode the request path arrives already prefixed, so this matches. Under embedding, Starlette's `Mount` strips the mount prefix before the inner app sees the request; with the required `base_url` == mount-prefix pairing (D2), the inner route would then carry a DOUBLE prefix and never match, breaking resource loading. The implementation SHALL adjust resource-route construction in embedded mode (e.g. register the route without the `base_url` prefix when `root_app` is configured) and SHALL keep standalone behavior byte-identical. Because standalone behavior is unchanged, no `cli` spec delta is required; the `asgi-embed` spec carries the embedded-mode requirement.
+
+## Risks / Trade-offs
+
+- [Double-dispatch cost: self-site fetches re-enter the host app and route back into WebComPy for page paths] → Only when components fetch page paths, which blocked_paths already prevents; API fetches terminate at host endpoints.
+- [`configure()` currently raises when called twice — CLI internally calls it once with the inner app] → The embedding path must bypass/replace that call; implementation adds an explicit reconfiguration path (e.g. `configure(..., allow_rebind=True)` or deferring the CLI call when `root_app` is set). Detail finalized in implementation; spec constrains behavior, not mechanism.
+- [`configure_server_context` re-instantiates the fetch port] → `configure_server_context()` assigns a fresh `ServerFetchPort` to `app._server_fetch_port` on every call. The documented embedding order (`configure_server_context(app, root_app=host)` AFTER `create_asgi_app()`) relies on this: the second call replaces the CLI-configured port, and render contexts read `app._server_fetch_port` at context creation, so subsequent requests use the root-bound port. The `root_app` binding must re-derive prefixed blocked paths and `base_url` for the replacement port. The order is also mandatory: `create_asgi_app()` internally calls `configure_server_context()` via `resolve_build_artifacts`, so a call BEFORE it would be overwritten.
+- [Host middleware (auth, CORS) now wraps WebComPy responses] → Generally desirable; documented as a feature of embedding.
+- [Hash-mode embedding] → Supported identically (pre-rendered shell served under the prefix); covered by a test.
+
+## Migration Plan
+
+None. Default behavior (`root_app=None`) is byte-identical to today.
+
+## Open Questions
+
+- Exact mechanism for superseding the CLI's `configure()` call (rebind flag vs. deferral) — implementation detail to settle with tests.

--- a/openspec/changes/feat-asgi-embed/proposal.md
+++ b/openspec/changes/feat-asgi-embed/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: feat-asgi-embed
+
+## Why
+
+Teams with an existing FastAPI (or other ASGI) application often want to add a small admin UI or internal tool without standing up a separate frontend stack. WebComPy's serving app is already a plain ASGI callable, so embedding should be possible — and it nearly works today via `outer.mount("/admin", serving.asgi)`. But there is one structural blocker: `ServerFetchPort.configure()` is bound to the inner WebComPy ASGI app, so self-site fetches from embedded components can only reach WebComPy's own routes — they cannot reach the outer app's endpoints (the very APIs an embedded admin UI exists to consume). This change makes embedding an officially supported, documented pattern with the wiring to make self-site fetch reach the outer application.
+
+## What Changes
+
+- `configure_server_context()` gains an optional `root_app` parameter: when provided, `ServerFetchPort` is configured against the outer (root) ASGI application instead of WebComPy's internal serving app, so self-site fetches traverse the full outer routing table (sibling mounts, outer API routes).
+- Official embedding pattern documented: build the serving app via `create_asgi_app()`, mount `serving.asgi` under a path prefix in the host app, and pass the host app as `root_app`.
+- `AppConfig.base_url` SHALL be set to the mount prefix so generated URLs (assets, page links, self-site fetch resolution) align with the embedded location; the spec defines how `base_url` interacts with the mount prefix.
+- Blocked-path semantics adapt: when `root_app` is used, page-route blocking is evaluated against WebComPy's page paths under the mount prefix; outer API routes remain fetchable.
+- Verified support matrix: SSR rendering embedded under a host FastAPI app; static/asset endpoints served correctly under the prefix; self-site fetch reaching outer endpoints during SSR.
+- Out of scope: running under SSG (embedding is a server-runtime pattern), hot reload inside a host app.
+
+## Capabilities
+
+### New Capabilities
+
+- `asgi-embed`: Embedding a WebComPy serving app into a host ASGI application, including fetch-port wiring (`root_app`), `base_url`/prefix alignment, and blocked-path behavior.
+
+### Modified Capabilities
+
+- `server-fetch-asgi`: `ServerFetchPort.configure()` SHALL support binding to a root ASGI app distinct from WebComPy's internal serving app, with self-site resolution and blocking evaluated accordingly.
+
+## Impact
+
+- **Code**: `packages/webcompy-server/src/webcompy_server/__init__.py` (`configure_server_context` signature), `packages/webcompy-server/src/webcompy_server/ports/_fetch.py` (root-app binding), docs and an example project.
+- **APIs**: additive parameter; no breaking changes.
+- **Dependencies**: none.
+- **Specs**: new `asgi-embed`; delta to `server-fetch-asgi`.
+
+## Known Issues Addressed
+
+(none)
+
+## Non-goals
+
+- Mounting external apps INTO WebComPy (that is `feat-asgi-mount`).
+- An embedded app that simultaneously configures its own `WebComPyServerConfig.mounts` (combining `root_app` binding with inner mounts) — unspecified; may be addressed by a future change.
+- Lifespan bridging beyond what Starlette mounting already provides (host app owns startup/shutdown; WebComPy has no server-side lifespan needs today).
+- Multiple embedded WebComPy apps in one host (not verified; may work, not guaranteed).
+- SSG for embedded deployments.

--- a/openspec/changes/feat-asgi-embed/specs/asgi-embed/spec.md
+++ b/openspec/changes/feat-asgi-embed/specs/asgi-embed/spec.md
@@ -1,0 +1,54 @@
+# Spec: asgi-embed
+
+## ADDED Requirements
+
+### Requirement: WebComPy serving apps shall be embeddable into host ASGI applications
+The framework SHALL officially support embedding a WebComPy serving app into a host ASGI application via standard mounting (e.g. Starlette/FastAPI `Mount`/`mount`). The documented pattern is: construct the serving app with `create_asgi_app()`, wire the fetch port with `configure_server_context(app, root_app=host)`, and mount `serving.asgi` under a path prefix. In embedded mode the host application owns the server process (`run_server()` is not used). SSR pages, framework asset endpoints, and static files SHALL be served correctly under the mount prefix.
+
+#### Scenario: Embedded SSR page render
+- **WHEN** a WebComPy app is mounted at `/admin` in a host FastAPI app and a client requests `/admin/` (or a page path under it)
+- **THEN** the SSR HTML SHALL be returned with correct asset URLs under `/admin`
+
+#### Scenario: Framework endpoints work under the prefix
+- **WHEN** a client requests `/_webcompy-assets/...` or other framework endpoints under the mount prefix
+- **THEN** they SHALL be served as in standalone mode
+
+#### Scenario: Resource endpoint works under the prefix
+- **WHEN** a client requests `{mount_prefix}/_webcompy-resource/{path}` for an allow-listed resource
+- **THEN** the resource SHALL be served as in standalone mode
+- **AND** the standalone (non-embedded) resource-route behavior SHALL remain unchanged
+
+#### Scenario: Host routes unaffected
+- **WHEN** the host app has its own routes (e.g. `/api/items`)
+- **THEN** direct requests to those routes SHALL be handled by the host exactly as if WebComPy were not mounted
+
+### Requirement: base_url shall match the mount prefix in embedded mode
+When embedded under a mount prefix, `AppConfig.base_url` SHALL be set to that prefix (e.g. `/admin/`). Generated asset URLs, router links, and self-site fetch URL resolution SHALL then align with the embedded location. The documentation SHALL present `base_url` and the mount prefix as a required pairing.
+
+#### Scenario: Asset URLs carry the prefix
+- **WHEN** `base_url="/admin/"` and the app is mounted at `/admin`
+- **THEN** URLs emitted into the HTML for scripts/assets SHALL begin with `/admin/`
+
+#### Scenario: Client-side navigation builds prefixed history URLs
+- **WHEN** an embedded history-mode app with `base_url="/admin/"` performs a client-side navigation to `/users`
+- **THEN** the browser history URL SHALL be built with the prefix via `HistoryPort` URL updates (`/admin/users/`)
+- **AND** guard-driven redirects SHALL likewise replace URLs under the prefix
+
+### Requirement: Self-site fetch in embedded mode shall reach the host application
+When `configure_server_context(app, root_app=host)` is used, `ServerFetchPort` SHALL dispatch self-site fetches against the host ASGI application, so fetches from embedded components can reach the host's own routes (including sibling mounts and host API endpoints) in-process during SSR. Fetched responses SHALL be recorded in the hydration transfer cache as usual.
+
+#### Scenario: Component fetches a host API during SSR
+- **WHEN** an embedded component fetches `/api/items` during SSR and `/api/items` is a host route outside the WebComPy mount
+- **THEN** the request SHALL be dispatched in-process through the host app via ASGI transport
+- **AND** the response SHALL be returned to the component and recorded in the transfer cache
+
+### Requirement: Blocked paths in embedded mode shall cover prefixed page routes only
+In embedded mode, page-route blocking SHALL apply to WebComPy page paths under the mount prefix (e.g. `/admin/users`), preventing recursive SSR fetches. Host routes outside the mount prefix SHALL NOT be blocked.
+
+#### Scenario: Page recursion still prevented
+- **WHEN** an embedded component attempts a self-site fetch to `/admin/users` where `/users` is a WebComPy page route
+- **THEN** the fetch SHALL be blocked with the standard blocked-path behavior
+
+#### Scenario: Host API routes are not blocked
+- **WHEN** an embedded component fetches `/api/items` (a host route)
+- **THEN** the fetch SHALL NOT be blocked

--- a/openspec/changes/feat-asgi-embed/specs/server-fetch-asgi/spec.md
+++ b/openspec/changes/feat-asgi-embed/specs/server-fetch-asgi/spec.md
@@ -1,0 +1,14 @@
+# Delta Spec: server-fetch-asgi
+
+## ADDED Requirements
+
+### Requirement: ServerFetchPort shall support binding to a root ASGI app
+`ServerFetchPort` SHALL support being configured against a root ASGI application that is distinct from WebComPy's internal serving app (embedded deployments). `configure_server_context()` SHALL accept an optional `root_app` parameter; when provided, self-site fetch dispatch SHALL target `root_app` instead of the internal serving app. When `root_app` is `None` (default), behavior SHALL be exactly as before. The mechanism SHALL prevent double-configuration conflicts when the CLI also configures the port (either by deferring the CLI's configuration or by an explicit rebind path).
+
+#### Scenario: root_app provided
+- **WHEN** `configure_server_context(app, root_app=host)` is called and the serving app is mounted into `host`
+- **THEN** self-site fetches during SSR SHALL be dispatched through `host` via ASGI transport
+
+#### Scenario: Default binding unchanged
+- **WHEN** `configure_server_context(app)` is called without `root_app`
+- **THEN** self-site fetches SHALL be dispatched through WebComPy's internal serving app as before this change

--- a/openspec/changes/feat-asgi-embed/tasks.md
+++ b/openspec/changes/feat-asgi-embed/tasks.md
@@ -1,0 +1,30 @@
+# Tasks: feat-asgi-embed
+
+## 1. Fetch port root binding
+
+- [ ] 1.1 Add `root_app` parameter to `configure_server_context()` (packages/webcompy-server/src/webcompy_server/__init__.py) and thread it to `ServerFetchPort` configuration
+- [ ] 1.2 Implement root-app binding in `ServerFetchPort` (packages/webcompy-server/src/webcompy_server/ports/_fetch.py): self-site dispatch against `root_app`; resolve the double-`configure()` interaction with the CLI (deferral or explicit rebind)
+- [ ] 1.3 Adjust blocked-path evaluation for embedded mode: page paths prefixed by the mount prefix; host routes outside the prefix never blocked
+
+## 2. Embedding support
+
+- [ ] 2.1 Verify and fix asset/endpoint URL generation under a non-root `base_url` matching the mount prefix; in particular the `/_webcompy-resource` route is registered with the `base_url` prefix inside the app (`_server.py`) while the browser URL builder also prefixes `base_url` (`ports/_browser/_resource.py`) — under a mount this double-prefixes; adjust embedded-mode route construction while keeping standalone behavior unchanged (per design D5)
+- [ ] 2.2 Verify hash-mode serving under a mount prefix
+
+## 3. Tests
+
+- [ ] 3.1 Integration test: host Starlette/FastAPI app with `mount("/admin", serving.asgi)` — SSR page render, framework endpoints under prefix, host routes unaffected
+- [ ] 3.2 Integration test: embedded component self-site fetches a host API route during SSR via ASGI transport; response recorded in transfer cache
+- [ ] 3.3 Test: blocked-path behavior — `/admin/<page>` blocked, host `/api/...` fetchable
+- [ ] 3.4 Test: default (`root_app=None`) behavior byte-identical to before
+
+## 4. Docs and verification
+
+- [ ] 4.1 Docs + minimal example project: embedding WebComPy as an admin UI inside an existing FastAPI app, including the required `base_url`/mount-prefix pairing and the note that the host owns the server process (per `doc-spec-references`: docs reference the owning specs as source of truth rather than transcribing requirement prose)
+- [ ] 4.2 `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run python -m pytest tests/ --tb=short` all pass
+
+## 5. Spec reference sync
+
+- [ ] 5.1 Update AGENTS.md: add `asgi-embed` to the Current Specs list; add File→Spec Mapping entries for `webcompy_server/__init__.py` (`configure_server_context` → `asgi-embed/spec.md`) and the modified `server-fetch-asgi` rows
+- [ ] 5.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions and sync invariant headings/spec references
+- [ ] 5.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes

--- a/openspec/changes/feat-asgi-mount/.openspec.yaml
+++ b/openspec/changes/feat-asgi-mount/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/feat-asgi-mount/design.md
+++ b/openspec/changes/feat-asgi-mount/design.md
@@ -1,0 +1,73 @@
+# Design: feat-asgi-mount
+
+## Context
+
+`create_asgi_app()` (packages/webcompy-cli/src/webcompy_cli/_server.py) builds a flat list of Starlette `Route` objects: internal `/_webcompy-*` endpoints, one route per static file, and a final `/{path:path}` catch-all that performs SSR. The route list is assembled locally with no extension point. `WebComPyServerConfig` (packages/webcompy-cli/src/webcompy_cli/config/_server_config.py) currently holds only `port` and `dev`. SSG (`generate_static_site`) fetches pages through the same ASGI app via `httpx.ASGITransport`, and `ServerFetchPort` routes self-site fetches through the same transport with `blocked_paths` derived from page routes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let projects mount arbitrary ASGI apps (FastAPI, Starlette, raw ASGI callables) at chosen path prefixes.
+- Zero interference with SSR/SSG and framework endpoints; explicit error on path collisions.
+- Self-site fetch to mounts works in-process during SSR and SSG with no extra wiring.
+
+**Non-Goals:**
+- Mounting WebComPy into an external app (see `feat-asgi-embed`).
+- Middleware/auth configuration on behalf of mounted apps.
+- Any typed client or RPC layer.
+
+## Decisions
+
+### D1: Declaration via `WebComPyServerConfig.mounts` as a lazy callable
+```python
+@dataclass
+class WebComPyServerConfig:
+    port: int = 8080
+    dev: bool = False
+    mounts: Callable[[], dict[str, ASGIApp]] | None = None
+```
+Usage:
+```python
+def mounts():
+    from my_app.api import api  # FastAPI app; imported lazily
+    return {"/api": api}
+
+config = WebComPyBuildConfig(..., server=WebComPyServerConfig(mounts=mounts))
+```
+**Why a callable**: importing a FastAPI app at config-import time would drag server-only dependencies into any context that imports the config (including tooling and resolution logic) and slow CLI startup. The callable is invoked exactly once inside `create_asgi_app()`. Alternatives considered: (a) a plain `dict` field — rejected (import-time side effects); (b) a separate config file — rejected (project-config deliberately consolidated to a single `webcompy_config.py`).
+
+### D2: Insert `Mount` entries before the HTML catch-all
+Starlette matches routes in order; `/{path:path}` swallows everything. Mounts are inserted after all `/_webcompy-*` and static-file routes, immediately before the catch-all page route. Within a mount, the user's app owns routing entirely.
+
+**Why**: minimal reordering; existing behavior for all current routes is unchanged.
+
+### D3: Collision detection at startup
+Before building the app, validate mount prefixes:
+- MUST NOT start with `/_webcompy` (framework-reserved).
+- MUST NOT equal or prefix-collide with a registered page route pattern (compare against `app.routes` paths; static path params complicate exact matching, so the check treats a mount prefix as colliding when a page route's static prefix is identical to or under the mount prefix).
+- On collision: raise `WebComPyException` listing all conflicts at server startup / SSG start (fail fast).
+
+**Why**: silent shadowing (either a page swallowing `/api/...` or a mount hiding a page) would be extremely confusing. A startup error is the only sane behavior.
+
+### D4: FetchPort gains mount awareness for base_url resolution
+`ServerFetchPort.configure(asgi, blocked_paths, base_url=..., mount_prefixes=...)` is already called with the fully assembled app — including mounts — because `configure()` runs after `Starlette(routes=...)` construction; this change adds the configured mount prefixes to the call. `blocked_paths` derives from page routes only, so mount paths are not blocked by construction. One code change to the fetch port IS required: self-site URL resolution exempts mount paths from `base_url` prefixing. Mounts are absolute server paths (the route table does NOT prefix them by `base_url`, per the `cli` delta), so a fetch to `/api/users` under `base_url="/myapp"` must be dispatched as `/api/users` — not `/myapp/api/users` — to reach the mount. Without the exemption, mounted endpoints are unreachable via self-site fetch under any non-root `base_url`. The `server-fetch-asgi` base_url-resolution requirement is MODIFIED accordingly.
+
+### D5: SSG is mount-aware but mount-silent
+`generate_static_site` only GETs page routes and `/_webcompy_404`, so mounts never leak into `dist/`. Components that fetch mount endpoints during SSG get responses via ASGITransport, cached into the hydration transfer payload as with any self-site fetch. Deployed static sites then replay those responses without a server (existing hydration behavior).
+
+**Trade-off accepted**: a static deployment has no live `/api`; data fetched at build time is baked, and runtime-only fetches against mounts will fail on static hosting. This is inherent to SSG and documented; per-call opt-out of baking is handled in `feat-typed-api-client` (`transfer=False`).
+
+## Risks / Trade-offs
+
+- [Mount paths vs `base_url`] → Mount paths are absolute server paths, independent of `app.base_url`. Self-site fetch resolution exempts mount paths from `base_url` prefixing (D4), so mounted endpoints are reachable under any `base_url`. Docs still note that mounts are NOT prefixed by `base_url` in the route table (unlike page routes), with a spec scenario + example showing fetch URL vs mount path under a non-root `base_url`.
+- [Callable returning a fresh app each call] → `create_asgi_app()` invokes the callable once and caches the result on the serving app; document single-invocation semantics.
+- [Lifespan events of mounted apps (FastAPI startup/shutdown)] → Starlette `Mount` propagates lifespan only if the parent app is served with lifespan support; `run_server` uses `uvicorn.run(serving.asgi)` which handles Starlette lifespan. Document that mounted-app lifespan works via Starlette's router lifespan; edge cases deferred.
+- [Mounted apps share the process and event loop with SSR] → A blocking mounted endpoint blocks page rendering. Document that mounted apps should be async; no enforcement.
+
+## Migration Plan
+
+None. `mounts=None` default preserves current behavior exactly.
+
+## Open Questions
+
+- Exact collision-detection semantics for parameterized page routes (`/users/{id}` vs mount `/users`): proposal — treat as collision only when the page route's literal prefix is under the mount prefix; finalize during implementation with tests.

--- a/openspec/changes/feat-asgi-mount/proposal.md
+++ b/openspec/changes/feat-asgi-mount/proposal.md
@@ -1,0 +1,45 @@
+# Proposal: feat-asgi-mount
+
+## Why
+
+WebComPy's server currently exposes only framework-owned endpoints (`/_webcompy-*`, static files, and the SSR catch-all). There is no way for a project to attach its own HTTP endpoints. Python's natural home is the server side, and users who want "a small app with a backend" — a REST API for the frontend, a webhook receiver, an admin data endpoint — must run a separate server process today. The `server-fetch-asgi` spec already assumes components can fetch "their own application's API endpoints" during SSR/SSG, but provides no way to create such endpoints. Allowing users to mount arbitrary ASGI applications (e.g. FastAPI) into the WebComPy server closes this gap with minimal framework surface.
+
+## What Changes
+
+- `WebComPyServerConfig` gains a `mounts` field: a zero-argument callable returning `dict[str, ASGIApp]` (path prefix → ASGI app). The callable form defers import/construction of user apps until server startup.
+- `create_asgi_app()` inserts one Starlette `Mount` per entry BEFORE the SSR catch-all route (`/{path:path}`), so mounted apps take precedence over page rendering.
+- Mount path prefixes that collide with a framework-reserved prefix (`/_webcompy-*`) or with a registered page route SHALL cause a startup error listing the conflicting paths.
+- Self-site fetches to mounted paths during SSR/SSG work through the existing `ServerFetchPort` ASGITransport path; fetched responses are collected into the hydration transfer cache as today (bake-on-SSG behavior is unchanged). Mount prefixes SHALL be excluded from `blocked_paths` semantics (they are intended fetch targets, not page routes). Mount prefixes SHALL also be excluded from `base_url` prefixing in self-site URL resolution (mounts are absolute server paths), so mounted endpoints are reachable via self-site fetch under any `base_url`.
+- SSG (`webcompy generate`) SHALL work unchanged when mounts are configured: only page routes are written to `dist/`; mounts are reachable in-process during generation for data fetching.
+- Hash-mode: mounts are mounted identically; since hash-mode pages are pre-rendered at startup, mounted endpoints behave the same as in history mode.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `cli`: The server route table gains user-provided ASGI mounts, inserted before the SSR catch-all; collision detection with reserved prefixes and page routes is required.
+- `server-fetch-asgi`: Mount path prefixes SHALL NOT be treated as blocked page paths; self-site fetches to mounts SHALL resolve through the ASGI transport. The base_url-resolution requirement is MODIFIED: paths under a mount prefix are exempt from `base_url` prefixing (mounts are absolute server paths).
+- `ssg-via-ssr`: SSG SHALL remain functional when mounts are configured; mount endpoints SHALL be reachable via ASGITransport during generation; mount responses SHALL NOT be written into `dist/`.
+- `project-config`: `WebComPyServerConfig` gains the `mounts` field.
+
+## Impact
+
+- **Code**: `packages/webcompy-cli/src/webcompy_cli/config/_server_config.py` (new field), `packages/webcompy-cli/src/webcompy_cli/_server.py` (route assembly + collision detection + passing mount prefixes to the fetch port), `packages/webcompy-server/src/webcompy_server/ports/_fetch.py` (base_url-prefix exemption for mount paths), possibly `packages/webcompy-cli/src/webcompy_cli/_generate.py` (no change expected; verification only).
+- **APIs**: `WebComPyServerConfig(mounts=...)` (additive, backward compatible).
+- **Dependencies**: None (Starlette `Mount` is already available).
+- **Specs**: `openspec/specs/cli/spec.md`, `server-fetch-asgi`, `ssg-via-ssr`, `project-config`.
+
+## Known Issues Addressed
+
+(none)
+
+## Non-goals
+
+- Typed clients or RPC on top of mounted apps (separate changes: `feat-typed-api-client`, `feat-json-rpc`).
+- Mounting WebComPy itself into an external ASGI app (separate change: `feat-asgi-embed`).
+- Middleware configuration for mounted apps (users configure middleware inside their own app).
+- Per-mount SSG export (mounts are runtime endpoints; only their responses fetched during page rendering are baked into hydration payloads via the existing transfer cache).

--- a/openspec/changes/feat-asgi-mount/specs/cli/spec.md
+++ b/openspec/changes/feat-asgi-mount/specs/cli/spec.md
@@ -1,0 +1,31 @@
+# Delta Spec: cli
+
+## ADDED Requirements
+
+### Requirement: The server shall mount user-provided ASGI applications
+The dev/prod server SHALL support mounting user-provided ASGI applications at configured path prefixes. Mounts SHALL be declared via `WebComPyServerConfig.mounts`, a zero-argument callable returning `dict[str, ASGIApp]` (path prefix → ASGI app) or `None`. `create_asgi_app()` SHALL invoke the callable at most once per serving app construction and SHALL insert one Starlette `Mount` per entry into the route list immediately before the SSR catch-all route (`/{path:path}`), after all framework-internal and static-file routes. Mount path prefixes SHALL NOT be prefixed by `app.base_url`.
+
+#### Scenario: Mounting a FastAPI app at /api
+- **WHEN** `WebComPyServerConfig(mounts=lambda: {"/api": fastapi_app})` is configured and the server is running
+- **THEN** a request to `/api/users` SHALL be handled by `fastapi_app`
+- **AND** a request to a page route SHALL still be handled by SSR
+
+#### Scenario: Mounts take precedence over the catch-all
+- **WHEN** a mount is configured at `/api` and no page route matches `/api/anything`
+- **THEN** requests to `/api/...` SHALL be routed to the mounted app, not to SSR
+- **AND** unmatched paths inside the mount SHALL produce the mounted app's own 404
+
+#### Scenario: No mounts configured preserves current behavior
+- **WHEN** `mounts` is `None` (default)
+- **THEN** the route table SHALL be exactly as before this change
+
+### Requirement: Mount path collisions shall fail fast at startup
+`create_asgi_app()` SHALL validate mount prefixes before constructing the ASGI app. A mount prefix that starts with `/_webcompy` (framework-reserved) SHALL be rejected. A mount prefix that collides with a registered page route SHALL be rejected. On any collision, the server SHALL raise an error listing all conflicting paths before serving begins; the same validation SHALL apply during SSG.
+
+#### Scenario: Reserved prefix collision
+- **WHEN** a mount is declared at `/_webcompy-api`
+- **THEN** startup SHALL fail with an error naming `/_webcompy-api` as reserved
+
+#### Scenario: Page route collision
+- **WHEN** a page route `/admin` exists and a mount is declared at `/admin`
+- **THEN** startup SHALL fail with an error listing the conflict

--- a/openspec/changes/feat-asgi-mount/specs/project-config/spec.md
+++ b/openspec/changes/feat-asgi-mount/specs/project-config/spec.md
@@ -1,0 +1,15 @@
+# Delta Spec: project-config
+
+## ADDED Requirements
+
+### Requirement: WebComPyServerConfig shall support ASGI mounts
+`WebComPyServerConfig` SHALL provide a `mounts` field of type `Callable[[], dict[str, ASGIApp]] | None` defaulting to `None`. The callable form SHALL defer import and construction of user ASGI apps until server startup, so that importing `webcompy_config.py` does not import server-only application code. The field is server-only configuration and SHALL NOT affect browser-relevant config (`WebComPyAppConfig`).
+
+#### Scenario: Declaring mounts lazily
+- **WHEN** a project sets `WebComPyServerConfig(mounts=lambda: {"/api": api_app})` in `webcompy_config.py`
+- **THEN** importing the config module SHALL NOT import `api_app`
+- **AND** the callable SHALL be invoked when the serving app is constructed
+
+#### Scenario: Default configuration unchanged
+- **WHEN** `WebComPyServerConfig()` is constructed without `mounts`
+- **THEN** `mounts` SHALL be `None` and serving behavior SHALL be unchanged

--- a/openspec/changes/feat-asgi-mount/specs/server-fetch-asgi/spec.md
+++ b/openspec/changes/feat-asgi-mount/specs/server-fetch-asgi/spec.md
@@ -1,0 +1,38 @@
+# Delta Spec: server-fetch-asgi
+
+## MODIFIED Requirements
+
+### Requirement: ServerFetchPort shall resolve self-site URLs against base_url
+
+When `base_url` is configured on the app (e.g., `/myapp/`), self-site absolute paths SHALL be resolved with the `base_url` prefix, EXCEPT for paths under a configured ASGI mount prefix: mounts are absolute server paths, so paths under a mount prefix SHALL be dispatched without the `base_url` prefix. For example, with `base_url="/myapp/"`, a fetch to `/api/data` SHALL be routed to `/myapp/api/data` unless `/api` is a configured mount, in which case it SHALL be dispatched as `/api/data`.
+
+#### Scenario: Self-site fetch with base_url
+- **WHEN** `base_url="/myapp/"` is configured
+- **AND** a component calls `await fetch_port.fetch("/api/data")`
+- **AND** `/api` is NOT a configured mount
+- **THEN** the request SHALL be routed to `/myapp/api/data` within the ASGI app
+
+#### Scenario: Self-site fetch with default base_url
+- **WHEN** `base_url="/"` is the default
+- **AND** a component calls `await fetch_port.fetch("/api/data")`
+- **THEN** the request SHALL be routed to `/api/data` within the ASGI app
+
+#### Scenario: Self-site fetch to a mount path under non-root base_url
+- **WHEN** `base_url="/myapp/"` is configured and `/api` is a configured mount
+- **AND** a component calls `await fetch_port.fetch("/api/users")`
+- **THEN** the request SHALL be dispatched as `/api/users` (without the `base_url` prefix)
+- **AND** the request SHALL reach the mounted app in-process via `httpx.ASGITransport`
+
+## ADDED Requirements
+
+### Requirement: Mount path prefixes shall not be blocked for self-site fetch
+`blocked_paths` derivation SHALL remain based on page routes only. Paths under a configured ASGI mount prefix SHALL NOT be considered blocked, even if a mounted endpoint shares a path shape with a page route. Self-site fetches to mount paths during SSR/SSG SHALL be routed through the ASGI transport and reach the mounted app in-process, dispatched without `base_url` prefixing per the base_url-resolution requirement.
+
+#### Scenario: Fetching a mounted endpoint during SSR
+- **WHEN** a component fetches `/api/users` during SSR and `/api` is a configured mount
+- **THEN** the request SHALL be dispatched in-process via `httpx.ASGITransport` to the mounted app
+- **AND** the response SHALL be returned to the component and recorded in the transfer cache as with any self-site fetch
+
+#### Scenario: Mount paths never appear in blocked_paths
+- **WHEN** `blocked_paths` is computed for an app with page routes and a `/api` mount
+- **THEN** no entry in `blocked_paths` SHALL match `/api/...`

--- a/openspec/changes/feat-asgi-mount/specs/ssg-via-ssr/spec.md
+++ b/openspec/changes/feat-asgi-mount/specs/ssg-via-ssr/spec.md
@@ -1,0 +1,16 @@
+# Delta Spec: ssg-via-ssr
+
+## ADDED Requirements
+
+### Requirement: SSG shall remain functional when ASGI mounts are configured
+`generate_static_site()` SHALL work unchanged when `WebComPyServerConfig.mounts` is set: the same `create_asgi_app(mode="prod")` pipeline SHALL be used, mount endpoints SHALL be reachable via `httpx.ASGITransport` during generation (so components can fetch mounted APIs in-process at build time), and only page routes plus the 404 page SHALL be written to `dist/`. Mount endpoint responses SHALL NOT be exported as static files. Responses fetched from mounts during generation SHALL be baked into hydration payloads via the existing transfer cache.
+
+#### Scenario: Component fetches a mounted API during generation
+- **WHEN** a page component fetches `/api/users` during SSG and `/api` is a configured mount
+- **THEN** the fetch SHALL be served in-process via ASGITransport
+- **AND** the response SHALL be included in the page's hydration transfer payload
+- **AND** no `/api/...` file SHALL appear in `dist/`
+
+#### Scenario: Static output contains only pages
+- **WHEN** SSG completes for an app with mounts configured
+- **THEN** `dist/` SHALL contain page HTML, static files, and framework assets only

--- a/openspec/changes/feat-asgi-mount/tasks.md
+++ b/openspec/changes/feat-asgi-mount/tasks.md
@@ -1,0 +1,36 @@
+# Tasks: feat-asgi-mount
+
+## 1. Config surface
+
+- [ ] 1.1 Add `mounts: Callable[[], dict[str, ASGIApp]] | None = None` to `WebComPyServerConfig` (packages/webcompy-cli/src/webcompy_cli/config/_server_config.py), with an ASGI-app protocol type usable at type-check time without importing Starlette in the config module
+- [ ] 1.2 Verify `webcompy_config.py` import does not trigger mount callable invocation (lazy semantics test)
+
+## 2. Route assembly
+
+- [ ] 2.1 In `create_asgi_app()` (packages/webcompy-cli/src/webcompy_cli/_server.py), invoke the mounts callable once and insert one Starlette `Mount` per entry immediately before the SSR catch-all route
+- [ ] 2.2 Implement collision detection: reject prefixes starting with `/_webcompy` and prefixes colliding with registered page routes; raise `WebComPyException` listing all conflicts before serving
+- [ ] 2.3 Apply the same mount handling to the hash-mode serving path
+
+## 3. SSG and fetch integration
+
+- [ ] 3.1 Verify/ensure `ServerFetchPort.configure()` receives the fully assembled app including mounts plus the configured mount prefixes, and add regression tests that mount paths are absent from `blocked_paths` and are dispatched without `base_url` prefixing under a non-root `base_url`
+- [ ] 3.2 Verify `generate_static_site()` with mounts configured: pages generated, mount endpoints reachable in-process during generation, no mount paths in `dist/`
+
+## 4. Tests
+
+- [ ] 4.1 Unit test: mount insertion order (mount before catch-all; internal routes unaffected)
+- [ ] 4.2 Unit test: collision detection for reserved prefix and page-route conflicts
+- [ ] 4.3 Integration test (webcompy_testing ASGI client): a mounted Starlette/FastAPI-style app responds at `/api/...` while SSR pages still render
+- [ ] 4.4 Integration test: component self-site fetch to a mounted endpoint during SSR returns the mounted app's response and populates the transfer cache (including a non-root `base_url` case)
+- [ ] 4.5 Integration test: SSG with mounts completes; mounted fetch response is baked into hydration payload; `dist/` has no mount files
+
+## 5. Docs and verification
+
+- [ ] 5.1 Add an example or docs page showing `WebComPyServerConfig(mounts=...)` with a FastAPI app, including the note that mount paths are not prefixed by `base_url` (per `doc-spec-references`: docs reference the owning specs as source of truth rather than transcribing requirement prose)
+- [ ] 5.2 `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run python -m pytest tests/ --tb=short` all pass
+
+## 6. Spec reference sync
+
+- [ ] 6.1 Update AGENTS.md: verify the File→Spec Mapping entries for `webcompy_cli/` (`cli`, `project-config`, `ssg-via-ssr`) and `webcompy_server/ports/` (`server-fetch-asgi`) against the modified specs, and check the Framework Invariants list for fetch/mount-related staleness
+- [ ] 6.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions about self-site fetch resolution and sync spec references
+- [ ] 6.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes

--- a/openspec/changes/feat-json-rpc/.openspec.yaml
+++ b/openspec/changes/feat-json-rpc/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/feat-json-rpc/design.md
+++ b/openspec/changes/feat-json-rpc/design.md
@@ -1,0 +1,73 @@
+# Design: feat-json-rpc
+
+## Context
+
+Preceding changes provide all the plumbing: `feat-asgi-mount` inserts user/framework ASGI apps into the route table; `ServerFetchPort` makes self-site calls in-process during SSR/SSG with hydration baking; `from_json` (typed-api-client) reconstructs typed values schema-first; `encode_with_meta` (typed-response) produces the metadata sidecar for non-JSON-native types. What remains is a procedure-dispatch layer. JSON-RPC 2.0 is chosen over a bespoke protocol because it is small, fully specified, and tool-compatible.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Register Python functions as procedures; call them from browser/SSR with typed params and results.
+- Full JSON-RPC 2.0 wire conformance including batch and notifications.
+- Secure server-side typed decoding via explicit allowlist — never by wire-provided class names.
+
+**Non-Goals:**
+- WebSockets, streaming, OpenAPI generation, fluent proxies, cross-service RPC.
+
+## Decisions
+
+### D1: One endpoint, method registry, standard envelope
+The dispatcher is a single ASGI endpoint (Starlette route) mounted at `/_webcompy-rpc` by default (registrable at a custom path via the mount mechanism). A per-app registry maps method names to procedures. Request handling: parse JSON → validate envelope → look up method → decode params → invoke (await if coroutine) → encode result → respond. Batch requests map over entries; notifications (`id` absent) execute without a response body.
+
+**Why a single endpoint**: keeps routing trivial, batches natural, and the attack surface centralized behind one validation path.
+
+### D2: Metadata rides as an extra member, never inside standard members
+```json
+{"jsonrpc": "2.0", "method": "users.get", "params": {"id": 1}, "id": 1}
+{"jsonrpc": "2.0", "result": {...}, "meta": {"result.created": "datetime"}, "id": 1}
+```
+`meta` uses the `typed-response` format (path→tag map). JSON-RPC 2.0 permits additional members; standard-conformant peers ignore it.
+
+**Why**: embedding metadata inside `params`/`result` would corrupt the argument schema the procedure expects. A sibling member keeps both worlds clean — generic JSON-RPC clients can call procedures with plain JSON.
+
+### D3: Server-side decoding is allowlist-only — the security crux
+Hydration decoding trusts server-generated payloads, and typed-response decoding happens client-side. RPC is the first path where the SERVER decodes CLIENT-controlled typed data. Therefore:
+- `params` are decoded with `from_json(schema, params, strict=True)`; schemas come from the server-side procedure registration (type annotations of the registered function), never from the request.
+- `meta` tags map to the closed restoration set from `typed-response`; dataclass/class restoration from `meta` names is forbidden unless the class was explicitly registered via an allowlist API (reusing the `register_type_handler` concept from transfer-codec, scoped per registry).
+- Violations (unknown method, schema mismatch, unregistered type tag) map to JSON-RPC error codes `-32601`/`-32602`.
+
+### D4: Procedures declare schemas by signature
+```python
+@rpc.procedure
+async def get_user(id: int) -> User: ...
+```
+Param schema derives from the function's type annotations (`inspect.signature` + `get_type_hints`); result schema from the return annotation. Shared dataclasses live in the app package (shipped to the browser), so client and server literally import the same classes.
+
+**Why**: no separate IDL or codegen — the Python signature IS the contract. Validation is structural (from_json strict), not value-constraint based; procedures needing value validation do it in the body (documented).
+
+### D5: Client is a thin typed caller over FetchPort
+```python
+user = await rpc.call("get_user", {"id": 1}, result_type=User)
+```
+The client serializes the envelope, posts through `FetchPort` (self-site → in-process during SSR/SSG; transfer cache → hydration bake), then decodes `result` via `from_json` + `meta`. JSON-RPC errors raise a dedicated `RpcError` carrying code/message/data. Batch and notification helpers are provided but the single-call path is the documented default.
+
+### D6: Dispatcher placement reuses the mount mechanism
+The dispatcher ASGI app is mounted through the same route-insertion point as user mounts (`feat-asgi-mount`), reserved prefix `/_webcompy-rpc` registered in the CLI spec's endpoint table. The insertion is framework-internal: it bypasses the user-mount collision validation (which rejects `/_webcompy*` prefixes) and is documented by a `cli` delta in this change. Disabled when no procedures are registered (no endpoint added).
+
+## Risks / Trade-offs
+
+- [Signature-derived schemas drift from runtime behavior (e.g. `**kwargs`)] → `**kwargs`/untyped params are rejected at registration time; spec requires fully annotated signatures.
+- [Batch requests amplify a validation bug across entries] → each batch entry is validated independently; per-entry errors returned per-entry per JSON-RPC 2.0.
+- [Notification execution during SSR could fire-and-forget fetch side effects] → notifications during SSR execute inline (no response expected but work completes before render finishes, via the async scheduler); documented.
+- [Allowlist registry becomes a second type system to maintain] → it reuses `register_type_handler` and defaults to the closed tag set; most apps never touch it.
+- [Error responses leaking internals] → internal errors return `-32603` with a generic message; details logged server-side only. Spec-mandated.
+- [`RpcError` raised inside component setup/render] → participates in the framework error pipeline (`error-handling` spec) with no special handling: catchable by `ErrorBoundary`; during SSG an uncontained error fails the build.
+
+## Migration Plan
+
+None — new capability, off unless procedures are registered.
+
+## Open Questions
+
+- Whether `meta` on requests (client→server metadata for params) is needed beyond the closed tag set — default: supported with the closed set + allowlist; revisit after real usage.
+- Exact default mount path (`/_webcompy-rpc` vs `/_webcompy/rpc`) — finalize in implementation; spec uses `/_webcompy-rpc`.

--- a/openspec/changes/feat-json-rpc/proposal.md
+++ b/openspec/changes/feat-json-rpc/proposal.md
@@ -1,0 +1,43 @@
+# Proposal: feat-json-rpc
+
+## Why
+
+`feat-typed-api-client` + `feat-asgi-mount` cover calling conventional HTTP APIs with typed clients. But for APIs built specifically for a WebComPy app, a procedure-call model is a better fit than hand-designing REST resources: define a Python function server-side, call it from the browser with typed arguments and results. Because both sides run Python and share modules via the app wheel, procedures can share dataclass schemas directly. Building on the JSON-RPC 2.0 standard (instead of a bespoke protocol) gives batching, notifications, standard error codes, and interoperable tooling for free.
+
+## What Changes
+
+- New JSON-RPC 2.0 dispatcher: a Starlette endpoint (intended mount point: `/_webcompy-rpc` or a user-chosen path via the `feat-asgi-mount` mechanism) plus a server-side procedure registry. Procedures are plain Python functions (sync or async) registered by name.
+- Full JSON-RPC 2.0 conformance: `jsonrpc`/`method`/`params`/`id` envelope, positional and named params, batch requests, notifications, and the standard error codes (`-32700` parse error, `-32600` invalid request, `-32601` method not found, `-32602` invalid params, `-32603` internal error).
+- One sanctioned extension: an optional `meta` member alongside `params`/`result` carrying transfer metadata in the `typed-response` wire format, enabling typed restoration of non-JSON-native values. The extension never alters standard members, so generic JSON-RPC clients can still call procedures (metadata simply goes unused or unproduced).
+- Type safety with a strict security boundary: params and results deserialize via `from_json` (strict mode server-side) against per-procedure registered schemas. Type restoration from `meta` uses an explicit **allowlist registry** (reusing `register_type_handler`-style registration): the server SHALL NOT resolve classes from client-controlled names. This change is the only place where the server decodes client-controlled typed payloads, and the allowlist is mandatory there.
+- Browser client: `rpc.call("method", params, result_type=T)` (or generated thin wrappers) going through `FetchPort` — so SSR/SSG calls dispatch in-process via ASGI transport and results are baked into hydration payloads like any self-site fetch; `transfer=False` opt-out applies.
+
+## Capabilities
+
+### New Capabilities
+
+- `json-rpc`: JSON-RPC 2.0 dispatcher, procedure registry, metadata extension, allowlist type decoding, and the typed browser client.
+
+### Modified Capabilities
+
+- `cli`: The server route table gains a framework-internal JSON-RPC dispatcher endpoint at the reserved prefix `/_webcompy-rpc` (present only when procedures are registered; inserted via the mount route-insertion point but exempt from user-mount collision validation).
+
+## Impact
+
+- **Code**: new module `packages/webcompy-server/src/webcompy_server/rpc/` (dispatcher + registry), browser client in `packages/webcompy/src/webcompy/ajax/` or `webcompy/rpc/`, wiring for the official mount point.
+- **APIs**: new public APIs (`register_procedure`/decorator, `rpc.call`).
+- **Dependencies**: none.
+- **Implementation order**: Builds on `feat-asgi-mount` (mount route-insertion point), `feat-typed-api-client` (`from_json`), and `feat-typed-response` (`encode_with_meta` / `meta` wire format); those changes MUST be implemented first.
+- **Specs**: new `json-rpc`; delta to `cli`.
+
+## Known Issues Addressed
+
+(none)
+
+## Non-goals
+
+- WebSocket transport or server-initiated calls (JSON-RPC over HTTP POST only).
+- Auto-generated OpenAPI documentation for procedures (JSON-RPC is not REST; tooling is out of scope).
+- Chained/fluent client proxies (same deferral as `feat-typed-api-client`).
+- Cross-service RPC (the dispatcher serves the same-process app; external exposure is possible but not a design target).
+- Streaming responses.

--- a/openspec/changes/feat-json-rpc/specs/cli/spec.md
+++ b/openspec/changes/feat-json-rpc/specs/cli/spec.md
@@ -1,0 +1,18 @@
+# Delta Spec: cli
+
+## ADDED Requirements
+
+### Requirement: The server shall expose a JSON-RPC dispatcher endpoint at a reserved prefix
+When one or more RPC procedures are registered, the dev/prod server SHALL expose the JSON-RPC dispatcher endpoint at `/_webcompy-rpc` (a framework-reserved prefix under `/_webcompy`). The dispatcher SHALL be inserted as a framework-internal route via the same route-insertion point as user-provided ASGI mounts, and SHALL NOT be subject to the user-mount collision validation (which rejects `/_webcompy*` prefixes). The dispatcher MAY be registered at a custom path. When no procedures are registered, the endpoint SHALL NOT be added to the route table.
+
+#### Scenario: Endpoint present when procedures are registered
+- **WHEN** at least one procedure is registered and the server is running
+- **THEN** POST requests to `/_webcompy-rpc` SHALL be handled by the dispatcher
+
+#### Scenario: Endpoint absent when no procedures are registered
+- **WHEN** no procedures are registered
+- **THEN** the route table SHALL NOT contain `/_webcompy-rpc`
+
+#### Scenario: Custom dispatcher path
+- **WHEN** the dispatcher is registered at a user-chosen path
+- **THEN** POST requests to that path SHALL be handled by the dispatcher

--- a/openspec/changes/feat-json-rpc/specs/json-rpc/spec.md
+++ b/openspec/changes/feat-json-rpc/specs/json-rpc/spec.md
@@ -1,0 +1,82 @@
+# Spec: json-rpc
+
+## ADDED Requirements
+
+### Requirement: JSON-RPC 2.0 dispatcher
+The framework SHALL provide a JSON-RPC 2.0 dispatcher as an ASGI endpoint, mounted by default at `/_webcompy-rpc` through the same mount mechanism as user-provided ASGI apps (and registrable at a custom path). The dispatcher insertion is framework-internal and SHALL NOT be subject to the user-mount collision validation defined by the `cli` capability. The dispatcher SHALL implement the JSON-RPC 2.0 specification: the `jsonrpc: "2.0"` member, `method`, optional `params` (by-position array or by-name object), `id`, single and batch requests, notifications (requests without `id`, producing no response body), and the standard error codes `-32700`, `-32600`, `-32601`, `-32602`, `-32603`. When no procedures are registered, the endpoint SHALL NOT be added to the route table.
+
+#### Scenario: Single call
+- **WHEN** a client POSTs `{"jsonrpc": "2.0", "method": "get_user", "params": {"id": 1}, "id": 1}` with a registered `get_user` procedure
+- **THEN** the dispatcher SHALL invoke the procedure and respond with `{"jsonrpc": "2.0", "result": <value>, "id": 1}`
+
+#### Scenario: Batch call
+- **WHEN** a client POSTs an array of valid request objects
+- **THEN** the dispatcher SHALL process each entry independently and SHALL return an array of per-entry responses (excluding notifications)
+
+#### Scenario: Notification
+- **WHEN** a client sends a request object without an `id`
+- **THEN** the procedure SHALL execute and no response body SHALL be returned for that entry
+
+#### Scenario: Unknown method
+- **WHEN** a client calls an unregistered method name
+- **THEN** the response SHALL be a JSON-RPC error with code `-32601`
+
+#### Scenario: Malformed request
+- **WHEN** a client POSTs invalid JSON or an object failing envelope validation
+- **THEN** the response SHALL use error code `-32700` or `-32600` respectively
+
+#### Scenario: Batch containing only notifications
+- **WHEN** a client POSTs a batch array whose entries are all notifications
+- **THEN** the procedures SHALL execute
+- **AND** the server SHALL return no response body at all (NOT even an empty array), per JSON-RPC 2.0
+
+#### Scenario: Empty batch array
+- **WHEN** a client POSTs an empty JSON array as the batch
+- **THEN** the response SHALL be a JSON-RPC error with code `-32600`
+
+### Requirement: Procedure registration by annotated signature
+Procedures SHALL be plain Python functions (sync or async) registered by name, via decorator or explicit registry call. Procedures SHALL have fully annotated parameters and return types; registrations with untyped parameters or `**kwargs` SHALL be rejected at registration time. The parameter schema SHALL derive from the function's type annotations; the result schema SHALL derive from the return annotation. Procedures may raise exceptions; unhandled exceptions SHALL map to error code `-32603` with a generic message (details logged server-side only).
+
+#### Scenario: Decorator registration
+- **WHEN** a fully annotated async function is decorated with the procedure decorator
+- **THEN** it SHALL be callable via its registered name through the dispatcher
+
+#### Scenario: Untyped procedure rejected
+- **WHEN** a function with unannotated parameters is registered
+- **THEN** registration SHALL raise an error identifying the offending parameters
+
+### Requirement: Server-side typed decoding with mandatory allowlist
+The dispatcher SHALL decode `params` using `from_json(schema, params, strict=True)` with schemas derived from procedure annotations — never from request content. Type restoration from request `meta` SHALL be limited to the closed set of built-in type tags plus types explicitly registered through an allowlist registration API. The dispatcher SHALL NOT import or resolve classes from client-controlled names under any circumstances.
+
+#### Scenario: Typed params reconstruction
+- **WHEN** a procedure `def f(user: User) -> ...` is called with `params: {"user": {...}}`
+- **THEN** the procedure SHALL receive a reconstructed `User` instance
+- **AND** extra keys in the payload SHALL be rejected with error `-32602` (strict decoding)
+
+#### Scenario: Unregistered type tag rejected
+- **WHEN** request metadata references a type tag outside the closed set and not in the allowlist registry
+- **THEN** the dispatcher SHALL respond with error `-32602` and SHALL NOT attempt class resolution
+
+### Requirement: Metadata extension member
+Requests and responses MAY carry a `meta` member alongside `params`/`result` containing transfer metadata in the `typed-response` wire format (path→type-tag map). The extension SHALL NOT alter standard JSON-RPC members, and peers ignoring `meta` SHALL interoperate normally. Result encoding SHALL use `encode_with_meta` semantics for non-JSON-native values.
+
+#### Scenario: Typed result with metadata
+- **WHEN** a procedure returns a dataclass containing `bytes` and `Decimal` fields
+- **THEN** the response `result` SHALL contain pristine JSON and `meta` SHALL record those types
+- **AND** the framework client SHALL restore the original Python types
+
+#### Scenario: Generic client interoperability
+- **WHEN** a non-WebComPy JSON-RPC client calls a procedure with plain JSON params and ignores `meta`
+- **THEN** the call SHALL succeed per the JSON-RPC 2.0 specification
+
+### Requirement: Typed browser client over FetchPort
+The framework SHALL provide a client API (e.g. `rpc.call(method, params, result_type=T)`) that posts envelopes through `FetchPort`. During SSR/SSG, self-site dispatch SHALL be in-process via ASGI transport and results SHALL be recorded in the hydration transfer cache (bake), with the `transfer=False` opt-out applying as for other self-site fetches. JSON-RPC error responses SHALL raise a dedicated `RpcError` carrying `code`, `message`, and `data`. Result decoding SHALL apply `from_json` with response `meta`.
+
+#### Scenario: RPC during SSR is baked
+- **WHEN** a component performs an RPC call during SSR against the same app's dispatcher
+- **THEN** no network I/O SHALL occur
+- **AND** the response SHALL be recorded in the hydration transfer cache so the browser replays it without re-calling
+
+#### Scenario: Error mapping
+- **WHEN** the dispatcher returns a JSON-RPC error
+- **THEN** the client SHALL raise `RpcError` with the error's code, message, and data

--- a/openspec/changes/feat-json-rpc/tasks.md
+++ b/openspec/changes/feat-json-rpc/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: feat-json-rpc
+
+## 1. Dispatcher core
+
+- [ ] 1.1 Implement the JSON-RPC 2.0 dispatcher endpoint (packages/webcompy-server/src/webcompy_server/rpc/): envelope validation, single/batch, notifications, standard error codes
+- [ ] 1.2 Implement the procedure registry with decorator and explicit registration; reject untyped/`**kwargs` signatures at registration time; derive param/result schemas from annotations
+- [ ] 1.3 Implement invocation pipeline: strict `from_json` param decoding, sync/async procedure support, exception → `-32603` with generic client message and server-side logging
+
+## 2. Typed wire and security
+
+- [ ] 2.1 Support the `meta` extension member on requests and responses (typed-response wire format); result encoding via `encode_with_meta`
+- [ ] 2.2 Implement the allowlist type registry (reusing `register_type_handler` concepts, scoped per registry) and enforce closed-set decoding; no class resolution from client-controlled names
+- [ ] 2.3 Map validation failures to `-32602`, unknown methods to `-32601`, parse/envelope errors to `-32700`/`-32600`
+
+## 3. Mount and client
+
+- [ ] 3.1 Mount the dispatcher at `/_webcompy-rpc` as a framework-internal route via the `feat-asgi-mount` route-insertion point when procedures are registered (bypassing user-mount collision validation, per the `cli` delta); support custom mount path; register the reserved prefix
+- [ ] 3.2 Implement the browser/SSR client (`rpc.call(method, params, result_type=T)`) over FetchPort with `RpcError` mapping
+- [ ] 3.3 Verify SSR/SSG in-process dispatch and hydration bake; verify `transfer=False` opt-out
+
+## 4. Tests
+
+- [ ] 4.1 Protocol conformance tests: single/batch/notification, all standard error codes, generic JSON-RPC client interop without meta, including the all-notification batch (no response body at all) and empty batch array (`-32600`) edge cases
+- [ ] 4.2 Typed decoding tests: dataclass params/results, meta restoration, strict rejection of extra keys, unregistered tag rejection (no class resolution)
+- [ ] 4.3 Registration tests: decorator, duplicate names, untyped rejection
+- [ ] 4.4 Integration tests: component RPC during SSR with bake; browser path; error propagation to `RpcError`
+- [ ] 4.5 Security test: crafted meta referencing arbitrary module-qualified class names is rejected without import attempts
+
+## 5. Docs and verification
+
+- [ ] 5.1 Docs: defining procedures with shared dataclasses, calling from components, security model (allowlist), batch/notification usage (per `doc-spec-references`: docs reference the owning specs as source of truth rather than transcribing requirement prose)
+- [ ] 5.2 `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run python -m pytest tests/ --tb=short` all pass
+
+## 6. Spec reference sync
+
+- [ ] 6.1 Update AGENTS.md: add `json-rpc` to the Current Specs list; add File→Spec Mapping entries for `webcompy_server/rpc/` (`json-rpc/spec.md`) and the browser client module, and update the `cli` rows for the reserved dispatcher endpoint
+- [ ] 6.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions and sync invariant headings/spec references
+- [ ] 6.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes

--- a/openspec/changes/feat-typed-api-client/.openspec.yaml
+++ b/openspec/changes/feat-typed-api-client/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/feat-typed-api-client/design.md
+++ b/openspec/changes/feat-typed-api-client/design.md
@@ -1,0 +1,71 @@
+# Design: feat-typed-api-client
+
+## Context
+
+`HttpClient` (packages/webcompy/src/webcompy/ajax/_fetch.py) exposes classmethod HTTP verbs returning `Response`, delegating to `inject(FETCH_PORT_KEY).fetch(...)`. The hydration transfer codec (`webcompy/hydration/_codec.py`) already serializes rich Python types, but its dataclass reconstruction resolves classes by module-qualified name — fine for server-generated hydration payloads, unnecessary for client-side decoding of ordinary JSON API responses. The key insight behind this design: when the client already holds the target schema (a dataclass it can import), the type annotations themselves carry all the information needed to restore rich types from plain JSON — no wire metadata required.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Typed API access against any plain-JSON HTTP API, client-side only, zero server cooperation.
+- Full generics support so `HttpClient.get(url, response_type=User)` is statically typed as `User`.
+- Nested dataclass reconstruction including containers (`list`/`dict`/`Optional`/`Union`) and leaf coercion (`datetime`, `date`, `time`, `UUID`, `Enum`).
+- SSR/SSG in-process fetching and hydration bake continue to work transparently; explicit opt-out (`transfer=False`) for runtime-only data.
+
+**Non-Goals:**
+- Server-side meta production/consumption (`feat-typed-response`).
+- RPC dispatch (`feat-json-rpc`).
+- Chained proxy clients, OpenAPI codegen, pydantic integration.
+
+## Decisions
+
+### D1: Self-contained deserializer instead of dacite/cattrs
+`from_json` is implemented in ~100 lines using `dataclasses.fields()` + `typing.get_type_hints()` + `typing.get_origin()/get_args()`.
+
+**Why**: external serde libraries would need to be resolvable as browser dependencies (Pyodide wheel availability), adding supply-chain and bundle risk for a small, well-understood problem. Alternatives considered: dacite (pure Python but an extra dependency to vendor into the browser), pydantic (heavyweight in Pyodide, and forces pydantic on browser code). The transfer-codec stays untouched — it serves hydration; `from_json` serves API responses.
+
+### D2: Type-annotation-driven leaf coercion
+When the target annotation is `datetime`, an ISO-8601 string value is parsed via `datetime.fromisoformat()`; similarly `date`/`time`/`UUID`/`Enum`. No tagging on the wire.
+
+**Why**: ISO strings are what real JSON APIs (FastAPI included) already emit. The annotation tells us the intended type, so the wire stays pristine plain JSON and existing APIs work unchanged.
+
+### D3: Asymmetric validation — lenient client by default
+`strict=False`: unknown keys ignored, coercion failures raise a descriptive `TypeError`/`ValueError` only for fields the schema actually declares. `strict=True`: unknown keys rejected, missing required fields rejected.
+
+**Why**: deployed static frontends can lag behind API evolution; a client that hard-fails on unknown keys breaks under routine additive API changes. Strictness belongs to trust boundaries (servers), and `feat-json-rpc` will reuse `from_json` with `strict=True`-style semantics plus an allowlist.
+
+### D4: `response_type` on existing `HttpClient` methods via overloads
+```python
+@overload
+async def get(url: str, *, response_type: None = None, ...) -> Response: ...
+@overload
+async def get(url: str, *, response_type: type[T], ...) -> T: ...
+```
+**Why**: keeps one entry point, is discoverable, and preserves backward compatibility. A separate `typed_get()` family would fork the API surface. Overloads are the established pyright-friendly pattern for "return type depends on an optional argument".
+
+Error handling: non-2xx responses raise for status before deserialization (existing `raise_for_status` semantics preserved); JSON parse or schema mismatch raises a dedicated `TypedResponseError` (subclass of `WebComPyException`) carrying the response excerpt.
+
+### D5: `transfer=False` on `use_async_result` implemented at collection time
+The async-result entry is marked non-transferable; `collect_transfer_data()` skips marked entries. On hydration the browser finds no transferred entry and executes the fetch on the client (existing fallback behavior of `use_async_result`).
+
+**Why**: marking at the composable is the least invasive point — components declare intent where the fetch is defined. Alternative (URL-pattern exclusion lists in config) was rejected: it splits intent away from the call site and is fragile under refactors. During SSG the fetch still executes at build time (the page needs content), but its result is not persisted — matching the semantics "never bake this into artifacts".
+
+Note: for data that must NOT even be fetched at build time, `ClientOnly` remains the tool; `transfer=False` governs persistence, not execution timing. The spec states this explicitly.
+
+Precedent: the storage persistence composables (`use_local_storage`/`use_session_storage`, `composables` spec) already establish the same exclusion pattern ("Storage-backed signals are excluded from SSR transfer"). The implementation SHOULD follow that established pattern (and reuse shared exclusion plumbing where it exists) rather than introducing a parallel mechanism.
+
+## Risks / Trade-offs
+
+- [`get_type_hints()` on browser-shipped modules may hit forward-reference edge cases] → resolve hints at call time with the module's globalns; add tests for `from __future__ import annotations` schemas, which the wheel builder must keep functional.
+- [Union coercion ambiguity (e.g. `Union[int, str]` matching both)] → coercion tries alternatives in declaration order; first structural match wins; documented.
+- [Deeply nested schemas cost runtime reflection per call] → cache resolved type hints per class (`functools.lru_cache`-style dict on the module); Pyodide-safe.
+- [Users expect pydantic-style validation strictness] → documented non-goal; `strict=True` covers structural checks only, not value constraints (no `gt=0`-style validators).
+- [Deserialization errors raised during component setup/render interact with the error pipeline] → Desirable, no special handling: `TypedResponseError` is an ordinary framework exception, so an `ErrorBoundary` can catch it and render a fallback (`error-handling` spec); during SSG an uncontained error fails the build, so pages with schema mismatches never ship as static artifacts.
+
+## Migration Plan
+
+None — additive API. Existing `HttpClient` calls are unchanged.
+
+## Open Questions
+
+- Exact module placement (`webcompy/ajax/_serde.py` vs a new `webcompy/serde/` package if `feat-typed-response`/`feat-json-rpc` reuse grows) — decide at implementation; public import path is re-exported from `webcompy.ajax` either way.

--- a/openspec/changes/feat-typed-api-client/proposal.md
+++ b/openspec/changes/feat-typed-api-client/proposal.md
@@ -1,0 +1,46 @@
+# Proposal: feat-typed-api-client
+
+## Why
+
+`HttpClient` returns untyped `Response` objects; every caller hand-parses JSON into ad-hoc dicts. Because a WebComPy app package is shipped to the browser as a wheel, both the server and the browser can literally import the same schema module — a unique advantage over TypeScript-style RPC (tRPC/Hono), which needs compiler tricks to share types. A schema-driven typed client delivers typed API access against ANY plain-JSON HTTP API (including pre-existing third-party or in-house FastAPI services) without requiring server cooperation, code generation, or a custom wire format.
+
+## What Changes
+
+- New schema-driven deserializer `from_json(cls, data, *, strict=False) -> T` (pure Python, Pyodide-compatible):
+  - Reconstructs nested dataclasses from plain JSON (dict/list/primitives).
+  - Resolves `list[T]`, `dict[str, T]`, `Optional[T]`, and `Union` types structurally from type annotations.
+  - Coerces ISO-8601 strings into `datetime`/`date`/`time`, and strings into `UUID`/`Enum`, driven by the target type annotation (no wire metadata required).
+  - `strict=False` (default, client-appropriate): unknown keys are ignored (forward compatibility against API version skew); `strict=True` rejects unknown keys, missing required fields, and type mismatches.
+- `HttpClient` methods (`get`/`post`/`put`/`delete`/`patch`/`head`/`options`) gain an optional `response_type: type[T] | None` parameter. When provided, the method returns `T` (deserialized via `from_json`); when omitted, it returns `Response` exactly as today. Typing uses `@overload` + `TypeVar` so static checkers infer the return type.
+- Typed requests go through the existing `FetchPort`, so SSR/SSG self-site fetches remain in-process and are baked into hydration payloads with no extra work.
+- `use_async_result` gains `transfer: bool = True`; `transfer=False` marks the result runtime-only: it is NOT recorded into the hydration transfer payload during SSR/SSG, so user-specific or real-time data is fetched fresh in the browser and never baked into static artifacts.
+- No server-side dependency: works against any existing HTTP API that returns plain JSON.
+
+## Capabilities
+
+### New Capabilities
+
+- `typed-api-client`: Schema-driven typed deserialization (`from_json`) and the `response_type` typed request API on `HttpClient`, including validation strictness modes and container/leaf type coercion rules.
+
+### Modified Capabilities
+
+- `composables`: `use_async_result` gains the `transfer` parameter controlling whether results are recorded into the hydration transfer payload (SSG bake opt-out).
+
+## Impact
+
+- **Code**: new module under `packages/webcompy/src/webcompy/ajax/` (e.g. `_serde.py`), `packages/webcompy/src/webcompy/ajax/_fetch.py` (`HttpClient` signatures), `packages/webcompy/src/webcompy/components/_hooks.py` (`use_async_result`), transfer collection (`webcompy/hydration/_collect.py`) respecting the opt-out.
+- **APIs**: additive only; existing `HttpClient` calls behave identically.
+- **Dependencies**: none (stdlib `dataclasses`, `typing`, `datetime`, `uuid`, `enum`).
+- **Specs**: new `typed-api-client`; delta to `composables`.
+
+## Known Issues Addressed
+
+(none)
+
+## Non-goals
+
+- Chained/proxy-style API clients (Hono RPC-style path builders) — Python-idiomatic design would need separate exploration; deferred.
+- OpenAPI-schema-driven client generation.
+- Wire-metadata (superjson-style `__webcompy_transfer_meta__`) production or consumption — that is `feat-typed-response`; this change's deserializer is schema-driven only.
+- Server-side request validation for RPC endpoints — `feat-json-rpc` scope.
+- pydantic as a shared schema layer (dataclasses only; pydantic models can still be used server-side independently).

--- a/openspec/changes/feat-typed-api-client/specs/composables/spec.md
+++ b/openspec/changes/feat-typed-api-client/specs/composables/spec.md
@@ -1,0 +1,20 @@
+# Delta Spec: composables
+
+## ADDED Requirements
+
+### Requirement: use_async_result shall support opting out of hydration transfer
+`use_async_result` SHALL accept a `transfer: bool = True` parameter. With `transfer=True` (default), the resolved result SHALL be recorded into the hydration transfer payload during SSR/SSG as today. With `transfer=False`, the result SHALL NOT be recorded into the transfer payload: during SSR/SSG the fetch still executes (the page needs its content), but the resolved data SHALL NOT be persisted into the generated HTML; in the browser, hydration finds no transferred entry and the fetch executes on the client. `transfer=False` governs persistence only — it does NOT prevent build-time execution (components requiring no build-time execution SHALL use `ClientOnly`).
+
+#### Scenario: Default behavior unchanged
+- **WHEN** `use_async_result(fetcher)` is called without `transfer`
+- **THEN** the resolved result SHALL be included in the hydration transfer payload during SSR as before this change
+
+#### Scenario: transfer=False excludes data from the payload
+- **WHEN** `use_async_result(fetcher, transfer=False)` is rendered during SSR or SSG
+- **THEN** the fetch SHALL execute for rendering
+- **AND** the hydration payload embedded in the HTML SHALL NOT contain the result
+- **AND** after hydration in the browser the fetcher SHALL execute client-side
+
+#### Scenario: Sensitive data is not baked into static artifacts
+- **WHEN** a page generated via SSG uses `use_async_result(fetcher, transfer=False)` for user-specific data
+- **THEN** the generated HTML files SHALL NOT contain that data in their hydration payloads

--- a/openspec/changes/feat-typed-api-client/specs/typed-api-client/spec.md
+++ b/openspec/changes/feat-typed-api-client/specs/typed-api-client/spec.md
@@ -1,0 +1,76 @@
+# Spec: typed-api-client
+
+## ADDED Requirements
+
+### Requirement: Schema-driven JSON deserialization
+The framework SHALL provide `from_json(cls, data, *, strict=False) -> T`, a pure-Python, Pyodide-compatible deserializer that reconstructs nested dataclasses from plain JSON structures (dict/list/str/int/float/bool/None). It SHALL resolve target types from type annotations and SHALL support: nested dataclasses, `list[T]`, `dict[str, T]`, `Optional[T]`, and `Union` types (matched structurally in declaration order). When a target annotation is `datetime`, `date`, or `time`, an ISO-8601 string value SHALL be parsed into that type; when the annotation is `UUID`, a string value SHALL be parsed via `UUID(...)`; when the annotation is an `Enum` subclass, the value SHALL be matched by enum value. The function SHALL NOT resolve classes from wire data (no module-qualified-name import from payload content).
+
+#### Scenario: Flat dataclass reconstruction
+- **WHEN** `from_json(User, {"id": 1, "name": "ada"})` is called for a dataclass `User(id: int, name: str)`
+- **THEN** a `User(id=1, name="ada")` instance SHALL be returned
+
+#### Scenario: Nested dataclass reconstruction
+- **WHEN** `from_json(Team, {"name": "core", "members": [{"id": 1, "name": "ada"}]})` is called for `Team(name: str, members: list[User])`
+- **THEN** the result SHALL be a `Team` whose `members[0]` is a `User` instance, not a dict
+
+#### Scenario: Optional and Union fields
+- **WHEN** a dataclass field is annotated `Team | None` and the value is `None`
+- **THEN** the result SHALL be `None`
+- **AND** when the value is an object, it SHALL be reconstructed as `Team`
+
+#### Scenario: ISO datetime coercion from annotation
+- **WHEN** a dataclass field is annotated `created_at: datetime` and the JSON value is `"2026-08-05T12:34:56"`
+- **THEN** the field SHALL be a `datetime` instance equal to `datetime.fromisoformat("2026-08-05T12:34:56")`
+- **AND** no wire metadata SHALL be required for this coercion
+
+#### Scenario: UUID and Enum coercion
+- **WHEN** fields are annotated `id: UUID` and `role: Role` (an Enum) with JSON values `"123e4567-..."` and `"admin"`
+- **THEN** the fields SHALL be a `UUID` instance and the `Role.ADMIN` member respectively
+
+#### Scenario: Deserialization raises on schema mismatch
+- **WHEN** a declared field is missing from the data or a value cannot be coerced to its annotation
+- **THEN** a descriptive error SHALL be raised naming the field and the expected type
+
+### Requirement: Lenient and strict validation modes
+`from_json` SHALL default to `strict=False`, in which unknown keys in the data SHALL be ignored (forward compatibility with additive API changes). With `strict=True`, unknown keys SHALL be rejected, missing required fields SHALL be rejected, and any type mismatch SHALL raise an error. The strictness parameter SHALL apply uniformly to nested dataclasses.
+
+#### Scenario: Unknown keys ignored by default
+- **WHEN** `from_json(User, {"id": 1, "name": "ada", "new_field": 42})` is called with default strictness
+- **THEN** reconstruction SHALL succeed and `new_field` SHALL be ignored
+
+#### Scenario: Unknown keys rejected in strict mode
+- **WHEN** `from_json(User, {"id": 1, "name": "ada", "new_field": 42}, strict=True)` is called
+- **THEN** an error SHALL be raised naming `new_field`
+
+### Requirement: Typed requests on HttpClient via response_type
+`HttpClient` HTTP verb methods SHALL accept an optional keyword-only `response_type: type[T] | None` parameter. When omitted (or `None`), the method SHALL return `Response` exactly as before. When provided, the method SHALL parse the response body as JSON and SHALL return the result of `from_json(response_type, body)`. Typed requests SHALL go through the existing `FetchPort`, preserving self-site in-process fetching during SSR/SSG and hydration transfer caching. The methods SHALL be typed with `@overload` so that static type checkers infer `Response` when `response_type` is omitted and `T` when it is provided. A non-2xx response SHALL raise according to the existing error semantics before any deserialization; a JSON parse or schema mismatch SHALL raise a dedicated framework exception.
+
+#### Scenario: Untyped call returns Response (backward compatible)
+- **WHEN** `await HttpClient.get("/api/health")` is called without `response_type`
+- **THEN** a `Response` instance SHALL be returned as before this change
+
+#### Scenario: Typed call returns a reconstructed dataclass
+- **WHEN** `await HttpClient.get("/api/users/1", response_type=User)` is called and the endpoint returns `{"id": 1, "name": "ada"}`
+- **THEN** the result SHALL be a `User` instance
+- **AND** static type checkers SHALL infer the result type as `User`
+
+#### Scenario: Typed call against an existing unmodified JSON API
+- **WHEN** `response_type` is used against a third-party or pre-existing API that returns plain JSON with no WebComPy-specific metadata
+- **THEN** deserialization SHALL succeed using schema-driven coercion alone
+
+#### Scenario: Typed fetch during SSR uses the in-process path
+- **WHEN** a component performs a typed self-site fetch during SSR against a mounted endpoint
+- **THEN** the request SHALL be dispatched via the ASGI transport (no network I/O)
+- **AND** the raw response SHALL be recorded in the hydration transfer cache as with any self-site fetch
+
+#### Scenario: Deserialization errors participate in the error pipeline
+- **WHEN** a typed fetch raises a schema-mismatch error during component setup or rendering inside an `ErrorBoundary`
+- **THEN** the boundary SHALL engage its fallback as for any descendant error
+- **AND** during SSG, an uncontained deserialization error SHALL fail the build
+
+### Requirement: Typed deserialization shall not require server cooperation
+The typed client SHALL work against any HTTP API returning plain JSON. The framework SHALL NOT require response metadata, custom headers, or server-side WebComPy integration for `response_type` deserialization.
+
+#### Scenario: Plain JSON endpoint
+- **WHEN** an endpoint returns ordinary `application/json` with no WebComPy headers or body keys
+- **THEN** `response_type` deserialization SHALL succeed

--- a/openspec/changes/feat-typed-api-client/tasks.md
+++ b/openspec/changes/feat-typed-api-client/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: feat-typed-api-client
+
+## 1. Deserializer core
+
+- [ ] 1.1 Implement `from_json(cls, data, *, strict=False) -> T` in a new module (packages/webcompy/src/webcompy/ajax/_serde.py): dataclass reconstruction via `dataclasses.fields()` + `typing.get_type_hints()`, with per-class hint caching
+- [ ] 1.2 Support containers: `list[T]`, `dict[str, T]`, `Optional[T]`, `Union` (structural match in declaration order)
+- [ ] 1.3 Support leaf coercion: `datetime`/`date`/`time` (ISO-8601 via `fromisoformat`), `UUID`, `Enum` (by value)
+- [ ] 1.4 Implement strict/lenient modes (unknown-key handling, missing-field errors) with descriptive error messages naming field and expected type
+- [ ] 1.5 Re-export the public API from `webcompy.ajax` and add a dedicated `TypedResponseError` (or similarly named) framework exception
+
+## 2. HttpClient integration
+
+- [ ] 2.1 Add keyword-only `response_type` parameter with `@overload` + `TypeVar` signatures to `HttpClient` verb methods (get/post/put/delete/patch/head/options), preserving `Response` return when omitted
+- [ ] 2.2 Wire typed calls through the existing FetchPort path; raise on non-2xx before deserialization; raise the dedicated exception on JSON/schema mismatch
+
+## 3. Transfer opt-out
+
+- [ ] 3.1 Add `transfer: bool = True` to `use_async_result` (packages/webcompy/src/webcompy/components/_hooks.py) and mark the entry non-transferable
+- [ ] 3.2 Make `collect_transfer_data()` (packages/webcompy/src/webcompy/hydration/_collect.py) skip non-transferable async-result entries
+- [ ] 3.3 Verify browser hydration falls back to client-side execution when no transferred entry exists
+
+## 4. Tests
+
+- [ ] 4.1 Serde unit tests: flat/nested dataclasses, list/dict/Optional/Union, datetime/date/UUID/Enum coercion, strict vs lenient, error messages
+- [ ] 4.2 Serde test: schema module using `from __future__ import annotations`
+- [ ] 4.3 HttpClient tests: untyped call returns `Response`; typed call returns `T`; type inference verified via pyright
+- [ ] 4.4 Integration test (webcompy_testing): typed self-site fetch during SSR uses ASGITransport and populates the transfer cache
+- [ ] 4.5 Integration test: `transfer=False` result absent from hydration payload; browser executes the fetch after hydration; SSG artifact does not contain the data
+
+## 5. Docs and verification
+
+- [ ] 5.1 Add docs/example: shared dataclass schema used from both a FastAPI endpoint and a WebComPy component via `response_type` (per `doc-spec-references`: docs reference the owning specs as source of truth rather than transcribing requirement prose)
+- [ ] 5.2 `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run python -m pytest tests/ --tb=short` all pass
+
+## 6. Spec reference sync
+
+- [ ] 6.1 Update AGENTS.md: add `typed-api-client` to the Current Specs list; add File→Spec Mapping entries for the new serde module (`webcompy/ajax/_serde.py` → `typed-api-client/spec.md`) and the modified `webcompy/ajax/` (`HttpClient`), `webcompy/components/` (`use_async_result`), and `webcompy/hydration/` (`_collect.py`) rows (`typed-api-client` + `composables`)
+- [ ] 6.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions and sync invariant headings/spec references
+- [ ] 6.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes

--- a/openspec/changes/feat-typed-response/.openspec.yaml
+++ b/openspec/changes/feat-typed-response/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/feat-typed-response/design.md
+++ b/openspec/changes/feat-typed-response/design.md
@@ -1,0 +1,59 @@
+# Design: feat-typed-response
+
+## Context
+
+`feat-typed-api-client` established that type restoration can be driven by client-held schemas for plain JSON. The residual gap is types whose JSON representation is ambiguous or lossy: `bytes` (no JSON representation at all), `set`/`tuple` (both serialize as arrays), `Decimal` (serializes as number or string with precision questions), and `Any`-typed fields where no annotation exists to drive coercion. The transfer-codec solves the same problem for hydration payloads, but its inline tagged representation (`__webcompy_type__` markers interleaved in the data) would pollute API response bodies and break OpenAPI accuracy. The superjson-style separation — pristine body plus a sidecar metadata map — keeps the body standard while giving a cooperating client full fidelity.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single framework-neutral serialization helper that produces (plain JSON body, metadata) pairs.
+- Two wire placements: response header (default) and inline body key for large metadata.
+- Zero hard dependency on FastAPI; a thin contrib `TypedJSONResponse` for the common case.
+- Client recognition integrated into the existing `response_type` path.
+
+**Non-Goals:**
+- Server-side decoding of untrusted metadata (allowlist concern — `feat-json-rpc`).
+- Request-body metadata; non-FastAPI contrib modules; OpenAPI tooling.
+
+## Decisions
+
+### D1: Metadata is a path→type map over the pristine JSON body
+`encode_with_meta(value)` walks the value and emits `(json_data, meta)` where `meta` maps JSON-ish paths (e.g. `"members[0].avatar"`) to type tags (`"bytes"`, `"set"`, `"tuple"`, `"decimal"`, ...). Path syntax: dot-separated keys with `[index]` for arrays — documented in the spec.
+
+**Why**: keeping the body pristine is the whole point (progressive enhancement: non-WebComPy consumers see a normal API). Inline tags (transfer-codec style) were rejected for API surfaces because they alter the body schema. Alternatives considered for tag granularity — per-field vs whole-payload single tag — per-field paths win because they compose with nested dataclasses naturally.
+
+### D2: Header mode is the default; body mode requires a top-level object
+- Header mode: `X-WebComPy-Transfer-Meta: <json>`. Body stays pristine; OpenAPI stays truthful; non-WebComPy clients ignore the header.
+- Body mode: metadata injected under `__webcompy_transfer_meta__` (consistent with the existing `__webcompy_*` key family). Required when metadata risks exceeding practical header size limits.
+- Body mode with a top-level array/scalar is an explicit error (`WebComPyException` at encode time), NOT an implicit fallback to a wrapper shape. Callers use header mode, or restructure their payload as an object (e.g. `{"items": [...]}`, which also plays well with pagination).
+
+**Why**: an implicit wrapper fallback creates two body shapes for the same endpoint and confuses both clients and OpenAPI. An explicit contract — "body mode requires object payloads" — is one rule, easy to validate and document. In practice, metadata-worthy responses (structured models) are objects; list-returning endpoints are typically simple or can adopt the items-wrapper idiom.
+
+### D3: The helper is the canonical contract; contrib classes are sugar
+`encode_with_meta` lives in a framework-neutral, dual-environment module (server-only usage in practice, but no server-only imports so it stays testable and reusable). `TypedJSONResponse(JSONResponse)` overrides `render()` to call the helper and set the header/body key — ~30 lines. Django/Flask/plain-Starlette users call the helper directly per docs recipes.
+
+**Why**: the wire format must have exactly one normative definition. Framework adapters come and go; the contract stays. This also keeps FastAPI out of the dependency graph (lazy import in the contrib module only).
+
+### D4: Client consumption layers meta on top of schema-driven coercion
+The `response_type` path in `HttpClient` (and standalone `from_json` via an optional `meta` parameter) first parses the body, then applies metadata-driven restoration at the recorded paths, then runs schema-driven reconstruction. Metadata takes precedence for the exact paths it records (e.g. restoring `bytes` that schema coercion could never produce); everything else flows through `from_json` as before.
+
+**Why**: schema-driven coercion remains the default workhorse; metadata is the exception channel. Precedence is unambiguous because metadata addresses concrete value positions, while annotations describe structure.
+
+### D5: No allowlist in this change
+Metadata decoding happens only in the browser/SSR client against responses from servers the app itself talks to. Type tags map to a fixed, closed set of restoration operations (bytes/set/tuple/decimal/datetime/...), not arbitrary class imports — so even a malicious server response cannot trigger code execution through this path. Arbitrary-class reconstruction from wire names remains exclusive to hydration (server-generated payloads) and is not extended here.
+
+## Risks / Trade-offs
+
+- [Header size limits (proxies commonly cap ~8-16KB total headers)] → body mode exists precisely for this; helper computes metadata size and `TypedJSONResponse` documents the trade-off; spec mandates the body-mode object-only contract.
+- [Path grammar ambiguity with keys containing dots/brackets] → path segments are percent-encoded per the spec's grammar; tests cover exotic keys.
+- [Two wire placements double client recognition logic] → recognition is a single check: body key presence first, else header (HttpClient sees headers; standalone `from_json` takes explicit `meta`). Spec fixes precedence: body key wins if both present (should not happen; servers pick one mode per response).
+- [pydantic models as input] → helper accepts dataclasses, pydantic models (via `model_dump()` when available), and plain structures; pydantic handling is duck-typed, no import.
+
+## Migration Plan
+
+None — additive. APIs not using the helper are unaffected.
+
+## Open Questions
+
+- Exact path-grammar encoding (percent-encoding vs JSON Pointer) — finalize in implementation; JSON Pointer (RFC 6901) is the leading candidate since it is an existing standard with escaping rules.

--- a/openspec/changes/feat-typed-response/proposal.md
+++ b/openspec/changes/feat-typed-response/proposal.md
@@ -1,0 +1,44 @@
+# Proposal: feat-typed-response
+
+## Why
+
+The schema-driven typed client (`feat-typed-api-client`) restores rich types from plain JSON using target annotations, which covers most real-world APIs. But some Python types cannot survive plain JSON even with schema knowledge on the client: `bytes`, `set` vs `list` distinction, `tuple` vs `list`, `Decimal`, and values behind `Any`-typed or polymorphic (`Union`) fields where the annotation alone cannot identify the concrete type. For APIs a project controls (new WebComPy-aware backends), the server can attach type metadata to responses so the client restores full fidelity — without breaking ordinary JSON consumers of the same API.
+
+## What Changes
+
+- New framework-neutral helper `encode_with_meta(value) -> tuple[plain_json, meta]`: serializes a dataclass/pydantic-model/plain-structure value into pristine JSON-compatible data plus a metadata map recording non-JSON-native types by path. No web-framework dependency.
+- Wire formats (both produced by the helper and consumed by the client):
+  - **Header mode (default)**: response body stays pristine plain JSON; metadata travels in the `X-WebComPy-Transfer-Meta` response header. Non-WebComPy clients are unaffected; OpenAPI schemas stay accurate.
+  - **Body mode (for large metadata)**: the response body MUST be a top-level JSON object; metadata is injected under the collision-resistant key `__webcompy_transfer_meta__`. Top-level arrays/scalars are NOT supported in body mode — they must use header mode; attempting body mode with a non-object payload is an explicit error (no silent fallback).
+- `TypedJSONResponse` for FastAPI in `webcompy_server.contrib.fastapi` (optional module, lazy FastAPI import): a thin `JSONResponse` subclass that applies `encode_with_meta` and emits header or body mode. FastAPI is NOT a dependency of the core packages; other frameworks (plain Starlette, Django, Flask) use `encode_with_meta` directly per documented recipes.
+- Client side: `from_json` / the `response_type` path in `HttpClient` learns to recognize `X-WebComPy-Transfer-Meta` and `__webcompy_transfer_meta__` and applies metadata-driven restoration for the types schema-driven coercion cannot handle (`bytes`, `set`, `tuple`, `Decimal`, and concrete-type hints for `Any`/ambiguous fields). Absent metadata, behavior is exactly as specified in `typed-api-client`.
+- Client-side decoding only: the server never decodes client-controlled metadata in this change, so no type allowlist is required here (that concern belongs to `feat-json-rpc`).
+
+## Capabilities
+
+### New Capabilities
+
+- `typed-response`: Metadata-augmented responses (`encode_with_meta`, wire formats, `TypedJSONResponse`, client-side metadata consumption rules).
+
+### Modified Capabilities
+
+- `typed-api-client`: The `response_type` deserialization path SHALL recognize and apply transfer metadata (header and body-key forms) when present, layered on top of schema-driven coercion.
+
+## Impact
+
+- **Code**: core helper in `packages/webcompy/src/webcompy/hydration/` or a shared serde module (framework-neutral, dual-environment); `packages/webcompy-server/src/webcompy_server/contrib/fastapi.py` (new, optional); client recognition in `packages/webcompy/src/webcompy/ajax/` (`from_json`/`HttpClient` typed path).
+- **APIs**: new public helpers; no changes to existing signatures.
+- **Dependencies**: none required; FastAPI only when using the contrib module (lazy import).
+- **Implementation order**: This change's delta targets the `typed-api-client` capability created by `feat-typed-api-client`; that change MUST be implemented and archived first.
+- **Specs**: new `typed-response`; delta to `typed-api-client`.
+
+## Known Issues Addressed
+
+(none)
+
+## Non-goals
+
+- Server-side decoding of client-controlled metadata (RPC scope: `feat-json-rpc`, which introduces the allowlist).
+- Contrib integrations for frameworks other than FastAPI (recipes documented; first-party modules deferred).
+- Automatic OpenAPI schema adjustments for metadata-augmented endpoints.
+- Metadata for request bodies (requests to FastAPI are already validated/typed by the server framework).

--- a/openspec/changes/feat-typed-response/specs/typed-api-client/spec.md
+++ b/openspec/changes/feat-typed-response/specs/typed-api-client/spec.md
@@ -1,0 +1,23 @@
+# Delta Spec: typed-api-client
+
+## ADDED Requirements
+
+### Requirement: Typed deserialization shall consume transfer metadata when present
+The `response_type` path of `HttpClient` and `from_json` SHALL recognize transfer metadata in both wire placements defined by `typed-response`: the `__webcompy_transfer_meta__` body key and the `X-WebComPy-Transfer-Meta` response header. When both are present (non-conforming servers), the body key SHALL take precedence. Metadata-driven restoration SHALL apply at the recorded paths and SHALL take precedence over schema-driven coercion for those exact values (restoring types such as `bytes`, `set`, `tuple`, and `Decimal` that annotations alone cannot identify). When no metadata is present, behavior SHALL remain purely schema-driven. `from_json` SHALL accept an optional `meta` parameter for standalone use.
+
+#### Scenario: Bytes restoration via metadata
+- **WHEN** a response body contains base64 text at a path recorded in metadata with type tag `bytes`
+- **AND** the target field is annotated `bytes`
+- **THEN** the reconstructed object SHALL contain the decoded `bytes` value
+
+#### Scenario: Set restoration via metadata
+- **WHEN** a JSON array is recorded in metadata with type tag `set` for a field annotated `set[str]`
+- **THEN** the reconstructed field SHALL be a Python `set`, not a `list`
+
+#### Scenario: Absent metadata behaves exactly as schema-driven
+- **WHEN** a response carries neither `__webcompy_transfer_meta__` nor `X-WebComPy-Transfer-Meta`
+- **THEN** deserialization SHALL behave exactly as specified by the schema-driven requirements
+
+#### Scenario: Body key takes precedence over header
+- **WHEN** both `__webcompy_transfer_meta__` and `X-WebComPy-Transfer-Meta` are present
+- **THEN** the body key metadata SHALL be used

--- a/openspec/changes/feat-typed-response/specs/typed-response/spec.md
+++ b/openspec/changes/feat-typed-response/specs/typed-response/spec.md
@@ -1,0 +1,62 @@
+# Spec: typed-response
+
+## ADDED Requirements
+
+### Requirement: Framework-neutral metadata encoder
+The framework SHALL provide `encode_with_meta(value) -> tuple[json_data, meta]` where `json_data` is a pristine JSON-compatible structure (dict/list/str/int/float/bool/None) and `meta` is a mapping from value paths to type tags. The helper SHALL accept dataclasses, pydantic models (duck-typed via `model_dump()`, without importing pydantic), and plain structures. Type tags SHALL cover at minimum: `bytes` (base64 in body), `set`, `tuple`, `decimal`, `datetime`, `date`, `time`, `uuid`. Types already representable in JSON without ambiguity (str/int/float/bool/None, and nested dataclass structure) SHALL NOT produce metadata entries. The helper SHALL NOT import any web framework.
+
+#### Scenario: Dataclass with non-JSON-native fields
+- **WHEN** `encode_with_meta(record)` is called for a dataclass containing `avatar: bytes`, `tags: set[str]`, and `price: Decimal`
+- **THEN** `json_data` SHALL contain base64 text for `avatar`, an array for `tags`, and a string for `price`
+- **AND** `meta` SHALL record the type tag for each of those paths
+- **AND** `json_data` SHALL contain no `__webcompy_` keys or other inline tags
+
+#### Scenario: Pure-JSON value produces empty metadata
+- **WHEN** `encode_with_meta({"a": 1, "b": ["x", True]})` is called
+- **THEN** `meta` SHALL be empty and `json_data` SHALL equal the input structure
+
+#### Scenario: pydantic model accepted without pydantic import
+- **WHEN** `encode_with_meta(model)` is called for a pydantic model instance
+- **THEN** serialization SHALL proceed via `model_dump()` and produce body and metadata as for an equivalent dataclass
+
+### Requirement: Header wire mode
+In header mode (the default), the response body SHALL be the pristine JSON representation and the metadata SHALL travel in the `X-WebComPy-Transfer-Meta` response header as JSON. API consumers that do not understand the header SHALL receive a completely ordinary JSON response.
+
+#### Scenario: FastAPI endpoint with header mode
+- **WHEN** an endpoint returns a metadata-augmented response in header mode
+- **THEN** the response body SHALL be plain JSON with no metadata keys
+- **AND** the `X-WebComPy-Transfer-Meta` header SHALL contain the metadata JSON
+- **AND** a non-WebComPy HTTP client SHALL be able to consume the response normally
+
+### Requirement: Body wire mode requires a top-level object
+In body mode, metadata SHALL be injected into the response body under the key `__webcompy_transfer_meta__`. Body mode SHALL require the payload to serialize to a top-level JSON object. If the payload is a top-level array or scalar, encoding in body mode SHALL raise an explicit error; there SHALL be NO implicit wrapper or fallback shape. Callers with array/scalar payloads SHALL use header mode or restructure the payload as an object.
+
+#### Scenario: Object payload in body mode
+- **WHEN** an object payload is encoded in body mode
+- **THEN** the original fields SHALL remain at the top level of the body
+- **AND** metadata SHALL appear under `__webcompy_transfer_meta__`
+- **AND** a non-WebComPy client ignoring unknown keys SHALL still consume the data fields normally
+
+#### Scenario: Array payload rejected in body mode
+- **WHEN** a top-level list payload is encoded in body mode
+- **THEN** an explicit error SHALL be raised instructing the caller to use header mode or an object payload
+- **AND** no fallback wrapper JSON SHALL be produced
+
+### Requirement: FastAPI TypedJSONResponse contrib module
+The framework SHALL provide `TypedJSONResponse` in `webcompy_server.contrib.fastapi`, a thin `JSONResponse` subclass that applies `encode_with_meta` and emits the selected wire mode. The module SHALL import FastAPI/Starlette lazily so that neither becomes a dependency of core packages. The default mode SHALL be header mode; body mode SHALL be selectable per response.
+
+#### Scenario: Returning a typed response from FastAPI
+- **WHEN** an endpoint returns `TypedJSONResponse(record)`
+- **THEN** the response SHALL carry metadata in header mode by default
+- **AND** importing `webcompy_server` without FastAPI installed SHALL NOT fail (the contrib module SHALL raise a clear error only when actually imported without FastAPI)
+
+### Requirement: Metadata decoding uses a closed set of type tags
+Client-side restoration from metadata SHALL map type tags to a fixed, closed set of restoration operations. The decoder SHALL NOT import or resolve classes from names appearing in metadata. This guarantees metadata decoding cannot trigger code execution, without requiring a type allowlist in this change.
+
+#### Scenario: Unknown type tag handling
+- **WHEN** metadata contains a type tag the client does not recognize
+- **THEN** the decoder SHALL raise a descriptive error (strict contexts) or leave the value as-is (default lenient behavior)
+
+## MODIFIED Requirements
+
+(none — client-consumption behavior is specified as a delta to `typed-api-client`)

--- a/openspec/changes/feat-typed-response/tasks.md
+++ b/openspec/changes/feat-typed-response/tasks.md
@@ -1,0 +1,38 @@
+# Tasks: feat-typed-response
+
+## 1. Core encoder
+
+- [ ] 1.1 Implement `encode_with_meta(value) -> tuple[json_data, meta]` in a framework-neutral module: dataclasses, pydantic (duck-typed `model_dump()`), plain structures; type tags for bytes/set/tuple/decimal/datetime/date/time/uuid
+- [ ] 1.2 Define and implement the path grammar (leading candidate: JSON Pointer RFC 6901) with escaping tests for keys containing dots/brackets/slashes
+- [ ] 1.3 Implement body-mode validation: top-level object required, explicit error for array/scalar with guidance message
+- [ ] 1.4 Ensure no `__webcompy_` keys or inline tags appear in pristine bodies (regression test)
+
+## 2. FastAPI contrib
+
+- [ ] 2.1 Create `packages/webcompy-server/src/webcompy_server/contrib/__init__.py` and `contrib/fastapi.py` with `TypedJSONResponse(JSONResponse)` (lazy imports, header mode default, body mode option)
+- [ ] 2.2 Verify importing `webcompy_server` without FastAPI installed does not fail; importing the contrib module without FastAPI raises a clear error
+
+## 3. Client consumption
+
+- [ ] 3.1 Extend `from_json` with an optional `meta` parameter applying metadata-driven restoration at recorded paths before schema-driven reconstruction
+- [ ] 3.2 Wire metadata recognition into the `HttpClient` `response_type` path: read `__webcompy_transfer_meta__` (precedence) or `X-WebComPy-Transfer-Meta` header; closed-set tag decoding only
+- [ ] 3.3 Ensure browser `FetchPort` responses expose headers sufficiently for header-mode recognition (adjust `Response` wrapper if needed)
+
+## 4. Tests
+
+- [ ] 4.1 Encoder unit tests: each type tag, nested paths, pydantic input, empty-meta case
+- [ ] 4.2 Body-mode contract tests: object injection, array/scalar explicit error, no fallback wrapper
+- [ ] 4.3 Contrib test (FastAPI installed in dev deps): `TypedJSONResponse` header/body modes; non-WebComPy client sees ordinary JSON
+- [ ] 4.4 Client tests: bytes/set/tuple/Decimal restoration, precedence rules, unknown-tag behavior (lenient default, strict error), absent-metadata parity
+- [ ] 4.5 Integration test: mounted FastAPI endpoint returning `TypedJSONResponse` consumed by a component via `response_type`, in SSR and browser paths
+
+## 5. Docs and verification
+
+- [ ] 5.1 Docs: header vs body mode guidance (header default; body for large metadata; object-only contract), recipes for plain Starlette/Django using `encode_with_meta` directly (per `doc-spec-references`: docs reference the owning specs as source of truth rather than transcribing requirement prose)
+- [ ] 5.2 `uv run ruff check .`, `uv run ruff format --check .`, `uv run pyright`, `uv run python -m pytest tests/ --tb=short` all pass
+
+## 6. Spec reference sync
+
+- [ ] 6.1 Update AGENTS.md: add `typed-response` to the Current Specs list; add File→Spec Mapping entries for the metadata-encoder module and `webcompy_server/contrib/` (`typed-response/spec.md`), and the `typed-api-client` client-consumption rows
+- [ ] 6.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions and sync invariant headings/spec references
+- [ ] 6.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes

--- a/openspec/changes/fix-cookie-propagation/.openspec.yaml
+++ b/openspec/changes/fix-cookie-propagation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-05

--- a/openspec/changes/fix-cookie-propagation/design.md
+++ b/openspec/changes/fix-cookie-propagation/design.md
@@ -1,0 +1,57 @@
+# Design: fix-cookie-propagation
+
+## Context
+
+`ServerCookiePort` (packages/webcompy-server/src/webcompy_server/ports/_cookie.py) currently stores only name/value pairs in an internal dict; all attributes passed to `set()` are discarded. The `CookiePort.set()` ABC accepts `max_age`, `path`, `secure`, `httponly`, and `samesite`, but has no `expires` or `domain` parameters. The `port-abstraction` spec documents this as a known limitation and notes that attributes must eventually propagate via `Set-Cookie` response headers. The HTML response for SSR pages is assembled in `send_html` (packages/webcompy-cli/src/webcompy_cli/_server.py), which builds a Starlette `HTMLResponse` after rendering via a per-request `ServerRenderContext`. The render context is created per request (`app.create_render_context(path, cookie_header=...)`) and disposed in `finally`, so it is the natural per-request carrier for pending cookie writes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Preserve the full attribute set on `ServerCookiePort.set()`.
+- Emit accumulated cookie writes as `Set-Cookie` headers on the SSR HTML response.
+- Keep per-request isolation (no cross-request leakage).
+- Specify SSG behavior: writes ignored, no error.
+
+**Non-Goals:**
+- Cookies on responses from user-mounted ASGI apps (out of scope; those apps own their responses).
+- Signed/encrypted cookies.
+- Changes to the browser-side `CookiePort`.
+
+## Decisions
+
+### D1: Accumulate pending writes in the render context, not the port
+`ServerCookiePort` is provided per render context via DI (`ServerRenderContext._register_ports()`). The port holds a small mutable list of pending `Set-Cookie` header strings (or structured records). `send_html` reads them from the context after `generate_html()` completes and before `ctx.dispose()`.
+
+**Why**: The port is the natural write interception point (component code calls `CookiePort.set()`), while the response assembly lives in the CLI layer. The render context is the only object both sides share. Alternatives considered: (a) returning cookies from `generate_html()` — rejected because it changes the html-generator contract for one concern; (b) a module-level collector — rejected (violates the no-new-globals invariant and breaks per-request isolation).
+
+### D2: Header emission point is `send_html` in `_server.py`
+Both history-mode and hash-mode SSR responses pass through `send_html` / its hash-mode counterpart. Hash mode renders once at startup into a cache, so cookies written there have no per-request meaning; hash-mode responses SHALL NOT emit accumulated cookies (documented behavior). Only the per-request history-mode path emits `Set-Cookie` headers.
+
+**Why**: Hash-mode serving is a static-style deployment; cookies set at startup render would leak across all requests.
+
+### D3: Attribute serialization uses Python stdlib `http.cookies.SimpleCookie`
+Build the `Set-Cookie` header value via `http.cookies` (`Morsel` handles `max-age`/`expires`/`path`/`domain`/`secure`/`httponly`/`samesite` formatting and quoting correctly). `expires` (a `datetime`) is formatted to the RFC 1123 date string `Morsel` expects; `domain` is assigned to the morsel's `domain` key. Multiple cookies → multiple `Set-Cookie` headers (Starlette `response.headers.append` / raw header list), since `Set-Cookie` must not be comma-joined.
+
+**Why**: Hand-rolling cookie serialization is error-prone (quoting, date format); stdlib is correct and adds no dependency. Note: `SimpleCookie` is server-only code — never imported in browser paths.
+
+### D4: SSG ignores writes silently
+`generate_static_site` fetches pages through the same ASGI app; `send_html` will emit headers during generation too, but httpx response headers are simply not persisted to the static file — no special-casing needed in the SSG layer. The spec requirement ("ignored, not an error") is satisfied by construction.
+
+### D5: `CookiePort.set()` gains keyword-only `expires` and `domain` parameters
+The attribute-retention requirement includes `expires` and `domain`, which the current ABC does not accept. Both are added as keyword-only parameters with `None` defaults (additive, backward compatible). `BrowserCookiePort.set()` applies them to `document.cookie` (`expires` formatted as a UTC date string, `domain` as-is), matching the existing attribute handling; `ServerCookiePort` retains them and serializes them via `Morsel` (D3).
+
+**Why**: `domain` is required for real cross-subdomain session cookies and `expires` for absolute-expiry cookies; both are natively supported by `document.cookie` and `http.cookies`, so the parity cost is minimal. Alternative considered: restrict the spec to the five attributes the ABC accepts today — rejected because it would leave the port unable to express common cookie configurations, and because the extension is purely additive (no existing call site is affected).
+
+## Risks / Trade-offs
+
+- [Attribute values with non-ASCII or control characters could produce malformed headers] → `http.cookies` performs quoting; add a test with values requiring quoting.
+- [A component setting many cookies inflates response headers] → Acceptable; bounded by typical session usage. No dedup beyond last-write-wins per cookie name (matching browser semantics: later `Set-Cookie` for the same name+path overwrites).
+- [Hash-mode users expect cookies to work] → Documented as unsupported; hash mode is static-style serving.
+
+## Migration Plan
+
+No migration. Existing behavior (attributes dropped) was undocumented for users; the change only adds headers that were previously absent.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/fix-cookie-propagation/proposal.md
+++ b/openspec/changes/fix-cookie-propagation/proposal.md
@@ -1,0 +1,42 @@
+# Proposal: fix-cookie-propagation
+
+## Why
+
+`ServerCookiePort` currently drops cookie attributes (`max_age`, `secure`, `samesite`, `httponly`, etc.) when `set()` is called during SSR — the cookie value is stored in internal state only and never reaches the browser. The `port-abstraction` spec already records this as a known limitation with a NOTE stating that attributes SHALL be propagated via `Set-Cookie` response headers once server-side functionality arrives. As WebComPy gains server-runtime capabilities (user-mounted ASGI apps, authentication-backed APIs), cookies set during SSR must be delivered to the browser with their attributes intact, or login/session flows silently break.
+
+## What Changes
+
+- `ServerCookiePort.set()` SHALL retain the full attribute set (`max_age`, `expires`, `path`, `domain`, `secure`, `httponly`, `samesite`) instead of discarding it.
+- To carry the full attribute set, `CookiePort.set()` gains keyword-only `expires: datetime | None = None` and `domain: str | None = None` parameters (additive, backward compatible). `BrowserCookiePort.set()` SHALL apply them to `document.cookie` alongside the existing attributes; `ServerCookiePort.set()` SHALL retain them for `Set-Cookie` emission.
+- Cookie writes performed during SSR SHALL be accumulated in the per-request `RenderContext` and emitted as `Set-Cookie` response headers on the HTML response produced by the dev/prod server.
+- In hash-mode serving, the HTML shell is pre-rendered once and cached, so accumulated cookie writes SHALL NOT be emitted on hash-mode responses; this SHALL be documented as specified behavior.
+- During SSG (`webcompy generate`), cookie writes SHALL be ignored (a static artifact cannot carry response headers); this SHALL be documented as specified behavior, not an error.
+- No breaking changes: the read path (`get()`, `get_all()`, request `Cookie` parsing) is unchanged, and `set()` is extended additively (keyword-only parameters with `None` defaults) on both browser and server implementations.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `port-abstraction`: The "ServerCookiePort ignores Set-Cookie attributes" limitation is resolved. Cookie attribute propagation via `Set-Cookie` response headers during SSR becomes a requirement (upgrading the existing NOTE), and SSG-time behavior (ignore writes) is specified.
+
+## Impact
+
+- **Code**: `packages/webcompy/src/webcompy/ports/_cookie.py` (ABC extension), `packages/webcompy/src/webcompy/ports/_browser/_cookie.py` (browser attribute application), `packages/webcompy-server/src/webcompy_server/ports/_cookie.py` (attribute retention + pending-write accumulation), `packages/webcompy-server/src/webcompy_server/_context.py` (access to pending cookies from render context), `packages/webcompy-cli/src/webcompy_cli/_server.py` (`send_html` response header emission).
+- **APIs**: Additive only: keyword-only `expires`/`domain` parameters added to `CookiePort.set()` (both `BrowserCookiePort` and `ServerCookiePort` accept them). Existing call sites are unaffected.
+- **Dependencies**: None.
+- **Specs**: `openspec/specs/port-abstraction/spec.md`.
+
+## Known Issues Addressed
+
+- Port abstraction: `ServerCookiePort` dropping `max_age`/`secure`/`samesite` attributes (documented in `port-abstraction` spec as a current limitation with a future-work NOTE).
+
+## Non-goals
+
+- Reading `Cookie` request headers beyond the existing `cookie_header` parsing (already supported).
+- Cookie propagation for responses produced by user-mounted ASGI applications (those apps own their own response headers).
+- Browser-side cookie attribute enforcement (delegated to the browser as today).
+- Encrypted/signed cookie support.

--- a/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
+++ b/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
@@ -46,9 +46,13 @@ ServerDOMPort SHALL additionally provide `render_html(node: DOMNode) -> str` for
 
 #### Scenario: ServerCookiePort ignores Set-Cookie attributes (current limitation)
 - **WHEN** `ServerCookiePort.set(name, value, max_age=3600, secure=True, samesite="Strict")` is called on the server
-- **THEN** the HTML page response SHALL include a `Set-Cookie` header for `name=value`
-- **AND** the header SHALL preserve the `max_age`, `secure`, `httponly`, `path`, and `samesite` attributes
-- **NOTE**: The current limitation documented by the pre-change spec (attributes discarded) is resolved by this change: attributes are retained and propagated via `Set-Cookie` response headers.
+- **THEN** the previous limitation documented by this scenario (attributes discarded) SHALL be considered retired
+- **AND** the full attribute set SHALL be retained and emitted via `Set-Cookie` response headers, as specified by the "ServerCookiePort propagates attributes via Set-Cookie during SSR" scenario
+
+#### Scenario: ServerCookiePort propagates attributes via Set-Cookie during SSR
+- **WHEN** `ServerCookiePort.set("session", "abc", max_age=3600, secure=True, samesite="Strict", httponly=True, path="/")` is called during SSR
+- **THEN** the HTML page response SHALL include a `Set-Cookie` header for `session=abc`
+- **AND** the header SHALL preserve `Max-Age=3600`, `Secure`, `SameSite=Strict`, `HttpOnly`, and `Path=/`
 
 #### Scenario: Multiple cookie writes produce multiple Set-Cookie headers
 - **WHEN** two different cookies are set during a single SSR request

--- a/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
+++ b/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
@@ -1,0 +1,64 @@
+# Delta Spec: port-abstraction
+
+## ADDED Requirements
+
+### Requirement: CookiePort.set() shall support expires and domain attributes
+`CookiePort.set()` SHALL accept keyword-only `expires: datetime | None = None` and `domain: str | None = None` parameters in addition to the existing attributes. Calls omitting them SHALL behave exactly as before this change. `BrowserCookiePort.set()` SHALL apply `expires` (formatted as a UTC date string) and `domain` to `document.cookie` alongside the existing attributes. `ServerCookiePort.set()` SHALL retain both for `Set-Cookie` emission.
+
+#### Scenario: Backward compatibility for existing call sites
+- **WHEN** `CookiePort.set(name, value, max_age=3600)` is called without `expires` or `domain`
+- **THEN** behavior SHALL be identical to before this change
+
+#### Scenario: Browser port applies expires and domain
+- **WHEN** `BrowserCookiePort.set("session", "abc", expires=dt, domain="example.com")` is called in the browser
+- **THEN** the `document.cookie` write SHALL include the `expires` attribute as a UTC date string and `domain=example.com`
+
+#### Scenario: Set-Cookie preserves Expires and Domain during SSR
+- **WHEN** `ServerCookiePort.set("session", "abc", expires=dt, domain="example.com")` is called during SSR
+- **THEN** the HTML page response's `Set-Cookie` header SHALL preserve the `Expires` and `Domain` attributes
+
+## MODIFIED Requirements
+
+### Requirement: Server port implementations shall provide equivalent behavior
+Server port implementations SHALL provide the same method signatures and return types as browser implementations. ServerDOMPort SHALL construct a virtual DOM tree via `VirtualDOMNode` instances instead of raising exceptions. `ServerDOMPort.create_element()` SHALL return a `VirtualDOMNode`. `ServerDOMPort.create_text_node()` SHALL return a virtual text node. `ServerDOMPort.query_selector()` and `get_element_by_id()` SHALL return `None` (SSG does not query existing DOM). `ServerDOMPort.set_title()` SHALL be a no-op. `ServerDOMPort.schedule_macro_task()` SHALL execute the callback synchronously.
+
+ServerDOMPort SHALL additionally provide `render_html(node: DOMNode) -> str` for serializing virtual trees to HTML strings.
+
+`ServerCookiePort.set()` SHALL retain the full attribute set (`max_age`, `expires`, `path`, `domain`, `secure`, `httponly`, `samesite`) associated with each cookie write. Cookie writes performed during SSR SHALL be accumulated per render context and SHALL be emitted as `Set-Cookie` response headers on the HTML page response, preserving all attributes. In hash-mode serving, the HTML shell is pre-rendered once and cached; accumulated cookie writes SHALL NOT be emitted on hash-mode responses. During SSG (`webcompy generate`), cookie writes SHALL be silently ignored (a static artifact cannot carry response headers); this SHALL NOT be treated as an error. The read path (`get()`, request `Cookie` header parsing) SHALL remain unchanged.
+
+#### Scenario: ServerDOMPort creates elements for virtual tree
+- **WHEN** `ServerDOMPort.create_element("div")` is called on the server
+- **THEN** a `VirtualDOMNode` SHALL be returned instead of raising an exception
+- **AND** the node SHALL have `nodeName == "DIV"` and `nodeType == 1`
+
+#### Scenario: ServerDOMPort serializes virtual tree to HTML
+- **WHEN** `ServerDOMPort.render_html(root)` is called on a virtual tree
+- **THEN** a valid HTML string SHALL be returned
+- **AND** void elements SHALL be self-closing and text SHALL be escaped
+
+#### Scenario: ServerFetchPort uses httpx
+- **WHEN** `ServerFetchPort.fetch("https://example.com/api")` is called
+- **THEN** an httpx request is sent and a `Response` object is returned
+
+#### Scenario: ServerHistoryPort stores path internally
+- **WHEN** `ServerHistoryPort.navigate("/test")` is called
+- **THEN** the port's `value` property returns "/test"
+
+#### Scenario: ServerCookiePort propagates attributes via Set-Cookie during SSR
+- **WHEN** `ServerCookiePort.set("session", "abc", max_age=3600, secure=True, samesite="Strict", httponly=True, path="/")` is called during SSR
+- **THEN** the HTML page response SHALL include a `Set-Cookie` header for `session=abc`
+- **AND** the header SHALL preserve `Max-Age=3600`, `Secure`, `SameSite=Strict`, `HttpOnly`, and `Path=/`
+
+#### Scenario: Multiple cookie writes produce multiple Set-Cookie headers
+- **WHEN** two different cookies are set during a single SSR request
+- **THEN** the HTML page response SHALL include one `Set-Cookie` header per cookie write
+- **AND** cookie writes from concurrent render contexts SHALL NOT leak into each other's responses
+
+#### Scenario: Cookie writes during SSG are ignored
+- **WHEN** `ServerCookiePort.set(...)` is called while `webcompy generate` renders a page
+- **THEN** no error SHALL be raised
+- **AND** the generated static HTML SHALL be unaffected
+
+#### Scenario: Cookie writes are not emitted in hash mode
+- **WHEN** `ServerCookiePort.set(...)` is called during the hash-mode pre-render
+- **THEN** the cached shell response SHALL NOT include a `Set-Cookie` header

--- a/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
+++ b/openspec/changes/fix-cookie-propagation/specs/port-abstraction/spec.md
@@ -44,10 +44,11 @@ ServerDOMPort SHALL additionally provide `render_html(node: DOMNode) -> str` for
 - **WHEN** `ServerHistoryPort.navigate("/test")` is called
 - **THEN** the port's `value` property returns "/test"
 
-#### Scenario: ServerCookiePort propagates attributes via Set-Cookie during SSR
-- **WHEN** `ServerCookiePort.set("session", "abc", max_age=3600, secure=True, samesite="Strict", httponly=True, path="/")` is called during SSR
-- **THEN** the HTML page response SHALL include a `Set-Cookie` header for `session=abc`
-- **AND** the header SHALL preserve `Max-Age=3600`, `Secure`, `SameSite=Strict`, `HttpOnly`, and `Path=/`
+#### Scenario: ServerCookiePort ignores Set-Cookie attributes (current limitation)
+- **WHEN** `ServerCookiePort.set(name, value, max_age=3600, secure=True, samesite="Strict")` is called on the server
+- **THEN** the HTML page response SHALL include a `Set-Cookie` header for `name=value`
+- **AND** the header SHALL preserve the `max_age`, `secure`, `httponly`, `path`, and `samesite` attributes
+- **NOTE**: The current limitation documented by the pre-change spec (attributes discarded) is resolved by this change: attributes are retained and propagated via `Set-Cookie` response headers.
 
 #### Scenario: Multiple cookie writes produce multiple Set-Cookie headers
 - **WHEN** two different cookies are set during a single SSR request

--- a/openspec/changes/fix-cookie-propagation/tasks.md
+++ b/openspec/changes/fix-cookie-propagation/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: fix-cookie-propagation
+
+## 1. Cookie port attribute extension
+
+- [ ] 1.1 Add keyword-only `expires: datetime | None = None` and `domain: str | None = None` parameters to the `CookiePort.set()` ABC (packages/webcompy/src/webcompy/ports/_cookie.py)
+- [ ] 1.2 Apply `expires` (UTC date string) and `domain` in `BrowserCookiePort.set()` (packages/webcompy/src/webcompy/ports/_browser/_cookie.py) alongside the existing attributes
+
+## 2. Server cookie port
+
+- [ ] 2.1 Extend `ServerCookiePort` (packages/webcompy-server/src/webcompy_server/ports/_cookie.py) to retain the full attribute set (`max_age`, `expires`, `path`, `domain`, `secure`, `httponly`, `samesite`) on `set()`, storing structured pending writes alongside the existing internal dict read path
+- [ ] 2.2 Add an accessor on `ServerCookiePort` (e.g. `get_pending_set_cookie_headers()`) that serializes pending writes to `Set-Cookie` header strings via `http.cookies.SimpleCookie` (server-only import; `expires` formatted to the RFC 1123 date string `Morsel` expects, `domain` assigned to the morsel) with last-write-wins per cookie name+path
+- [ ] 2.3 Expose pending cookies from `ServerRenderContext` (packages/webcompy-server/src/webcompy_server/_context.py) so the CLI layer can read them after rendering
+
+## 3. Response header emission
+
+- [ ] 3.1 In `send_html` (packages/webcompy-cli/src/webcompy_cli/_server.py), read pending `Set-Cookie` headers from the render context after `generate_html()` completes (before `ctx.dispose()`) and append them to the `HTMLResponse` as separate headers
+- [ ] 3.2 Ensure the hash-mode pre-rendered response path does NOT emit accumulated cookies
+
+## 4. Tests
+
+- [ ] 4.1 Unit test: `ServerCookiePort.set()` with full attributes produces a correct `Set-Cookie` header string (Max-Age, Expires, Domain, Secure, HttpOnly, SameSite, Path preserved)
+- [ ] 4.2 Unit test: multiple cookie writes produce one header per cookie; last-write-wins for same name+path
+- [ ] 4.3 Unit test: values requiring quoting are serialized correctly
+- [ ] 4.4 Unit test: `BrowserCookiePort.set()` with `expires`/`domain` includes both attributes in the `document.cookie` write (via a browser test double)
+- [ ] 4.5 Integration test (webcompy_testing ASGI client): SSR response includes `Set-Cookie` headers set by a component during rendering
+- [ ] 4.6 Test: SSG (`generate_static_site`) completes without error when a component sets cookies, and static output is unaffected
+- [ ] 4.7 Test: hash-mode serving does not emit `Set-Cookie` headers for cookies set during the pre-render
+
+## 5. Verification
+
+- [ ] 5.1 `uv run ruff check .` and `uv run ruff format --check .` pass
+- [ ] 5.2 `uv run pyright` passes
+- [ ] 5.3 `uv run python -m pytest tests/ --tb=short` passes
+
+## 6. Spec reference sync
+
+- [ ] 6.1 Update AGENTS.md: verify the File→Spec Mapping entries covering `webcompy/ports/` and `webcompy_server/ports/` against the modified `port-abstraction` spec, and check the Framework Invariants list for cookie-related staleness
+- [ ] 6.2 Check `.opencode/skills/webcompy-review/SKILL.md` for stale assumptions about `ServerCookiePort` attribute handling and sync spec references
+- [ ] 6.3 Run `python3 scripts/check-doc-spec-refs.py` and confirm it passes


### PR DESCRIPTION
## Description

Adds six OpenSpec change proposals establishing a server-runtime roadmap for
WebComPy: mounting external ASGI apps (e.g. FastAPI) into the WebComPy
server, embedding WebComPy into existing ASGI apps, typed API access that
shares Python schemas between server and browser, and a JSON-RPC 2.0
procedure layer. Proposals only — no code changes.

The changes form a dependency-ordered roadmap:

1. `fix-cookie-propagation` — propagate cookie attributes (`max_age`,
   `expires`, `domain`, `secure`, `httponly`, `samesite`) via `Set-Cookie`
   response headers during SSR; extends `CookiePort.set()` additively with
   `expires`/`domain`.
2. `feat-asgi-mount` — `WebComPyServerConfig.mounts` hook to mount
   user-provided ASGI apps before the SSR catch-all, with collision
   detection, mount-aware self-site fetch resolution (mount paths exempt
   from `base_url` prefixing and blocked paths), and SSG compatibility.
3. `feat-typed-api-client` — schema-driven `from_json` deserializer
   (nested dataclasses, containers, ISO datetime/UUID/Enum coercion) and a
   `response_type` parameter on `HttpClient` (overload + TypeVar), working
   against any plain-JSON API; `use_async_result(transfer=False)` opt-out
   for SSG bake.
4. `feat-typed-response` — framework-neutral `encode_with_meta` helper and
   FastAPI `TypedJSONResponse` contrib (header mode default via
   `X-WebComPy-Transfer-Meta`, body mode via `__webcompy_transfer_meta__`
   for object payloads only); client-side metadata consumption layered on
   the typed client.
5. `feat-asgi-embed` — officially support mounting WebComPy into a host
   ASGI app (`configure_server_context(root_app=...)`), including
   `base_url`/mount-prefix pairing and the `/_webcompy-resource`
   double-prefix compensation.
6. `feat-json-rpc` — JSON-RPC 2.0 dispatcher with procedure registry,
   metadata extension, and a mandatory server-side type allowlist
   (no class resolution from client-controlled names).

Design highlights: type restoration is schema-driven first (client-held
dataclasses, no codegen — both runtimes import the same wheel-shipped
modules); wire metadata is the exception channel for types plain JSON
cannot express; SSG bakes self-site fetch results via the existing
hydration transfer cache with an explicit runtime-only opt-out; the only
server-side decode of client-controlled data (JSON-RPC params) is
allowlist-gated.

## Related Resources

- OpenSpec Changes: `fix-cookie-propagation`, `feat-asgi-mount`,
  `feat-typed-api-client`, `feat-typed-response`, `feat-asgi-embed`,
  `feat-json-rpc`
- Issues: none
- Specs affected:
  - Modified: `openspec/specs/port-abstraction/spec.md`,
    `openspec/specs/cli/spec.md`,
    `openspec/specs/server-fetch-asgi/spec.md`,
    `openspec/specs/ssg-via-ssr/spec.md`,
    `openspec/specs/project-config/spec.md`,
    `openspec/specs/composables/spec.md`
  - New (on archive): `typed-api-client`, `typed-response`, `asgi-embed`,
    `json-rpc`

## Type of Change

- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [x] docs — Documentation
- [ ] chore — Maintenance, dependencies, CI
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [ ] Yes (describe migration path below)
- [x] No

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [ ] OpenSpec change is archived (if applicable) — N/A: proposals are not
      yet implemented
- [ ] Tests added/updated for changed code — N/A: no code changes
- [ ] E2E tests pass (if UI-affecting change) — N/A: no UI changes
- [ ] Dual environment verified (browser + server) — N/A: no code changes
- [x] No new module-level globals introduced (use DI instead) — N/A: no
      code changes
- [ ] `webcompy generate` produces correct output (if SSG-visible) — N/A:
      no code changes