### PR TITLE
chore: promote browser-tests CI job to hard gate and add PR template checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,6 +36,7 @@
 - [ ] PR title and body are written in English
 - [ ] All completed OpenSpec changes have specs synced and are archived (if applicable)
 - [ ] Tests added/updated for changed code
+- [ ] Browser tests pass (if browser-runtime change) — `scripts/run-browser-tests.sh` (probes are hard gate)
 - [ ] E2E tests pass (if UI-affecting change)
 - [ ] Dual environment verified (browser + server)
 - [ ] No new module-level globals introduced (use DI instead)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,8 @@ jobs:
           path: ci-test-results.log
 
   browser-tests:
-    # Browser unit tier: executes tests/browser/** inside a real PyScript runtime.
-    # Initially allowed to fail while the flake budget is being evaluated.
     needs: [detect-scope, lint, typecheck, test]
     if: ${{ needs.detect-scope.outputs.has-code-changes == 'true' && !failure() && !cancelled() && (github.event_name != 'pull_request' || github.event.action == 'ready_for_review' || !github.event.pull_request.draft) }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,7 +371,7 @@ uv run python -m webcompy inspect pyexec --repl              # REPL over stdin l
 
 ### Pre-Push Verification (before pushing a branch)
 
-1. **Local CI checks** — use the `webcompy-local-ci` skill (lint, typecheck, unit tests)
+1. **Local CI checks** — use the `webcompy-local-ci` skill (lint, typecheck, unit tests); for browser-runtime changes also run `scripts/run-browser-tests.sh` (probes are hard gate)
 2. **Code review** — use the `webcompy-review` skill (or `@webcompy-reviewer` for sandboxed CI invocation)
 
 ### PR Lifecycle


### PR DESCRIPTION
## Description

Hardens the browser testing tier and makes it visible in the PR process:

- **CI (`ci.yml`)** — Removes the job-level `continue-on-error: true` (and its “initially allowed to fail while the flake budget is being evaluated” comment) from the `browser-tests` job. `Run browser tests` and `Run environment probes (hard gate)` now fail the workflow on failure. `Run dual-run sweep (informational)` keeps its step-level `continue-on-error: true` per `browser-dualrun` spec (informational by default).

- **PR template (`.github/PULL_REQUEST_TEMPLATE.md`)** — Adds `Browser tests pass (if browser-runtime change) — scripts/run-browser-tests.sh (probes are hard gate)` between `Tests added/updated` and `E2E tests pass` so the new hard gate is discoverable before push. `CONTRIBUTING.md` Pre-Push Verification is updated to cross-reference the same command.

Verified locally on `cosmic-orchid@c6d769a0` before the CI change:

- `uv run pytest tests/test_browser_probes_classifier.py tests/test_browser_dualrun_sweep.py tests/test_browser_version_sweep.py tests/test_inspect_pyexec_unit.py` — 60 passed
- `scripts/run-browser-tests.sh --probes` — 17 passed (probes suite 17/17)
- `scripts/run-browser-tests.sh --dual` — 35 passed / 1 skipped (`artifacts/browser-dualrun.json` written)
- `scripts/run-browser-tests.sh` (full tier) — 35 passed / 1 skipped (probes 17 included)

CI history: #284 (`feat/browser-probes-pyexec`) ran `browser-tests` with all three steps green (single sample since #281). No flake observed; with local verification green, the job is now promoted.

## Related Resources

- OpenSpec Change: N/A — follow-up to `2026-08-26-feat-browser-probes-pyexec` (archived, specs synced in #284) aligning CI and PR process with spec; no spec delta in this PR
- Issues: N/A
- Specs affected: `openspec/specs/browser-probes/spec.md` (requires hard gate for `tests/browser/probes/**`), `openspec/specs/browser-dualrun/spec.md` (dual-run remains informational — step-level `continue-on-error` retained intentionally)

## Type of Change

- [ ] feat — New feature or enhancement
- [ ] fix — Bug fix
- [ ] refactor — Code refactoring (no behavior change)
- [ ] docs — Documentation
- [x] chore — Maintenance, dependencies, CI
- [ ] test — Adding or updating tests
- [ ] style — Code style changes (formatting, etc.)
- [ ] perf — Performance improvement

## Breaking Changes?

- [ ] Yes (describe migration path below)
- [x] No

## Checklist

- [x] Change type matches branch name prefix
- [x] PR title and body are written in English
- [x] All completed OpenSpec changes have specs synced and are archived (if applicable) — #284 already archived; no new OpenSpec change in this PR
- [x] Tests added/updated for changed code — N/A (CI/docs-only); browser tier verified locally (see Description)
- [x] Browser tests pass (if browser-runtime change) — `scripts/run-browser-tests.sh` (probes are hard gate) — verified locally (see Description)
- [x] E2E tests pass (if UI-affecting change) — N/A
- [x] Dual environment verified (browser + server) — browser tier verified locally (see Description)
- [x] No new module-level globals introduced (use DI instead)
- [x] `webcompy generate` produces correct output (if SSG-visible) — N/A