### PR TITLE
chore: make webcompy-inspector subagent-only

### DIFF
--- a/.opencode/agents/webcompy-inspector.md
+++ b/.opencode/agents/webcompy-inspector.md
@@ -1,7 +1,7 @@
 ---
 name: webcompy-inspector
 description: Inspects and verifies WebComPy applications in a browser using webcompy inspect CLI commands (knowledge in the webcompy-inspect skill).
-mode: all
+mode: subagent
 temperature: 0.1
 permission:
   edit:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,14 +254,14 @@ When creating a PR, the body MUST follow the template in `.github/PULL_REQUEST_T
 
 ## Agents and Skills
 
-Two thin agents provide permission-sandboxed execution for the CI AI review job and browser inspection respectively. Each loads its companion skill:
+Two thin agents provide permission-sandboxed execution. `webcompy-reviewer` is invoked by the CI AI review job (subagent via `--agent`); `webcompy-inspector` is subagent-only (it does not appear in the chat agent selector) and is used to offload verbose browser inspection to a sandboxed child session. Each loads its companion skill:
 
 | Agent | Purpose | Loads |
 |---|---|---|
 | `webcompy-reviewer` | PR review (invoked by the CI AI review job via `--agent`) | `webcompy-review` |
-| `webcompy-inspector` | Browser verification via the `webcompy inspect` CLI | `webcompy-inspect` |
+| `webcompy-inspector` | Browser verification via the `webcompy inspect` CLI (subagent-only) | `webcompy-inspect` |
 
-Reusable knowledge lives in skills under `.opencode/skills/`. OpenCode auto-loads a skill when its `description` matches the current task, so prefer invoking a skill directly over going through an agent unless the agent's permission sandbox is required:
+Reusable knowledge lives in skills under `.opencode/skills/`. OpenCode auto-loads a skill when its `description` matches the current task, so prefer invoking a skill directly over going through an agent unless the agent's permission sandbox is required. For browser verification, load the `webcompy-inspect` skill directly, or delegate to the sandboxed `@webcompy-inspector` subagent when you want inspection output kept out of the main session.
 
 | Task | Skill |
 |---|---|

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -166,7 +166,7 @@ OpenCode のスキルは `.opencode/skills/` 配下にあり、必要に応じ�
 | エージェント | 責務 |
 |---|---|
 | `webcompy-reviewer` | OpenSpec スペックに基づく自動 PR レビュー（CI 使用） |
-| `webcompy-inspector` | `webcompy inspect` によるブラウザ検証 |
+| `webcompy-inspector` | `webcompy inspect` によるブラウザ検証（サブエージェント専用） |
 
 ### タスク委譲（OpenCode）
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Agents (provide permission sandboxes; load their companion skill):
 | Agent | Responsibility |
 |---|---|
 | `webcompy-reviewer` | Automated pull request review against OpenSpec specs (used by CI) |
-| `webcompy-inspector` | Browser verification via `webcompy inspect` |
+| `webcompy-inspector` | Browser verification via `webcompy inspect` (subagent-only) |
 
 ### Delegating Tasks (OpenCode)
 


### PR DESCRIPTION
## Description

Restrict the `webcompy-inspector` OpenCode agent to subagent mode (`mode: subagent`)
so it no longer appears in the chat agent selector. It remains available for
sandboxed browser inspection via `@webcompy-inspector` or the subagent tool,
offloading verbose screenshot/console output to a child session.

The `webcompy-inspect` skill is unchanged and continues to be referenced by
`webcompy-browser-development`, `webcompy-component-development`, and
`webcompy-docs-development`. Documentation (AGENTS.md, CONTRIBUTING.md,
CONTRIBUTING.ja.md) is updated to reflect that the inspector is subagent-only.

## Related Resources

- OpenSpec Change: none
- Issues: none
- Specs affected: none

## Type of Change

- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [ ] docs — Documentation
- [x] chore — Maintenance, dependencies, CI
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [ ] Yes (describe migration path below)
- [x] No

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [x] OpenSpec change is archived (if applicable)
- [x] Tests added/updated for changed code
- [x] E2E tests pass (if UI-affecting change)
- [x] Dual environment verified (browser + server)
- [x] No new module-level globals introduced (use DI instead)
- [x] `webcompy generate` produces correct output (if SSG-visible)