### PR TITLE
fix: limit E2E parallel concurrency to half the available CPUs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,12 @@ jobs:
       - name: Run E2E tests
         run: |
           max_attempts=3
+          result=1
           for i in $(seq 1 "$max_attempts"); do
+            set +e
             scripts/run-e2e-tests.sh ${{ matrix.group.name }} --serving-mode=${{ matrix.serving_mode }} 2>&1 | tee ci-e2e-results.log
             result=${PIPESTATUS[0]}
+            set -e
             [ "$result" -eq 0 ] && break
             echo "E2E tests failed (attempt $i/$max_attempts), retrying in 10s..."
             sleep 10
@@ -253,7 +256,6 @@ jobs:
           name: e2e-server-log-${{ matrix.group.name }}-${{ matrix.serving_mode }}
           path: |
             e2e/core/.e2e-server.log
-            e2e/docs/.e2e-docs-server.log
             .tmp/e2e-test-corpus/
       - uses: actions/upload-artifact@v4
         if: always()
@@ -314,9 +316,12 @@ jobs:
           DOCS_DIST_DIR: ${{ github.workspace }}/docs_app/dist
         run: |
           max_attempts=3
+          result=1
           for i in $(seq 1 "$max_attempts"); do
+            set +e
             scripts/run-e2e-tests.sh ${{ matrix.group.name }} --serving-mode=${{ matrix.serving_mode }} 2>&1 | tee ci-e2e-results.log
             result=${PIPESTATUS[0]}
+            set -e
             [ "$result" -eq 0 ] && break
             echo "E2E tests failed (attempt $i/$max_attempts), retrying in 10s..."
             sleep 10
@@ -327,7 +332,6 @@ jobs:
         with:
           name: e2e-server-log-${{ matrix.group.name }}-${{ matrix.serving_mode }}
           path: |
-            e2e/core/.e2e-server.log
             e2e/docs/.e2e-docs-server.log
             .tmp/e2e-test-corpus/
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,49 @@ jobs:
           - name: error-handling
             files: e2e/core/test_error_handling.py
         serving_mode: [prod, static]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-environment
+        with:
+          uv-sync-args: "--group docs"
+          playwright-install: "true"
+      - name: Run E2E tests
+        run: |
+          max_attempts=3
+          for i in $(seq 1 "$max_attempts"); do
+            scripts/run-e2e-tests.sh ${{ matrix.group.name }} --serving-mode=${{ matrix.serving_mode }} 2>&1 | tee ci-e2e-results.log
+            result=${PIPESTATUS[0]}
+            [ "$result" -eq 0 ] && break
+            echo "E2E tests failed (attempt $i/$max_attempts), retrying in 10s..."
+            sleep 10
+          done
+          exit "$result"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: e2e-server-log-${{ matrix.group.name }}-${{ matrix.serving_mode }}
+          path: |
+            e2e/core/.e2e-server.log
+            e2e/docs/.e2e-docs-server.log
+            .tmp/e2e-test-corpus/
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ci-e2e-log-${{ matrix.group.name }}-${{ matrix.serving_mode }}
+          path: ci-e2e-results.log
+
+  docs-e2e:
+    # Docs E2E tests exercise the generated docs site, so they run only when the
+    # site was (re)generated (i.e. docs_app/ or the source packages changed).
+    if: ${{ needs.detect-scope.outputs.has-generate-changes == 'true' && !failure() && !cancelled() && (github.event_name != 'pull_request' || github.event.action == 'ready_for_review' || !github.event.pull_request.draft) }}
+    needs: [detect-scope, generate]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -eo pipefail {0}
+    strategy:
+      fail-fast: false
+      matrix:
         include:
           - group:
               name: docs-home
@@ -262,7 +305,6 @@ jobs:
           uv-sync-args: "--group docs"
           playwright-install: "true"
       - name: Download docs dist artifact
-        if: startsWith(matrix.group.name, 'docs-')
         uses: actions/download-artifact@v7
         with:
           name: docs-dist
@@ -297,7 +339,7 @@ jobs:
   review:
     name: AI Code Review
     if: ${{ always() && !failure() && !cancelled() && (github.event_name != 'pull_request' || github.event.action == 'ready_for_review' || !github.event.pull_request.draft) }}
