### PR TITLE
chore: clarify OpenSpec checklist to require spec sync and archive

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@
 
 - [ ] Change type matches branch name prefix
 - [ ] PR title and body are written in English
-- [ ] OpenSpec change is archived (if applicable)
+- [ ] All completed OpenSpec changes have specs synced and are archived (if applicable)
 - [ ] Tests added/updated for changed code
 - [ ] E2E tests pass (if UI-affecting change)
 - [ ] Dual environment verified (browser + server)


### PR DESCRIPTION
## Description

Clarify the OpenSpec checklist item in the PR template so that completed changes are explicitly required to have both specs synced and the change archived. The previous item mentioned only archiving; this change adds the missing `specs synced` part and clarifies the scope as "all completed changes".

Change:
- `.github/PULL_REQUEST_TEMPLATE.md:37`
  - Before: `OpenSpec change is archived (if applicable)`
  - After:  `All completed OpenSpec changes have specs synced and are archived (if applicable)`

This aligns the template with the workflow described in `CONTRIBUTING.md` (Sync Specs + Archive) and the CI `openspec-check` job that blocks merge when a `complete` change is not archived.

## Related Resources

- OpenSpec Change: N/A (template-only change)
- Issues: N/A
- Specs affected: N/A

## Type of Change

- [x] chore — Maintenance, dependencies, CI
- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [ ] docs — Documentation
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [x] No
- [ ] Yes (describe migration path below)

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [x] All completed OpenSpec changes have specs synced and are archived (if applicable)
- [x] Tests added/updated for changed code
- [x] E2E tests pass (if UI-affecting change)
- [x] Dual environment verified (browser + server)
- [x] No new module-level globals introduced (use DI instead)
- [x] `webcompy generate` produces correct output (if SSG-visible)
