### PR TITLE
chore: track latest 1.x opencode-ai in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,7 @@ jobs:
         run: git checkout -- . && git clean -fd
 
       - name: Install OpenCode
-        run: npm install -g opencode-ai@v1.17.13
+        run: npm install -g opencode-ai@^1
 
       - name: Ensure scratch directory exists
         run: mkdir -p .tmp


### PR DESCRIPTION
## Description

Updates the CI AI review job's OpenCode install to track the latest 1.x release instead of a stale pin. `npm install -g opencode-ai@v1.17.13` was pinned and goes stale, contributing to frequent AI review failures; the caret range `^1` now resolves the newest published 1.x release (currently `1.18.21`) on every CI run.

## Related Resources

- OpenSpec Change: none (dependency/CI version only; no spec or API impact)
- Issues: none
- Specs affected: none

## Type of Change

- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [ ] docs — Documentation
- [x] chore — Maintenance, dependencies, CI
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [x] No
- [ ] Yes (describe migration path below)

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [x] OpenSpec change is archived (if applicable)
- [ ] Tests added/updated for changed code
- [ ] E2E tests pass (if UI-affecting change)
- [ ] Dual environment verified (browser + server)
- [x] No new module-level globals introduced (use DI instead)
- [ ] `webcompy generate` produces correct output (if SSG-visible)