-    needs: [detect-scope, openspec, openspec-check, lint, typecheck, generate, test, e2e-matrix]
+    needs: [detect-scope, openspec, openspec-check, lint, typecheck, generate, test, e2e-matrix, docs-e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     concurrency:

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -9,7 +9,11 @@
 #   scripts/run-e2e-tests.sh docs-home --serving-mode=static
 #   scripts/run-e2e-tests.sh --console-level=error   # only show console errors in output
 #   scripts/run-e2e-tests.sh --console-file-level=info # save error+warning+info to file
-#   scripts/run-e2e-tests.sh --parallel               # run groups in parallel
+#   scripts/run-e2e-tests.sh --parallel               # run groups in parallel (bounded)
+#
+# In --parallel mode at most half of the available CPUs (minimum 1) run
+# concurrently, so the machine is not overwhelmed by the full matrix. Set
+# WEBCOMPY_E2E_MAX_PARALLEL to override the concurrency limit explicitly.
 #
 # Prerequisites:
 #   uv sync --all-groups
@@ -83,7 +87,8 @@ for arg in "$@"; do
     echo "      Minimum console level to display in output (default: warning)"
     echo "  --console-file-level=off|error|warning|info|log|debug"
     echo "      Minimum console level to save to log files (default: debug)"
-    echo "  --parallel                     Run groups in parallel"
+    echo "  --parallel                     Run groups in parallel (at most half the available CPUs, min 1)"
+    echo "                                 Override the concurrency limit with WEBCOMPY_E2E_MAX_PARALLEL"
     echo ""
     echo "Core E2E groups:"
     for name in "${!E2E_GROUPS[@]}"; do
@@ -104,6 +109,32 @@ done
 
 if [ ${#SELECTED_GROUPS[@]} -eq 0 ]; then
   SELECTED_GROUPS=("${!E2E_GROUPS[@]}" "${!DOCS_GROUPS[@]}")
+fi
+
+# Concurrency limit for --parallel: at most half of the CPUs available to this
+# process (minimum 1), honoring CPU affinity/cgroup limits via `nproc`.
+# Override explicitly with WEBCOMPY_E2E_MAX_PARALLEL.
+if [ -z "${WEBCOMPY_E2E_MAX_PARALLEL:-}" ]; then
+  if command -v nproc >/dev/null 2>&1; then
+    AVAIL_CPUS="$(nproc)"
+  elif command -v getconf >/dev/null 2>&1; then
+    AVAIL_CPUS="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)"
+  else
+    AVAIL_CPUS="1"
+  fi
+  MAX_PARALLEL=$((AVAIL_CPUS >= 2 ? AVAIL_CPUS / 2 : 1))
+else
+  MAX_PARALLEL="$WEBCOMPY_E2E_MAX_PARALLEL"
+fi
+
+case "$MAX_PARALLEL" in
+  '' | *[!0-9]*)
+    echo "error: WEBCOMPY_E2E_MAX_PARALLEL must be a positive integer, got '$MAX_PARALLEL'" >&2
+    exit 1
+    ;;
+esac
+if [ "$MAX_PARALLEL" -lt 1 ]; then
+  MAX_PARALLEL=1
 fi
 
 _find_free_port() {
@@ -326,26 +357,48 @@ _run_single_bg() {
 }
 
 if [ "$PARALLEL" -eq 1 ]; then
+  declare -a TASK_LIST=()
   declare -a PIDS=()
   declare -A PID_TASK=()
 
   while IFS='|' read -r group_name mode files; do
-    _run_single_bg "$group_name" "$mode" "$files" &
-    pid=$!
-    PIDS+=("$pid")
-    PID_TASK["$pid"]="$group_name ($mode)"
+    TASK_LIST+=("$group_name|$mode|$files")
   done < <(_build_run_tasks)
 
   PASSED=0
   FAILED=0
   declare -a FAILED_NAMES=()
 
-  for pid in "${PIDS[@]}"; do
-    if wait "$pid"; then
-      ((PASSED++)) || true
-    else
-      ((FAILED++)) || true
-      FAILED_NAMES+=("${PID_TASK[$pid]}")
+  # Bounded worker pool: never run more than MAX_PARALLEL groups at once.
+  # Reap finished jobs before launching the next ones so the machine is not
+  # overwhelmed by the full matrix.
+  while [ "${#TASK_LIST[@]}" -gt 0 ] || [ "${#PIDS[@]}" -gt 0 ]; do
+    while [ "${#PIDS[@]}" -lt "$MAX_PARALLEL" ] && [ "${#TASK_LIST[@]}" -gt 0 ]; do
+      IFS='|' read -r group_name mode files <<< "${TASK_LIST[0]}"
+      TASK_LIST=("${TASK_LIST[@]:1}")
+      _run_single_bg "$group_name" "$mode" "$files" &
+      pid=$!
+      PIDS+=("$pid")
+      PID_TASK["$pid"]="$group_name ($mode)"
+    done
+
+    NEW_PIDS=()
+    for pid in "${PIDS[@]}"; do
+      if kill -0 "$pid" 2>/dev/null; then
+        NEW_PIDS+=("$pid")
+      else
+        if wait "$pid"; then
+          ((PASSED++)) || true
+        else
+          ((FAILED++)) || true
+          FAILED_NAMES+=("${PID_TASK[$pid]}")
+        fi
+      fi
+    done
+    PIDS=("${NEW_PIDS[@]}")
+
+    if [ "${#PIDS[@]}" -ge "$MAX_PARALLEL" ] && [ "${#TASK_LIST[@]}" -gt 0 ]; then
+      sleep 1
     fi
   done
 

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -371,7 +371,10 @@ if [ "$PARALLEL" -eq 1 ]; then
 
   # Bounded worker pool: never run more than MAX_PARALLEL groups at once.
   # Reap finished jobs before launching the next ones so the machine is not
-  # overwhelmed by the full matrix.
+  # overwhelmed by the full matrix. Sleeping whenever a job is still running
+  # (including during the final drain, when TASK_LIST is empty) lets the shell
+  # process SIGCHLD and reap finished background jobs; without it a tight
+  # builtin-only loop can spin forever on a completed (zombie) job.
   while [ "${#TASK_LIST[@]}" -gt 0 ] || [ "${#PIDS[@]}" -gt 0 ]; do
     while [ "${#PIDS[@]}" -lt "$MAX_PARALLEL" ] && [ "${#TASK_LIST[@]}" -gt 0 ]; do
       IFS='|' read -r group_name mode files <<< "${TASK_LIST[0]}"
@@ -397,7 +400,7 @@ if [ "$PARALLEL" -eq 1 ]; then
     done
     PIDS=("${NEW_PIDS[@]}")
 
-    if [ "${#PIDS[@]}" -ge "$MAX_PARALLEL" ] && [ "${#TASK_LIST[@]}" -gt 0 ]; then
+    if [ "${#PIDS[@]}" -gt 0 ]; then
       sleep 1
     fi
   done


### PR DESCRIPTION
## Description

This PR makes the E2E runner and its CI wiring robust and machine-friendly.

### 1. Bound `--parallel` concurrency

`scripts/run-e2e-tests.sh --parallel` previously launched every group ×
serving-mode task at once with `&` — a full local run spawns 34 concurrent
browser/server tasks, which exhausts CPU and memory on the host machine. The
concurrency is now bounded:

- The parallel limit defaults to **half of the CPUs available to the process**
  (minimum 1), detected via `nproc` (honors CPU affinity/cgroup limits), falling
  back to `getconf _NPROCESSORS_ONLN` and then `1`.
- The limit can be overridden explicitly with `WEBCOMPY_E2E_MAX_PARALLEL`
  (validated as a positive integer).
- The `--parallel` branch is reworked into a **bounded worker pool**: tasks are
  queued, at most `MAX_PARALLEL` run at once, and finished jobs are reaped
  (PASSED/FAILED accounting preserved) before the next ones launch. The reap loop
  sleeps whenever a job is still running — including during the final drain — so
  the shell reaps finished background jobs and the pool terminates instead of
  livelocking on a completed (zombie) job.

### 2. Gate docs E2E on the generated docs site

The docs E2E groups were part of `e2e-matrix`, which runs whenever source or E2E
files change. But the `generate` job (which produces the `docs-dist` artifact the
docs groups download) only runs when source or docs change. An e2e-only change
therefore triggered `e2e-matrix` while `generate` was skipped, and every docs
group failed to download the missing artifact. The docs groups are now a separate
`docs-e2e` job gated on `has-generate-changes`, and the AI review job waits for
it too.

### 3. Repair the CI E2E retry loop

The "Run E2E tests" step intends to retry up to 3 times, but the workflow runs
with `bash -eo pipefail`: a failing `run-e2e-tests.sh | tee` pipeline exited the
step before `PIPESTATUS` could be read, so the retry never happened. The loop is
now wrapped in `set +e` / `set -e` so failures are captured and retried.

### 4. Narrow log uploads

`e2e-matrix` now runs only core groups, so its server-log artifact no longer
references the docs log path; `docs-e2e` carries the docs log path.

## Related Resources

- OpenSpec Change: N/A (standalone E2E infra fix, no spec-driven change)
- Issues: N/A
- Specs affected: none (scripts + CI workflow only, no source packages)

## Type of Change

- [x] fix — Bug fix

## Breaking Changes?

- [x] No

## Checklist

- [x] Change type matches branch name prefix (`fix/...`)
- [x] PR title and body are written in English
- [x] OpenSpec change is archived (if applicable) — N/A
- [x] Tests added/updated for changed code — validated with `bash -n`, a
      simulated bounded-pool harness (all tasks accounted, no livelock), and a
      real `--parallel` run of `bootstrap-static` + `components`
- [x] E2E tests pass (if UI-affecting change) — CI core e2e matrix passes; the
      one `test_loading_screen` failure observed locally was a timing flake that
      passes on re-run
- [ ] Dual environment verified (browser + server) — N/A (script + workflow only)
- [x] No new module-level globals introduced (use DI instead)
- [ ] `webcompy generate` produces correct output (if SSG-visible) — N/A
